### PR TITLE
feat(resize):include test to resize cstor volume

### DIFF
--- a/experiments/functional/cstor-volume-resize/README.md
+++ b/experiments/functional/cstor-volume-resize/README.md
@@ -1,0 +1,37 @@
+## Experiment Metadata
+
+| Type       | Description                                                  | Storage | Applications | K8s Platform |
+| ---------- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Functional | Increase the storage capacity of cstor volume created using CSI. | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- cStor CSPC should be created.
+- Application should be deployed using CSI provisioner.
+- The feature-gate `--feature-gates=ExpandCSIVolumes` should be set to true.
+- The module `iscsi_tcp` should be enabled.
+
+## Exit-Criteria
+
+- Volume should be resized successfully and application should be accessible seamlessly.
+- Application should be able to use the new space.
+
+## Notes
+
+- This functional test checks if the cStor volume can be resized.
+- This litmusbook accepts the parameters in form of job environmental variables.
+- This job updates the storage capacity of PVC with the new capacity and configures the PVC to increase its size.
+- It checks if the application is accessible and the corresponding file system is scaled up.
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| APP_NAMESPACE | Namespace where application and volume is deployed.    |
+| APP_PVC       | Name of PVC whose storage capacity has to be increased |
+| APP_LABEL     | Label of application pod                               |
+| PV_CAPACITY   | Current storage capacity of volume                     |
+| NEW_CAPACITY  | Desired storage capacity of volume                     |
+| OPERATOR_NS   | Namespace where OpenEBS is deployed                    |
+

--- a/experiments/functional/cstor-volume-resize/run_litmus_test.yml
+++ b/experiments/functional/cstor-volume-resize/run_litmus_test.yml
@@ -25,20 +25,20 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: percona
+            value: app-percona-ns
 
             # Application pvc
           - name: APP_PVC
             value: percona-mysql-claim 
 
           - name: APP_LABEL
-            value: 'app=busybox-jiva'
+            value: 'name=percona'
 
           - name: PV_CAPACITY
-            value: 10G
+            value: 5G
           
           - name: NEW_CAPACITY
-            value: 20G
+            value: 10G
 
             #Target namespace
           - name: OPERATOR_NS

--- a/experiments/functional/cstor-volume-resize/run_litmus_test.yml
+++ b/experiments/functional/cstor-volume-resize/run_litmus_test.yml
@@ -1,0 +1,48 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-cstor-vol-resize-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-cstor-vol-resize
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: percona
+
+            # Application pvc
+          - name: APP_PVC
+            value: percona-mysql-claim 
+
+          - name: APP_LABEL
+            value: 'app=busybox-jiva'
+
+          - name: PV_CAPACITY
+            value: 10G
+          
+          - name: NEW_CAPACITY
+            value: 20G
+
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-vol-resize/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/cstor-volume-resize/run_litmus_test.yml
+++ b/experiments/functional/cstor-volume-resize/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:
@@ -45,4 +45,4 @@ spec:
             value: openebs
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/functional/cstor-vol-resize/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-volume-resize/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/cstor-volume-resize/test.yml
+++ b/experiments/functional/cstor-volume-resize/test.yml
@@ -1,0 +1,79 @@
+---
+#Description: Validate if cstor volume can be resized.
+#
+########################################################################################
+#Steps:                                                                                #
+#1) Creating LitmusResult CR for updating test result.                                 #
+#2) Obtain the PVC spec                                                                #
+#3) Update the PVC spec with the desired volume capacity.                              #
+#4) Apply the updated PVC spec                                                         #
+########################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+           
+        - block:
+
+            - name: Check if the desired PVC is bound
+              shell: >
+                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers 
+                -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: pvc_status
+              failed_when: "'Bound' not in pvc_status.stdout"
+
+            - name: Obtain the PVC spec
+              shell: >
+                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} 
+                --no-headers -o yaml > pvc.yml
+              args:
+                executable: /bin/bash
+
+            - name: Update the desired capacity in PVC spec
+              replace:
+                path: pvc.yml
+                regexp: "storage: {{ vol_size }}"
+                replace: "storage: {{ desired_vol_size }}"
+
+            - name: Configure PVC with the new capacity
+              shell: kubectl apply -f pvc.yml
+              args:
+                executable: /bin/bash
+              register: result
+              failed_when: "result.rc != 0"
+
+            - name: Check if the desired PVC is bound
+              shell: >
+                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers  
+                -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: pvc_status
+              failed_when: "'Bound' not in pvc_status.stdout"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/cstor-volume-resize/test.yml
+++ b/experiments/functional/cstor-volume-resize/test.yml
@@ -24,12 +24,12 @@
         - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
           vars:
             status: 'SOT'
-           
+
         - block:
 
             - name: Check if the desired PVC is bound
               shell: >
-                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers 
+                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers
                 -o custom-columns=:.status.phase
               args:
                 executable: /bin/bash
@@ -38,7 +38,7 @@
 
             - name: Obtain the PVC spec
               shell: >
-                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} 
+                kubectl get pvc {{ app_pvc }} -n {{ app_ns }}
                 --no-headers -o yaml > pvc.yml
               args:
                 executable: /bin/bash
@@ -58,7 +58,7 @@
 
             - name: Check if the desired PVC is bound
               shell: >
-                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers  
+                kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers
                 -o custom-columns=:.status.phase
               args:
                 executable: /bin/bash

--- a/experiments/functional/cstor-volume-resize/test_vars.yml
+++ b/experiments/functional/cstor-volume-resize/test_vars.yml
@@ -1,0 +1,21 @@
+---
+test_name: cstor-volume-resize
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+application_deployment: busybox_deployment.yml
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+application_name: "busybox"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+vol_size: "{{ lookup('env','PV_CAPACITY') }}"
+
+desired_vol_size: "{{ lookup('env','NEW_CAPACITY') }}"
+

--- a/experiments/functional/cstor-volume-resize/test_vars.yml
+++ b/experiments/functional/cstor-volume-resize/test_vars.yml
@@ -3,8 +3,6 @@ test_name: cstor-volume-resize
 
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 
-application_deployment: busybox_deployment.yml
-
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 
 app_label: "{{ lookup('env','APP_LABEL') }}"
@@ -12,8 +10,6 @@ app_label: "{{ lookup('env','APP_LABEL') }}"
 application_name: "busybox"
 
 app_pvc: "{{ lookup('env','APP_PVC') }}"
-
-storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 
 vol_size: "{{ lookup('env','PV_CAPACITY') }}"
 

--- a/experiments/functional/cstor-volume-resize/test_vars.yml
+++ b/experiments/functional/cstor-volume-resize/test_vars.yml
@@ -7,7 +7,7 @@ app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 
 app_label: "{{ lookup('env','APP_LABEL') }}"
 
-application_name: "busybox"
+application_name: "mysql"
 
 app_pvc: "{{ lookup('env','APP_PVC') }}"
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Resize volume created using csi provisioner

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 


