### PR TITLE
feat[upgrade]: converting chaos duraton time-format from seconds to milliseconds

### DIFF
--- a/chaoslib/openebs/cstor_target_network_delay.yaml
+++ b/chaoslib/openebs/cstor_target_network_delay.yaml
@@ -57,10 +57,10 @@
     executable: /bin/bash
   register: pumba_pod
 
-- name: Inject egress delay of {{network_delay}}ms on cstor target for {{ chaos_duration }}s
+- name: Inject egress delay of {{network_delay}}ms on cstor target for {{ chaos_duration }}ms
   shell: >
     kubectl exec {{ pumba_pod.stdout }} -n {{ app_ns }} 
-    -- pumba netem --interface eth0 --duration {{ chaos_duration }}s delay
+    -- pumba netem --interface eth0 --duration {{ chaos_duration }}ms delay
     --time {{ network_delay }} re2:k8s_cstor-istgt_{{ cstor_target_name }} 
   args:
     executable: /bin/bash

--- a/chaoslib/openebs/jiva_controller_network_delay.yaml
+++ b/chaoslib/openebs/jiva_controller_network_delay.yaml
@@ -81,10 +81,10 @@
     executable: /bin/bash
   register: pumba_pod
 
-- name: Inject egress delay of {{network_delay}}ms on jiva controller for {{ chaos_duration }}s
+- name: Inject egress delay of {{network_delay}}ms on jiva controller for {{ chaos_duration }}ms
   shell: >
     kubectl exec {{ pumba_pod.stdout }} -n {{ app_ns }} 
-    -- pumba netem --interface eth0 --duration {{ chaos_duration }}s delay
+    -- pumba netem --interface eth0 --duration {{ chaos_duration }}ms delay
     --time {{ network_delay }} re2:k8s_{{ jiva_controller_name[:-1] }} 
   args:
     executable: /bin/bash

--- a/experiments/chaos/openebs_replica_network_delay/run_litmus_test.yml
+++ b/experiments/chaos/openebs_replica_network_delay/run_litmus_test.yml
@@ -37,7 +37,7 @@ spec:
             value: "60000" # in milliseconds
 
           - name: CHAOS_DURATION
-            value: "60" # in seconds
+            value: "60000" # in milliseconds
 
           - name: DATA_PERSISTENCY
             value: ""  

--- a/experiments/chaos/openebs_target_network_delay/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_network_delay/run_litmus_test.yml
@@ -46,8 +46,8 @@ spec:
             value: "60000" # in milliseconds
 
           - name: CHAOS_DURATION
-            value: "60" # in seconds
-
+            value: "60000" # in milliseconds
+            
           - name: LIVENESS_APP_LABEL
             value: ""
 

--- a/experiments/chaos/openebs_target_network_loss/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_network_loss/run_litmus_test.yml
@@ -46,7 +46,7 @@ spec:
             value: "240000" # in milliseconds
 
           - name: CHAOS_DURATION
-            value: "240" # in seconds
+            value: "240000" # in milliseconds
 
           - name: LIVENESS_APP_LABEL
             value: ""


### PR DESCRIPTION
Signed-off-by: rajdas <mail.rajdas@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
converting chaos duration time-format from seconds to milliseconds

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
- [x] Pumba pod log
[result.log](https://github.com/mayadata-io/litmus/files/3686121/result.log)
- [x] Litmus result log
[lr.log](https://github.com/mayadata-io/litmus/files/3686125/lr.log)
