### PR TITLE
experiment[yaml]: Pod-CPU-consumption 

### DIFF
--- a/experiments/chaos/pod_cpu_consumption/pod_cpu_consumption.yml
+++ b/experiments/chaos/pod_cpu_consumption/pod_cpu_consumption.yml
@@ -1,0 +1,30 @@
+    - name: Get CPU Request by the pod 
+      shell: kubectl get po -n {{ app_ns }}  -l {{app_lkey}}="{{app_lvalue}}" -o jsonpath="{.items[0].spec.containers[0].resources.requests.cpu}"
+      register: cpu_request
+
+    - set_fact:
+        cpur: "{{ cpu_request.stdout.split('m')[0]}}"
+
+    - block:  
+
+        - name: Cordoning the node
+          shell: kubectl cordon {{ node_name }}
+
+        - name: Deleting the Application 
+          shell: kubectl delete po {{ pod_name }} -n {{ app_ns }}
+
+        - name: Uncordoning the node
+          shell: kubectl uncordon {{ node_name }}
+
+        - name: Getting status of application
+          shell: kubectl get pod -n {{ app_ns }}  -o=custom-columns=NAME:.status.phase --no-headers 
+          register: results
+          until: results.stdout == 'Running'
+          delay: 25
+          retries: 15
+  
+        - name: Getting the new nodename
+          shell: kubectl get po -n {{ app_ns }} -o=custom-columns=NODE:.spec.nodeName --no-headers
+          register: new_node
+ 
+      when: cpur | int > {{ cpu_input }}

--- a/experiments/chaos/pod_cpu_consumption/run_litmus_test.yml
+++ b/experiments/chaos/pod_cpu_consumption/run_litmus_test.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pod-cpu-consumption-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        cpu: pod-cons
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-my-ns
+
+#           Enter the cpu limit value for the pod - Ex. "400"
+          - name: CPU_INPUT
+            value: '400'
+
+          - name: APP_LABEL
+            value: 'name=mylabel'
+
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
+
+          - name: DATA_PERSISTENCY
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/pod_cpu_consumption/test.yml -i /etc/ansible/hosts -vv; exit 0"]        

--- a/experiments/chaos/pod_cpu_consumption/run_litmus_test.yml
+++ b/experiments/chaos/pod_cpu_consumption/run_litmus_test.yml
@@ -20,17 +20,19 @@ spec:
         imagePullPolicy: Always
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
-            value: default
+            value: "default"
 
+          ## ENTER THE NAMESPACE WHERE APP IS RUNNING
           - name: APP_NAMESPACE
-            value: app-my-ns
+            value: "app-my-ns" 
 
 #           Enter the cpu limit value for the pod - Ex. "400"
           - name: CPU_INPUT
-            value: '400'
+            value: "400"
 
+          ## ENTER THE LABEL OF APP
           - name: APP_LABEL
-            value: 'name=mylabel'
+            value: "name=mylabel"
 
           - name: LIVENESS_APP_LABEL
             value: ""

--- a/experiments/chaos/pod_cpu_consumption/test.yml
+++ b/experiments/chaos/pod_cpu_consumption/test.yml
@@ -1,0 +1,88 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/create_testname.yml
+   
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "cpu-consumption"
+
+         ## DISPLAY APP INFORMATION 
+        - name: Display the app information passed via the test job
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+
+         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+         ## GETTING THE POD NAME OF THE APPLICATION
+        - name: Getting the pod name of the Applicaiton
+          shell: kubectl get pod -n percona1 --field-selector status.phase=Running -o=custom-columns=NAME:".metadata.name" --no-headers
+          register: pod_names
+
+         ## GETTING THE PRE CHAOS NODE NAME OF APPLICATION 
+        - name: Getting the pre-chaos node name of application 
+          shell: kubectl get po -n percona1 -o=custom-columns=NODE:".spec.nodeName" --no-headers
+          register: node_names
+
+         ## CHECKING THE POD CPU CONSUMPTION AND ASSIGNING A CPU LIMIT
+        - name: Checking the pod CPU consumption and assigning a CPU limit
+          include_tasks: pod_cpu_consumption.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            pod_name: "{{ pod_names.stdout }}"
+            node_name: "{{ node_names.stdout }}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}" 
+            delay: 5
+            retries: 60
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECKx
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+    
+      always:
+
+         ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "{{ test_name }}"
+
+
+
+
+
+

--- a/experiments/chaos/pod_cpu_consumption/test.yml
+++ b/experiments/chaos/pod_cpu_consumption/test.yml
@@ -37,12 +37,12 @@
 
          ## GETTING THE POD NAME OF THE APPLICATION
         - name: Getting the pod name of the Applicaiton
-          shell: kubectl get pod -n percona1 --field-selector status.phase=Running -o=custom-columns=NAME:".metadata.name" --no-headers
+          shell: kubectl get pod -n {{ namespace }} --field-selector status.phase=Running -o=custom-columns=NAME:".metadata.name" --no-headers
           register: pod_names
 
          ## GETTING THE PRE CHAOS NODE NAME OF APPLICATION 
         - name: Getting the pre-chaos node name of application 
-          shell: kubectl get po -n percona1 -o=custom-columns=NODE:".spec.nodeName" --no-headers
+          shell: kubectl get po -n {{ namespace }} -o=custom-columns=NODE:".spec.nodeName" --no-headers
           register: node_names
 
          ## CHECKING THE POD CPU CONSUMPTION AND ASSIGNING A CPU LIMIT

--- a/experiments/chaos/pod_cpu_consumption/test_vars.yml
+++ b/experiments/chaos/pod_cpu_consumption/test_vars.yml
@@ -1,0 +1,7 @@
+test_name: pod-cpu-consumptions
+application_name: pod-cpu-check
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+cpu_input: "{{ lookup('env','CPU_INPUT') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"


### PR DESCRIPTION
Signed-off-by: udit <uditgaurav@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

A cpu-pod-consumption experiment is added. In this experiment we give a certain CPU input and if the pod's cpu request is more than it then it will schedule it to a new node. followings are the files added.
- [X] Directory - experiments/chaos/pod_cpu_consumption
    - [X] File 1 - pod_cpu_consumption.yml
    - [X] File 2 - run_litmus_test.yml
    - [X] File 3 -  test.yml
    - [X] File 4 - test_vars.yml

Before running the experiment:
```
[root@master-1558702621 allfiles]# kubectl get po -n percona1 -o wide
NAME                      READY     STATUS    RESTARTS   AGE       IP             NODE
percona-fc7db745c-hs4mk   1/1       Running   0          33m       172.23.6.168   node3-1558702621.mayalabs.io
```

After running the experiment with the CPU-input `400m` and application CPU-request `500m`
```
[root@master-1558702621 allfiles]# kubectl get po -n percona1 -o wide
NAME                      READY     STATUS    RESTARTS   AGE       IP             NODE
percona-fc7db745c-t8kt4   1/1       Running   0          1m        172.23.2.247   node2-1558702621.mayalabs.io
```
 
Here are the logs:

For positive case:
[logs.txt](https://github.com/mayadata-io/litmus/files/3672756/logs.txt)

For negative case:
[logs.txt](https://github.com/mayadata-io/litmus/files/3672785/logs.txt)




