### PR TITLE
feat[test]: Included test to migrate the cvr from one pool to another

### DIFF
--- a/chaoslib/openebs/fetch_data_from_replica.yml
+++ b/chaoslib/openebs/fetch_data_from_replica.yml
@@ -1,5 +1,5 @@
 - name: Get replica id
-  shell: kubectl get pods {{ rpod }} -n openebs -o jsonpath='{.spec.containers[*].env[0].value}'
+  shell: kubectl get pods {{ rpod }} -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d "," -f1
   register: cstor_id
 
 - name: Check for dataset name

--- a/experiments/functional/cstor-volume-migration/cvr.yaml
+++ b/experiments/functional/cstor-volume-migration/cvr.yaml
@@ -1,0 +1,26 @@
+apiVersion: openebs.io/v1alpha1
+kind: CStorVolumeReplica
+metadata:
+  annotations:
+    cstorpool.openebs.io/hostname: node_name
+    isRestoreVol: "false"
+    openebs.io/storage-class-ref: |
+      name: storage_class_name
+  finalizers:
+  - cstorvolumereplica.openebs.io/finalizer
+  generation: 1
+  labels:
+    cstorpool.openebs.io/name: csp_name
+    cstorpool.openebs.io/uid: csp_uid
+    cstorvolume.openebs.io/name: cstor_volume_name
+    openebs.io/cas-template-name: cstor-volume-create-default-1.3.0
+    openebs.io/persistent-volume: pv_name
+    openebs.io/version: 1.3.0
+  name: cstor_volume_name-csp_name
+  namespace: openebs
+spec:
+  capacity: initial_capacity
+  targetIP: target_ip
+  replicaid: "replica_id"
+status:
+  phase: Recreate

--- a/experiments/functional/cstor-volume-migration/run_litmus_test.yml
+++ b/experiments/functional/cstor-volume-migration/run_litmus_test.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-cstor-volume-replica-migration-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cvr-migration
+   
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK 
+            value: default
+
+          - name: APP_NAMESPACE
+            value: ""
+          
+          - name: PVC_NAME
+            value: ""
+
+          - name: OPERATOR_NS
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-volume-migration/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/cstor-volume-migration/test.yml
+++ b/experiments/functional/cstor-volume-migration/test.yml
@@ -1,0 +1,434 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+   - block:
+
+      ## RECORD START-OF-TEST IN LITMUS RESULT CR
+       - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+         vars:
+           status: 'SOT'
+        
+       - name: Obtain the Persistent Volume name
+         shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers -o custom-columns=:.spec.volumeName
+         args:
+           executable: /bin/bash
+         register: pv
+         failed_when: 'pv.stdout == ""'
+
+       - name: Obtain the StorageClass name from PVC
+         shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers -o custom-columns=:.spec.storageClassName
+         args:
+           executable: /bin/bash
+         register: sc_name
+         failed_when: 'sc_name.stdout == ""'
+       
+       - name: Get the cStorVolume name
+         shell: >
+           kubectl get cstorvolume -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} 
+           -o custom-columns=:.metadata.name --no-headers
+         args: 
+           executable: /bin/bash
+         register: cv_name
+         failed_when: 'cv_name.stdout == ""'
+         
+       - name: Check if the CVRs in health state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: cvr_status
+         until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+         retries: 30
+         delay: 10         
+
+       - name: Obtain the total number of cvr 
+         shell: kubectl get cvr -n {{ operator_ns }} --no-headers -l openebs.io/persistent-volume={{ pv.stdout }} | wc -l
+         args:
+           executable: /bin/bash
+         register: cvr_count
+         failed_when: 'cvr_count.stdout == ""'
+
+       - name: Obtain the ReplicationFactor from cstorvolume and check if it is equal to the cvr count
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.replicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: rf
+         failed_when: "cvr_count.stdout != rf.stdout"
+
+       - name: Obtain the consistencyFactor from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.consistencyFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: cf
+         failed_when: 'cf.stdout == ""'
+
+       - name: Obtain the desiredReplicationFactor from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.desiredReplicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: drf
+         failed_when: 'drf.stdout == ""'
+
+       - name: Get the node name for the cvr
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} 
+           -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\.openebs\.io\/hostname}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: cvr_node
+         failed_when: 'cvr_node.stdout == ""'
+
+       - name: Obtain the List of CVR's
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: cvr_list
+         failed_when: 'cvr_list.stdout == ""'
+
+       - name: Select random cvr from the list of cvr as target cvr to migrate
+         set_fact:
+           target_cvr: "{{ item }}"
+         with_random_choice: "{{ cvr_list.stdout_lines }}"
+
+       - name: Obtain the replica id from the selected replica
+         shell: kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} --no-headers -o custom-columns=:.spec.replicaid
+         args:
+           executable: /bin/bash
+         register: replica_id
+         failed_when: 'replica_id.stdout == ""'
+
+       - name: Obtain the knownreplica id value from the cstor volume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} 
+           -o custom-columns=:.status.replicaDetails.knownReplicas.{{ replica_id.stdout }} --no-headers
+         args:
+           executable: /bin/bash
+         register: rid_value
+         until: 'rid_value.stdout != ""'
+         delay: 10
+         retries: 30
+
+       - name: Obtain the csp name from targeted cvr
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} -o jsonpath='{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: csp_name
+         failed_when: 'csp_name.stdout == ""'
+
+       - name: Obtain the SPC name from csp
+         shell: >
+           kubectl get csp {{ csp_name.stdout }} -o jsonpath='{.metadata.labels.openebs\.io\/storage-pool-claim}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: spc_name
+         failed_when: 'spc_name.stdout == ""'
+
+       - name: Getting the list of csp node name correspond to provided spc
+         shell: >
+           kubectl get csp -l openebs.io/storage-pool-claim={{ spc_name.stdout }}
+           -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\.io\/hostname}{"\n"}{end}'               
+         register: csp_all
+         failed_when: 'csp_all.stdout == ""'
+
+       - name: Create a file to store CSP name
+         lineinfile:
+           create: yes
+           state: present
+           path: "./csp_all.tmp"
+           line: "{{ item.stdout }}"
+           mode: 0755
+         with_items:
+           - "{{ csp_all }}"
+
+       - name: Getting the list of nodes cvr is created
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\.openebs\.io\/hostname}{"\n"}{end}'
+         register: csp_cvr
+         failed_when: 'csp_cvr.stdout == ""'
+
+       - name: Create a file to store CSP name
+         lineinfile:
+           create: yes
+           state: present
+           path: "./csp_cvr.tmp"
+           line: "{{ item.stdout }}"
+           mode: 0755
+         with_items:
+           - "{{ csp_cvr }}"
+
+       - name: Getting the node name of the csp where no cvr is created
+         shell: |
+           cat csp_all.tmp | tr " " "\n" > csp_all
+           cat csp_cvr.tmp | tr " " "\n" > csp_cvr
+           comm -3 <(sort csp_all) <(sort csp_cvr)
+         args: 
+            executable: /bin/bash
+         register: free_csp_node
+
+       - name: Select random node from the list of nodes as target node
+         set_fact:
+           target_node: "{{ item }}"
+         with_random_choice: "{{ free_csp_node.stdout_lines }}"  
+         when: free_csp_node.stdout_lines != ""
+
+       - name: Obtain the CSP from the targeted node
+         shell: >
+           kubectl get csp -l kubernetes.io/hostname={{ target_node }},openebs.io/storage-pool-claim={{ spc_name.stdout }} 
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: csp_name
+         failed_when: 'csp_name.stdout == ""'
+
+       - name: Get the csp id
+         shell: kubectl get csp {{ csp_name.stdout }} --no-headers -o custom-columns=:.metadata.uid
+         args:
+           executable: /bin/bash
+         register: csp_uid
+         failed_when: 'csp_uid.stdout == ""'
+
+       - name: Obtain the Initial capacity of the target
+         shell: kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} -o jsonpath='{.spec.capacity}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: initial_capacity
+         failed_when: 'initial_capacity.stdout == ""'
+
+       - name: Get the target ip
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} -o jsonpath='{.spec.targetIP}{"\n"}'
+         args: 
+           executable: /bin/bash
+         register: target_ip
+         failed_when: 'target_ip.stdout == ""'
+
+       - name: Replace the node-name annotation in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "node_name"
+           replace: "{{ target_node }}"
+
+       - name: Replace the target ip annotations in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "target_ip"
+           replace: "{{ target_ip.stdout }}"
+
+       - name: Replace the replica id in CVR spec configuration
+         replace:
+           path: cvr.yaml
+           regexp: "replica_id"
+           replace: "{{ replica_id.stdout }}"           
+
+       - name: Replace the initial capacity annotaion in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "initial_capacity"
+           replace: "{{ initial_capacity.stdout }}"
+
+       - name: Replace the cvr name in cvr spec configuration
+         replace:
+           path: cvr.yaml
+           regexp: "cstor_volume_name-csp_name"
+           replace: "{{ cv_name.stdout }}-{{ csp_name.stdout }}"
+          
+       - name: Replace the csp name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "csp_name"
+           replace: "{{ csp_name.stdout }}"
+
+       - name: Replace the csp uid in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "csp_uid"
+           replace: "{{ csp_uid.stdout }}"       
+
+       - name: Replace the cstor volume name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "cstor_volume_name"
+           replace: "{{ cv_name.stdout }}"
+
+       - name: Replace the persistent volume name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "pv_name"
+           replace: "{{ pv.stdout }}"
+
+       - name: Replace the storage class name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "storage_class_name"
+           replace: "{{ sc_name.stdout }}"
+
+       - name: Apply the cvr yaml to migrate the cvr to new pool
+         shell: kubectl apply -f cvr.yaml
+         args:
+           executable: /bin/bash
+
+       - name: Remove the old cvr to migrate
+         shell: kubectl delete cvr -n {{ operator_ns }} {{ target_cvr }}
+         args:
+           executable: /bin/bash
+         
+       - name: Check if the cvr got removed
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: new_cvr_list
+         until: "target_cvr not in new_cvr_list.stdout"
+         delay: 5
+         retries: 30
+
+       - name: Check if the CVRs in healthy state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.status.phase --no-headers
+         args: 
+           executable: /bin/bash
+         register: new_cvr_status
+         until: "((new_cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in new_cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the new replica id value from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }}
+           -o custom-columns=:.status.replicaDetails.knownReplicas.{{ replica_id.stdout }} --no-headers
+         args:
+           executable: /bin/bash
+         register: new_rid_value
+         until: "new_rid_value.stdout != rid_value.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the ReplicationFactor after cvr migration and compare with replication factor obtained before migrate cvr
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.replicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_rf
+         failed_when: "after_rf.stdout != rf.stdout"
+
+       - name: Obtain the consistencyFactor after cvr migration and compare with consistency factor obtained before migrate cvr
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.consistencyFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_cf
+         failed_when: "after_cf.stdout != cf.stdout"
+
+       - name: Obtain the desiredReplicationFactor after cvr migration and compare with desiredReplication factor obtained before migrate cvr
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.desiredReplicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_drf
+         failed_when: "after_drf.stdout != drf.stdout"
+     
+       - name: Get istgt target pod details
+         shell: >
+           kubectl get pods  -l openebs.io/persistent-volume={{ pv.stdout }} 
+           -n {{ operator_ns }} -o custom-columns=:metadata.name --no-headers
+         register: istgt_replica
+         failed_when: 'istgt_replica.stdout == ""'
+
+       - name: Create an empty list of replica pods.
+         set_fact:
+           cstor_replicas_pod : []         
+
+       - name: Obtaining the pool deployments from cvr
+         shell: >
+            kubectl get cvr -n {{ operator_ns }}
+            -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+         args:
+            executable: /bin/bash
+         register: pool_deployment
+         failed_when: 'pool_deployment.stdout == ""'
+
+       - name: Obtaining the pool pods
+         shell: >
+           kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool={{ item }} 
+           -n {{ operator_ns }} --no-headers -o custom-columns=:.metadata.name
+         register: pool_pods
+         failed_when: 'pool_pods.stdout == ""'
+         with_items:
+           - "{{ pool_deployment.stdout_lines }}"
+
+       - name: Build a list of replica pods
+         set_fact:
+           cstor_replicas_pod : "{{ cstor_replicas_pod }} + [ '{{ item.stdout }}' ]"
+         with_items: "{{ pool_pods.results }}"
+
+       - name: Generate snapshot name
+         shell: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
+         register: snapname
+
+       - set_fact:
+           snap_name: "{{ snapname.stdout }}"
+
+       - name: Take snapshot for data verification
+         shell: >
+            kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol snapcreate {{ pv.stdout }} {{ snap_name }} 30 30
+         register: snap_status
+
+       - name: Install netcat on current host
+         shell: apt-get update && apt-get -y install netcat iproute2
+         register: dataset
+
+       - include: /chaoslib/openebs/fetch_data_from_replica.yml
+         loop: "{{ cstor_replicas_pod }}"
+         loop_control:
+           loop_var: rpod       
+
+       - set_fact:
+            base_replica: "{{ cstor_replicas_pod | list | first }}"
+
+       - name: compare data object
+         shell: diff {{ rpod }}.1.dump {{ base_replica }}.1.dump
+         loop: "{{ cstor_replicas_pod }}"
+         loop_control:
+           loop_var: rpod
+
+       - name: compare meta data object
+         shell: diff {{ rpod }}.3.dump {{ base_replica }}.3.dump
+         loop: "{{ cstor_replicas_pod }}"
+         loop_control:
+            loop_var: rpod
+
+       - name: Destroy snapshot created for data verification
+         shell: >
+           kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol snapdestroy {{ pv.stdout }} {{ snap_name }} 30 30
+         register: snap_status    
+
+       - set_fact: 
+           flag: "Pass" 
+          
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/cstor-volume-migration/test_vars.yml
+++ b/experiments/functional/cstor-volume-migration/test_vars.yml
@@ -1,0 +1,4 @@
+test_name: cstor-volume-replica-migration
+app_pvc: "{{ lookup('env','PVC_NAME') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a litmus experiment to migrate the cvr from one pool to another pool
- This test is checks the available free csp in node.
- Get the CVR needs to migrate to new csp
- Get the replicaid to migrate
- Apply the cvr yaml to migrate 
- delete the old cvr and checks all the cvr in healthy state.

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-10-11T06:40:18.832812 (delta: 0.074026)         elapsed: 0.074026 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-10-11T06:40:18.848102 (delta: 0.015221)         elapsed: 0.089316 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-10-11T06:40:21.853794 (delta: 3.005656)         elapsed: 3.095008 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-11T06:40:22.027746 (delta: 0.173874)         elapsed: 3.26896 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d22f35736eafe4ef58949ab377a75a7e7863fa92", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "93ab651eb1bd647daf05bb23e907daf3", "mode": "0644", "owner": "root", "size": 431, "src": "/root/.ansible/tmp/ansible-tmp-1570776022.1-55294875629010/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-11T06:40:23.125097 (delta: 1.097266)         elapsed: 4.366311 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.172346", "end": "2019-10-11 06:40:23.843842", "rc": 0, "start": "2019-10-11 06:40:23.671496", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-volume-replica-migration \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-volume-replica-migration ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-11T06:40:23.945088 (delta: 0.819906)         elapsed: 5.186302 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.023620", "end": "2019-10-11 06:40:25.297311", "failed_when_result": false, "rc": 0, "start": "2019-10-11 06:40:24.273691", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-volume-replica-migration configured", "stdout_lines": ["litmusresult.litmus.io/cstor-volume-replica-migration configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-11T06:40:25.465371 (delta: 1.520197)         elapsed: 6.706585 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-11T06:40:25.639928 (delta: 0.174475)         elapsed: 6.881142 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-11T06:40:25.736039 (delta: 0.095988)         elapsed: 6.977253 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the number of nodes in the cluster] **********************************
2019-10-11T06:40:25.851725 (delta: 0.115594)         elapsed: 7.092939 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'}", "delta": "0:00:00.405700", "end": "2019-10-11 06:40:26.615778", "rc": 0, "start": "2019-10-11 06:40:26.210078", "stderr": "", "stderr_lines": [], "stdout": "node1-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io\nnode4-konvoy.mayalabs.io\nnode5-konvoy.mayalabs.io", "stdout_lines": ["node1-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io", "node4-konvoy.mayalabs.io", "node5-konvoy.mayalabs.io"]}

TASK [Obtain the Persistent Volume name] ***************************************
2019-10-11T06:40:26.725444 (delta: 0.873618)         elapsed: 7.966658 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n cvr-migration --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.365116", "end": "2019-10-11 06:40:27.429907", "rc": 0, "start": "2019-10-11 06:40:27.064791", "stderr": "", "stderr_lines": [], "stdout": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c", "stdout_lines": ["pvc-80bcad89-1243-4b78-ab49-387717f4ad1c"]}

TASK [Obtain the StorageClass name from PVC] ***********************************
2019-10-11T06:40:27.555397 (delta: 0.829867)         elapsed: 8.796611 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n cvr-migration --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:00.387694", "end": "2019-10-11 06:40:28.315444", "rc": 0, "start": "2019-10-11 06:40:27.927750", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Get the cStorVolume name] ************************************************
2019-10-11T06:40:28.475066 (delta: 0.919586)         elapsed: 9.71628 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.344842", "end": "2019-10-11 06:40:29.153190", "rc": 0, "start": "2019-10-11 06:40:28.808348", "stderr": "", "stderr_lines": [], "stdout": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c", "stdout_lines": ["pvc-80bcad89-1243-4b78-ab49-387717f4ad1c"]}

TASK [Check if the CVRs in health state] ***************************************
2019-10-11T06:40:29.257288 (delta: 0.782114)         elapsed: 10.498502 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.377125", "end": "2019-10-11 06:40:29.962517", "rc": 0, "start": "2019-10-11 06:40:29.585392", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Obtain the total number of cvr] ******************************************
2019-10-11T06:40:30.107394 (delta: 0.850011)         elapsed: 11.348608 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs --no-headers -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c | wc -l", "delta": "0:00:00.373685", "end": "2019-10-11 06:40:30.802447", "rc": 0, "start": "2019-10-11 06:40:30.428762", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the ReplicationFactor from cstorvolume and check if it is equal to the cvr count] ***
2019-10-11T06:40:30.913912 (delta: 0.806434)         elapsed: 12.155126 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c\")].spec.replicationFactor}{\"\\n\"}'", "delta": "0:00:00.392985", "end": "2019-10-11 06:40:31.667117", "failed_when_result": false, "rc": 0, "start": "2019-10-11 06:40:31.274132", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the consistencyFactor from cstorvolume] ***************************
2019-10-11T06:40:31.790928 (delta: 0.876931)         elapsed: 13.032142 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c\")].spec.consistencyFactor}{\"\\n\"}'", "delta": "0:00:00.417074", "end": "2019-10-11 06:40:32.545326", "rc": 0, "start": "2019-10-11 06:40:32.128252", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the desiredReplicationFactor from cstorvolume] ********************
2019-10-11T06:40:32.651323 (delta: 0.860297)         elapsed: 13.892537 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c\")].spec.desiredReplicationFactor}{\"\\n\"}'", "delta": "0:00:00.421106", "end": "2019-10-11 06:40:33.398291", "rc": 0, "start": "2019-10-11 06:40:32.977185", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the node name for the cvr] *******************************************
2019-10-11T06:40:33.506316 (delta: 0.854892)         elapsed: 14.74753 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}'", "delta": "0:00:00.474043", "end": "2019-10-11 06:40:34.305457", "rc": 0, "start": "2019-10-11 06:40:33.831414", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io"]}

TASK [Obtain the List of CVR's] ************************************************
2019-10-11T06:40:34.424638 (delta: 0.918216)         elapsed: 15.665852 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.389772", "end": "2019-10-11 06:40:35.123018", "rc": 0, "start": "2019-10-11 06:40:34.733246", "stderr": "", "stderr_lines": [], "stdout": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz\npvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-lm2l\npvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-wg2s", "stdout_lines": ["pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz", "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-lm2l", "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-wg2s"]}

TASK [Select random cvr from the list of cvr as target cvr to migrate] *********
2019-10-11T06:40:35.247644 (delta: 0.822909)         elapsed: 16.488858 ******* 
ok: [127.0.0.1] => (item=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz) => {"ansible_facts": {"target_cvr": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz"}, "changed": false, "item": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz"}

TASK [Obtain the replica id from the selected replica] *************************
2019-10-11T06:40:35.467038 (delta: 0.219316)         elapsed: 16.708252 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz --no-headers -o custom-columns=:.spec.replicaid", "delta": "0:00:00.396907", "end": "2019-10-11 06:40:36.158827", "rc": 0, "start": "2019-10-11 06:40:35.761920", "stderr": "", "stderr_lines": [], "stdout": "20B4C39187222171F87209B1BD9A1C8F", "stdout_lines": ["20B4C39187222171F87209B1BD9A1C8F"]}

TASK [Obtain the knownreplica id value from the cstor volume] ******************
2019-10-11T06:40:36.293830 (delta: 0.826705)         elapsed: 17.535044 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -n openebs -o custom-columns=:.status.replicaDetails.knownReplicas.20B4C39187222171F87209B1BD9A1C8F --no-headers", "delta": "0:00:00.414609", "end": "2019-10-11 06:40:37.036858", "rc": 0, "start": "2019-10-11 06:40:36.622249", "stderr": "", "stderr_lines": [], "stdout": "15384324569355104661", "stdout_lines": ["15384324569355104661"]}

TASK [Obtain the csp name from targeted cvr] ***********************************
2019-10-11T06:40:37.180352 (delta: 0.886428)         elapsed: 18.421566 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz\")].metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}'", "delta": "0:00:00.438233", "end": "2019-10-11 06:40:37.974291", "rc": 0, "start": "2019-10-11 06:40:37.536058", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-4zdz", "stdout_lines": ["cstor-block-disk-pool-stripe-4zdz"]}

TASK [Obtain the SPC name from csp] ********************************************
2019-10-11T06:40:38.082718 (delta: 0.902286)         elapsed: 19.323932 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-block-disk-pool-stripe-4zdz\")].metadata.labels.openebs\\.io\\/storage-pool-claim}{\"\\n\"}'", "delta": "0:00:00.432507", "end": "2019-10-11 06:40:38.825297", "rc": 0, "start": "2019-10-11 06:40:38.392790", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe", "stdout_lines": ["cstor-block-disk-pool-stripe"]}

TASK [Check if the csp availabel to migrate the cvr] ***************************
2019-10-11T06:40:38.926829 (delta: 0.844035)         elapsed: 20.168043 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:01.402349", "end": "2019-10-11 06:40:40.639115", "rc": 0, "start": "2019-10-11 06:40:39.236766", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode1-konvoy.mayalabs.io\nnode4-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node1-konvoy.mayalabs.io", "node4-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io"]}

TASK [Getting the list of csp node name correspond to provided spc] ************
2019-10-11T06:40:40.763745 (delta: 1.836818)         elapsed: 22.004959 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:00.429545", "end": "2019-10-11 06:40:41.585843", "rc": 0, "start": "2019-10-11 06:40:41.156298", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode1-konvoy.mayalabs.io\nnode4-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node1-konvoy.mayalabs.io", "node4-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io"]}

TASK [Create a file to store CSP name] *****************************************
2019-10-11T06:40:41.687462 (delta: 0.923638)         elapsed: 22.928676 ******* 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u'kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o=jsonpath=\'{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{"\\n"}{end}\'', u'end': u'2019-10-11 06:40:41.585843', u'stdout': u'node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode1-konvoy.mayalabs.io\nnode4-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io', u'changed': True, 'failed': False, u'delta': u'0:00:00.429545', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'node5-konvoy.mayalabs.io', u'node2-konvoy.mayalabs.io', u'node1-konvoy.mayalabs.io', u'node4-konvoy.mayalabs.io', u'node3-konvoy.mayalabs.io'], u'start': u'2019-10-11 06:40:41.156298'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:00.429545", "end": "2019-10-11 06:40:41.585843", "failed": false, "rc": 0, "start": "2019-10-11 06:40:41.156298", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode1-konvoy.mayalabs.io\nnode4-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node1-konvoy.mayalabs.io", "node4-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the list of nodes cvr is created] ********************************
2019-10-11T06:40:42.355859 (delta: 0.668312)         elapsed: 23.597073 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:00.447996", "end": "2019-10-11 06:40:43.120465", "rc": 0, "start": "2019-10-11 06:40:42.672469", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io"]}

TASK [Create a file to store CSP name] *****************************************
2019-10-11T06:40:43.256924 (delta: 0.900977)         elapsed: 24.498138 ******* 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u'kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o=jsonpath=\'{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{"\\n"}{end}\'', u'end': u'2019-10-11 06:40:43.120465', u'stdout': u'node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io', u'changed': True, 'failed': False, u'delta': u'0:00:00.447996', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'node5-konvoy.mayalabs.io', u'node2-konvoy.mayalabs.io', u'node3-konvoy.mayalabs.io'], u'start': u'2019-10-11 06:40:42.672469'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:00.447996", "end": "2019-10-11 06:40:43.120465", "failed": false, "rc": 0, "start": "2019-10-11 06:40:42.672469", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io\nnode2-konvoy.mayalabs.io\nnode3-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io", "node2-konvoy.mayalabs.io", "node3-konvoy.mayalabs.io"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the node name of the csp where no cvr is created] ****************
2019-10-11T06:40:43.733699 (delta: 0.47668)         elapsed: 24.974913 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat csp_all.tmp | tr \" \" \"\\n\" > csp_all\n cat csp_cvr.tmp | tr \" \" \"\\n\" > csp_cvr\n comm -3 <(sort csp_all) <(sort csp_cvr)", "delta": "0:00:00.232696", "end": "2019-10-11 06:40:44.278032", "rc": 0, "start": "2019-10-11 06:40:44.045336", "stderr": "", "stderr_lines": [], "stdout": "node1-konvoy.mayalabs.io\nnode4-konvoy.mayalabs.io", "stdout_lines": ["node1-konvoy.mayalabs.io", "node4-konvoy.mayalabs.io"]}

TASK [Select random node from the list of nodes as target node] ****************
2019-10-11T06:40:44.402527 (delta: 0.668753)         elapsed: 25.643741 ******* 
ok: [127.0.0.1] => (item=node1-konvoy.mayalabs.io) => {"ansible_facts": {"target_node": "node1-konvoy.mayalabs.io"}, "changed": false, "item": "node1-konvoy.mayalabs.io"}

TASK [Obtain the CSP from the targeted node] ***********************************
2019-10-11T06:40:44.589709 (delta: 0.187072)         elapsed: 25.830923 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l kubernetes.io/hostname=node1-konvoy.mayalabs.io,openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.416373", "end": "2019-10-11 06:40:45.284270", "rc": 0, "start": "2019-10-11 06:40:44.867897", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-q2ae", "stdout_lines": ["cstor-block-disk-pool-stripe-q2ae"]}

TASK [Get the csp id] **********************************************************
2019-10-11T06:40:45.396295 (delta: 0.806489)         elapsed: 26.637509 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-stripe-q2ae --no-headers -o custom-columns=:.metadata.uid", "delta": "0:00:00.387494", "end": "2019-10-11 06:40:46.089110", "rc": 0, "start": "2019-10-11 06:40:45.701616", "stderr": "", "stderr_lines": [], "stdout": "3949613b-6b97-4d3a-9083-e99c363d4595", "stdout_lines": ["3949613b-6b97-4d3a-9083-e99c363d4595"]}

TASK [Obtain the Initial capacity of the target] *******************************
2019-10-11T06:40:46.207193 (delta: 0.810808)         elapsed: 27.448407 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz\")].spec.capacity}{\"\\n\"}'", "delta": "0:00:00.426913", "end": "2019-10-11 06:40:46.961696", "rc": 0, "start": "2019-10-11 06:40:46.534783", "stderr": "", "stderr_lines": [], "stdout": "5G", "stdout_lines": ["5G"]}

TASK [Get the target ip] *******************************************************
2019-10-11T06:40:47.079117 (delta: 0.871832)         elapsed: 28.320331 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz\")].spec.targetIP}{\"\\n\"}'", "delta": "0:00:00.439200", "end": "2019-10-11 06:40:47.810303", "rc": 0, "start": "2019-10-11 06:40:47.371103", "stderr": "", "stderr_lines": [], "stdout": "172.21.77.238", "stdout_lines": ["172.21.77.238"]}

TASK [Replace the node-name annotation in cvr yaml] ****************************
2019-10-11T06:40:47.933584 (delta: 0.854371)         elapsed: 29.174798 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the target ip annotations in cvr yaml] ***************************
2019-10-11T06:40:48.623883 (delta: 0.6902)         elapsed: 29.865097 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the replica id in CVR spec configuration] ************************
2019-10-11T06:40:49.082022 (delta: 0.458061)         elapsed: 30.323236 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the initial capacity annotaion in cvr yaml] **********************
2019-10-11T06:40:49.539026 (delta: 0.45691)         elapsed: 30.78024 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the cvr name in cvr specc configuration] *************************
2019-10-11T06:40:49.935775 (delta: 0.39667)         elapsed: 31.176989 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the csp name in cvr yaml] ****************************************
2019-10-11T06:40:50.402135 (delta: 0.466265)         elapsed: 31.643349 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the csp uid in cvr yaml] *****************************************
2019-10-11T06:40:50.807762 (delta: 0.405319)         elapsed: 32.048976 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the cstor volume name in cvr yaml] *******************************
2019-10-11T06:40:51.249403 (delta: 0.441561)         elapsed: 32.490617 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the persistent volume name in cvr yaml] **************************
2019-10-11T06:40:51.656819 (delta: 0.407324)         elapsed: 32.898033 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the storage class name in cvr yaml] ******************************
2019-10-11T06:40:52.068451 (delta: 0.411535)         elapsed: 33.309665 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Apply the cvr yaml to migrate the cvr to new pool] ***********************
2019-10-11T06:40:52.468503 (delta: 0.399878)         elapsed: 33.709717 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cvr.yaml", "delta": "0:00:00.790969", "end": "2019-10-11 06:40:53.551318", "rc": 0, "start": "2019-10-11 06:40:52.760349", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-q2ae created", "stdout_lines": ["cstorvolumereplica.openebs.io/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-q2ae created"]}

TASK [Remove the old cvr to migrate] *******************************************
2019-10-11T06:40:53.644875 (delta: 1.176254)         elapsed: 34.886089 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete cvr -n openebs pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz", "delta": "0:00:06.590062", "end": "2019-10-11 06:41:00.575142", "rc": 0, "start": "2019-10-11 06:40:53.985080", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io \"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz\" deleted", "stdout_lines": ["cstorvolumereplica.openebs.io \"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-4zdz\" deleted"]}

TASK [Check if the cvr got removed] ********************************************
2019-10-11T06:41:00.680168 (delta: 7.035215)         elapsed: 41.921382 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.490223", "end": "2019-10-11 06:41:01.487111", "rc": 0, "start": "2019-10-11 06:41:00.996888", "stderr": "", "stderr_lines": [], "stdout": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-lm2l\npvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-q2ae\npvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-wg2s", "stdout_lines": ["pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-lm2l", "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-q2ae", "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-cstor-block-disk-pool-stripe-wg2s"]}

TASK [Check if the CVRs in healthy state] **************************************
2019-10-11T06:41:01.613371 (delta: 0.933132)         elapsed: 42.854585 ******* 
FAILED - RETRYING: Check if the CVRs in healthy state (30 retries left).
FAILED - RETRYING: Check if the CVRs in healthy state (29 retries left).
FAILED - RETRYING: Check if the CVRs in healthy state (28 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.388034", "end": "2019-10-11 06:41:34.350248", "rc": 0, "start": "2019-10-11 06:41:33.962214", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Obtain the new replica id value from cstorvolume] ************************
2019-10-11T06:41:34.479411 (delta: 32.865949)         elapsed: 75.720625 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -n openebs -o custom-columns=:.status.replicaDetails.knownReplicas.20B4C39187222171F87209B1BD9A1C8F --no-headers", "delta": "0:00:00.367909", "end": "2019-10-11 06:41:35.246650", "rc": 0, "start": "2019-10-11 06:41:34.878741", "stderr": "", "stderr_lines": [], "stdout": "17783093147407726087", "stdout_lines": ["17783093147407726087"]}

TASK [Obtain the ReplicationFactor after cvr migration and compare with replication factor obtained before migrate cvr] ***
2019-10-11T06:41:35.367318 (delta: 0.887827)         elapsed: 76.608532 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c\")].spec.replicationFactor}{\"\\n\"}'", "delta": "0:00:00.437284", "end": "2019-10-11 06:41:36.138831", "failed_when_result": false, "rc": 0, "start": "2019-10-11 06:41:35.701547", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the consistencyFactor after cvr migration and compare with consistency factor obtained before migrate cvr] ***
2019-10-11T06:41:36.276444 (delta: 0.909032)         elapsed: 77.517658 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c\")].spec.consistencyFactor}{\"\\n\"}'", "delta": "0:00:00.391795", "end": "2019-10-11 06:41:36.966313", "failed_when_result": false, "rc": 0, "start": "2019-10-11 06:41:36.574518", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the desiredReplicationFactor after cvr migration and compare with desiredReplication factor obtained before migrate cvr] ***
2019-10-11T06:41:37.166548 (delta: 0.890005)         elapsed: 78.407762 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -o jsonpath='{.items[?(@.metadata.name==\"pvc-80bcad89-1243-4b78-ab49-387717f4ad1c\")].spec.desiredReplicationFactor}{\"\\n\"}'", "delta": "0:00:00.358442", "end": "2019-10-11 06:41:37.833976", "failed_when_result": false, "rc": 0, "start": "2019-10-11 06:41:37.475534", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get istgt target pod details] ********************************************
2019-10-11T06:41:37.935176 (delta: 0.768518)         elapsed: 79.17639 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c -n openebs -o custom-columns=:metadata.name --no-headers", "delta": "0:00:00.377058", "end": "2019-10-11 06:41:38.637042", "rc": 0, "start": "2019-10-11 06:41:38.259984", "stderr": "", "stderr_lines": [], "stdout": "pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-target-84648b6c9bhdpp2", "stdout_lines": ["pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-target-84648b6c9bhdpp2"]}

TASK [Create an empty list of replica pods.] ***********************************
2019-10-11T06:41:38.783187 (delta: 0.847935)         elapsed: 80.024401 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_replicas_pod": []}, "changed": false}

TASK [Obtaining the pool deployments from cvr] *********************************
2019-10-11T06:41:38.906124 (delta: 0.122841)         elapsed: 80.147338 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-80bcad89-1243-4b78-ab49-387717f4ad1c --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:00.479194", "end": "2019-10-11 06:41:39.732239", "rc": 0, "start": "2019-10-11 06:41:39.253045", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-lm2l\ncstor-block-disk-pool-stripe-q2ae\ncstor-block-disk-pool-stripe-wg2s", "stdout_lines": ["cstor-block-disk-pool-stripe-lm2l", "cstor-block-disk-pool-stripe-q2ae", "cstor-block-disk-pool-stripe-wg2s"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
2019-10-11T06:41:39.846410 (delta: 0.940206)         elapsed: 81.087624 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-lm2l) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l\")].metadata.name}'", "delta": "0:00:00.483940", "end": "2019-10-11 06:41:40.693464", "item": "cstor-block-disk-pool-stripe-lm2l", "rc": 0, "start": "2019-10-11 06:41:40.209524", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-lm2l-d49b8967c", "stdout_lines": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-q2ae) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae\")].metadata.name}'", "delta": "0:00:00.611773", "end": "2019-10-11 06:41:41.612036", "item": "cstor-block-disk-pool-stripe-q2ae", "rc": 0, "start": "2019-10-11 06:41:41.000263", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-q2ae-6f8449c864", "stdout_lines": ["cstor-block-disk-pool-stripe-q2ae-6f8449c864"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-wg2s) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s\")].metadata.name}'", "delta": "0:00:00.524737", "end": "2019-10-11 06:41:42.414799", "item": "cstor-block-disk-pool-stripe-wg2s", "rc": 0, "start": "2019-10-11 06:41:41.890062", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4", "stdout_lines": ["cstor-block-disk-pool-stripe-wg2s-7d7974d5f4"]}

TASK [Obtaining the pool pods] *************************************************
2019-10-11T06:41:42.535914 (delta: 2.689431)         elapsed: 83.777128 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-lm2l-d49b8967c', '_ansible_item_result': True, u'delta': u'0:00:00.483940', 'stdout_lines': [u'cstor-block-disk-pool-stripe-lm2l-d49b8967c'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-lm2l', u'end': u'2019-10-11 06:41:40.693464', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l")].metadata.name}\'', 'item': u'cstor-block-disk-pool-stripe-lm2l', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-10-11 06:41:40.209524', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l-d49b8967c\")].metadata.name}'", "delta": "0:00:00.601660", "end": "2019-10-11 06:41:43.524863", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l\")].metadata.name}'", "delta": "0:00:00.483940", "end": "2019-10-11 06:41:40.693464", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-lm2l", "rc": 0, "start": "2019-10-11 06:41:40.209524", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-lm2l-d49b8967c", "stdout_lines": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c"]}, "rc": 0, "start": "2019-10-11 06:41:42.923203", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx", "stdout_lines": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-q2ae-6f8449c864', '_ansible_item_result': True, u'delta': u'0:00:00.611773', 'stdout_lines': [u'cstor-block-disk-pool-stripe-q2ae-6f8449c864'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-q2ae', u'end': u'2019-10-11 06:41:41.612036', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae")].metadata.name}\'', 'item': u'cstor-block-disk-pool-stripe-q2ae', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-10-11 06:41:41.000263', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae-6f8449c864\")].metadata.name}'", "delta": "0:00:00.561571", "end": "2019-10-11 06:41:44.399375", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae\")].metadata.name}'", "delta": "0:00:00.611773", "end": "2019-10-11 06:41:41.612036", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-q2ae", "rc": 0, "start": "2019-10-11 06:41:41.000263", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-q2ae-6f8449c864", "stdout_lines": ["cstor-block-disk-pool-stripe-q2ae-6f8449c864"]}, "rc": 0, "start": "2019-10-11 06:41:43.837804", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9", "stdout_lines": ["cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4', '_ansible_item_result': True, u'delta': u'0:00:00.524737', 'stdout_lines': [u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-wg2s', u'end': u'2019-10-11 06:41:42.414799', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s")].metadata.name}\'', 'item': u'cstor-block-disk-pool-stripe-wg2s', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-10-11 06:41:41.890062', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s-7d7974d5f4\")].metadata.name}'", "delta": "0:00:00.515477", "end": "2019-10-11 06:41:45.220496", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s\")].metadata.name}'", "delta": "0:00:00.524737", "end": "2019-10-11 06:41:42.414799", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-wg2s", "rc": 0, "start": "2019-10-11 06:41:41.890062", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4", "stdout_lines": ["cstor-block-disk-pool-stripe-wg2s-7d7974d5f4"]}, "rc": 0, "start": "2019-10-11 06:41:44.705019", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j", "stdout_lines": ["cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j"]}

TASK [Build a list of replica pods] ********************************************
2019-10-11T06:41:45.338410 (delta: 2.802405)         elapsed: 86.579624 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx', '_ansible_item_result': True, u'delta': u'0:00:00.601660', 'stdout_lines': [u'cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-stripe-lm2l-d49b8967c', '_ansible_item_result': True, u'delta': u'0:00:00.483940', 'stdout_lines': [u'cstor-block-disk-pool-stripe-lm2l-d49b8967c'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-lm2l', u'end': u'2019-10-11 06:41:40.693464', '_ansible_no_log': False, u'start': u'2019-10-11 06:41:40.209524', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-stripe-lm2l', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-10-11 06:41:43.524863', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l-d49b8967c")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-stripe-lm2l-d49b8967c', '_ansible_item_result': True, u'delta': u'0:00:00.483940', 'stdout_lines': [u'cstor-block-disk-pool-stripe-lm2l-d49b8967c'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-lm2l', u'end': u'2019-10-11 06:41:40.693464', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l")].metadata.name}\'', u'start': u'2019-10-11 06:41:40.209524', 'item': u'cstor-block-disk-pool-stripe-lm2l', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-lm2l-d49b8967c")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-10-11 06:41:42.923203', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l-d49b8967c\")].metadata.name}'", "delta": "0:00:00.601660", "end": "2019-10-11 06:41:43.524863", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l-d49b8967c\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l\")].metadata.name}'", "delta": "0:00:00.483940", "end": "2019-10-11 06:41:40.693464", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-lm2l\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-lm2l", "rc": 0, "start": "2019-10-11 06:41:40.209524", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-lm2l-d49b8967c", "stdout_lines": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c"]}, "rc": 0, "start": "2019-10-11 06:41:42.923203", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx", "stdout_lines": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9', '_ansible_item_result': True, u'delta': u'0:00:00.561571', 'stdout_lines': [u'cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-stripe-q2ae-6f8449c864', '_ansible_item_result': True, u'delta': u'0:00:00.611773', 'stdout_lines': [u'cstor-block-disk-pool-stripe-q2ae-6f8449c864'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-q2ae', u'end': u'2019-10-11 06:41:41.612036', '_ansible_no_log': False, u'start': u'2019-10-11 06:41:41.000263', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-stripe-q2ae', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-10-11 06:41:44.399375', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae-6f8449c864")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-stripe-q2ae-6f8449c864', '_ansible_item_result': True, u'delta': u'0:00:00.611773', 'stdout_lines': [u'cstor-block-disk-pool-stripe-q2ae-6f8449c864'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-q2ae', u'end': u'2019-10-11 06:41:41.612036', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae")].metadata.name}\'', u'start': u'2019-10-11 06:41:41.000263', 'item': u'cstor-block-disk-pool-stripe-q2ae', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-q2ae-6f8449c864")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-10-11 06:41:43.837804', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx", "cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae-6f8449c864\")].metadata.name}'", "delta": "0:00:00.561571", "end": "2019-10-11 06:41:44.399375", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae-6f8449c864\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae\")].metadata.name}'", "delta": "0:00:00.611773", "end": "2019-10-11 06:41:41.612036", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-q2ae\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-q2ae", "rc": 0, "start": "2019-10-11 06:41:41.000263", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-q2ae-6f8449c864", "stdout_lines": ["cstor-block-disk-pool-stripe-q2ae-6f8449c864"]}, "rc": 0, "start": "2019-10-11 06:41:43.837804", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9", "stdout_lines": ["cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j', '_ansible_item_result': True, u'delta': u'0:00:00.515477', 'stdout_lines': [u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4', '_ansible_item_result': True, u'delta': u'0:00:00.524737', 'stdout_lines': [u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-wg2s', u'end': u'2019-10-11 06:41:42.414799', '_ansible_no_log': False, u'start': u'2019-10-11 06:41:41.890062', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-stripe-wg2s', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-10-11 06:41:45.220496', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s-7d7974d5f4")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4', '_ansible_item_result': True, u'delta': u'0:00:00.524737', 'stdout_lines': [u'cstor-block-disk-pool-stripe-wg2s-7d7974d5f4'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-wg2s', u'end': u'2019-10-11 06:41:42.414799', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s")].metadata.name}\'', u'start': u'2019-10-11 06:41:41.890062', 'item': u'cstor-block-disk-pool-stripe-wg2s', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-stripe-wg2s-7d7974d5f4")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-10-11 06:41:44.705019', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx", "cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9", "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s-7d7974d5f4\")].metadata.name}'", "delta": "0:00:00.515477", "end": "2019-10-11 06:41:45.220496", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s-7d7974d5f4\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s\")].metadata.name}'", "delta": "0:00:00.524737", "end": "2019-10-11 06:41:42.414799", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-stripe-wg2s\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-wg2s", "rc": 0, "start": "2019-10-11 06:41:41.890062", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4", "stdout_lines": ["cstor-block-disk-pool-stripe-wg2s-7d7974d5f4"]}, "rc": 0, "start": "2019-10-11 06:41:44.705019", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j", "stdout_lines": ["cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j"]}}

TASK [Generate snapshot name] **************************************************
2019-10-11T06:41:45.589914 (delta: 0.25141)         elapsed: 86.831128 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1", "delta": "0:00:00.186717", "end": "2019-10-11 06:41:46.095314", "rc": 0, "start": "2019-10-11 06:41:45.908597", "stderr": "", "stderr_lines": [], "stdout": "smDH0kCuLK2ssbIfYouzHlSEInOW4g2V", "stdout_lines": ["smDH0kCuLK2ssbIfYouzHlSEInOW4g2V"]}

TASK [set_fact] ****************************************************************
2019-10-11T06:41:46.222619 (delta: 0.632613)         elapsed: 87.463833 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"snap_name": "smDH0kCuLK2ssbIfYouzHlSEInOW4g2V"}, "changed": false}

TASK [Take snapshot for data verification] *************************************
2019-10-11T06:41:46.387627 (delta: 0.164909)         elapsed: 87.628841 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-target-84648b6c9bhdpp2 -n openebs --container cstor-istgt -- istgtcontrol snapcreate pvc-80bcad89-1243-4b78-ab49-387717f4ad1c smDH0kCuLK2ssbIfYouzHlSEInOW4g2V 30 30", "delta": "0:00:01.948978", "end": "2019-10-11 06:41:48.652138", "rc": 0, "start": "2019-10-11 06:41:46.703160", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPCREATE command", "stdout_lines": ["DONE SNAPCREATE command"]}

TASK [Install netcat on current host] ******************************************
2019-10-11T06:41:48.796540 (delta: 2.408826)         elapsed: 90.037754 ******* 
 [WARNING]: Consider using the apt module rather than running apt-get.  If you
need to use command because apt is insufficient you can add warn=False to this
command task or set command_warnings=False in ansible.cfg to get rid of this
message.
changed: [127.0.0.1] => {"changed": true, "cmd": "apt-get update && apt-get -y install netcat iproute2", "delta": "0:00:13.213725", "end": "2019-10-11 06:42:02.398668", "rc": 0, "start": "2019-10-11 06:41:49.184943", "stderr": "", "stderr_lines": [], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease\nGet:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]\nGet:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]\nGet:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]\nGet:5 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [11.3 kB]\nGet:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [975 kB]\nGet:7 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [5391 B]\nGet:8 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [680 kB]\nGet:9 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [8734 B]\nGet:10 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [21.9 kB]\nGet:11 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1294 kB]\nGet:12 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [774 kB]\nFetched 4022 kB in 6s (639 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\niproute2 is already the newest version (4.15.0-2ubuntu1).\nnetcat is already the newest version (1.10-41.1).\n0 upgraded, 0 newly installed, 0 to remove and 38 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease", "Get:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]", "Get:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]", "Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]", "Get:5 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [11.3 kB]", "Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [975 kB]", "Get:7 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [5391 B]", "Get:8 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [680 kB]", "Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [8734 B]", "Get:10 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [21.9 kB]", "Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1294 kB]", "Get:12 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [774 kB]", "Fetched 4022 kB in 6s (639 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "iproute2 is already the newest version (4.15.0-2ubuntu1).", "netcat is already the newest version (1.10-41.1).", "0 upgraded, 0 newly installed, 0 to remove and 38 not upgraded."]}

TASK [include] *****************************************************************
2019-10-11T06:42:02.504620 (delta: 13.707913)         elapsed: 103.745834 ***** 
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1

TASK [Get replica id] **********************************************************
2019-10-11T06:42:02.832337 (delta: 0.327613)         elapsed: 104.073551 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:00.405537", "end": "2019-10-11 06:42:03.537196", "rc": 0, "start": "2019-10-11 06:42:03.131659", "stderr": "", "stderr_lines": [], "stdout": "6e887995-fc99-449b-9a90-e79b10f135f8", "stdout_lines": ["6e887995-fc99-449b-9a90-e79b10f135f8"]}

TASK [Check for dataset name] **************************************************
2019-10-11T06:42:03.659686 (delta: 0.827174)         elapsed: 104.9009 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- zfs list cstor-6e887995-fc99-449b-9a90-e79b10f135f8/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c", "delta": "0:00:01.015481", "end": "2019-10-11 06:42:04.990267", "rc": 0, "start": "2019-10-11 06:42:03.974786", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-6e887995-fc99-449b-9a90-e79b10f135f8/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c   164K  24.2G   111K  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-6e887995-fc99-449b-9a90-e79b10f135f8/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c   164K  24.2G   111K  -"]}

TASK [Dump snapshot datastream to a file] **************************************
2019-10-11T06:42:05.140840 (delta: 1.481052)         elapsed: 106.382054 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- bash -c \"zfs send cstor-6e887995-fc99-449b-9a90-e79b10f135f8/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V > /snap.data\"", "delta": "0:00:00.991024", "end": "2019-10-11 06:42:06.542033", "rc": 0, "start": "2019-10-11 06:42:05.551009", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
2019-10-11T06:42:06.687333 (delta: 1.546413)         elapsed: 107.928547 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:00.950231", "end": "2019-10-11 06:42:08.000092", "rc": 0, "start": "2019-10-11 06:42:07.049861", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
2019-10-11T06:42:08.147253 (delta: 1.459849)         elapsed: 109.388467 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:01.021237", "end": "2019-10-11 06:42:09.520700", "rc": 0, "start": "2019-10-11 06:42:08.499463", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5da0242b\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 98fee4872a4044f7\n\tfromguid = 0\n\ttoname = cstor-6e887995-fc99-449b-9a90-e79b10f135f8/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V\nEND checksum = 2b71a180aa2c/79e2b8a42bcb771d/616c210d135dc70e/4a2fc3d531f0fbe1\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 1649\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 36\n\tTotal DRR_SPILL records = 0\n\tTotal records = 1694\n\tTotal write size = 6750720 (0x670200)\n\tTotal stream length = 7279248 (0x6f1290)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5da0242b", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 98fee4872a4044f7", "\tfromguid = 0", "\ttoname = cstor-6e887995-fc99-449b-9a90-e79b10f135f8/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V", "END checksum = 2b71a180aa2c/79e2b8a42bcb771d/616c210d135dc70e/4a2fc3d531f0fbe1", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 1649", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 36", "\tTotal DRR_SPILL records = 0", "\tTotal records = 1694", "\tTotal write size = 6750720 (0x670200)", "\tTotal stream length = 7279248 (0x6f1290)"]}

TASK [Install netcat on replica pod] *******************************************
2019-10-11T06:42:09.733103 (delta: 1.585753)         elapsed: 110.974317 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:09.499904", "end": "2019-10-11 06:42:19.521648", "rc": 0, "start": "2019-10-11 06:42:10.021744", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead.", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (This frontend requires a controlling tty.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:2 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:1 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (176 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  netcat-traditional\nThe following NEW packages will be installed:\n  netcat netcat-traditional\n0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.\nNeed to get 64.1 kB of archives.\nAfter this operation, 191 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]\nFetched 64.1 kB in 0s (76.0 kB/s)\nSelecting previously unselected package netcat-traditional.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 9575 files and directories currently installed.)\r\nPreparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...\r\nUnpacking netcat-traditional (1.10-41) ...\r\nSelecting previously unselected package netcat.\r\nPreparing to unpack .../netcat_1.10-41_all.deb ...\r\nUnpacking netcat (1.10-41) ...\r\nSetting up netcat-traditional (1.10-41) ...\r\nupdate-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode\r\nSetting up netcat (1.10-41) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:1 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (176 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  netcat-traditional", "The following NEW packages will be installed:", "  netcat netcat-traditional", "0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.", "Need to get 64.1 kB of archives.", "After this operation, 191 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]", "Fetched 64.1 kB in 0s (76.0 kB/s)", "Selecting previously unselected package netcat-traditional.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 9575 files and directories currently installed.)", "Preparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...", "Unpacking netcat-traditional (1.10-41) ...", "Selecting previously unselected package netcat.", "Preparing to unpack .../netcat_1.10-41_all.deb ...", "Unpacking netcat (1.10-41) ...", "Setting up netcat-traditional (1.10-41) ...", "update-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode", "Setting up netcat (1.10-41) ..."]}

TASK [Start receiver to receive data object from replica pod] ******************
2019-10-11T06:42:19.633412 (delta: 9.90021)         elapsed: 120.874626 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "34113756412.2585", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/34113756412.2585", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
2019-10-11T06:42:20.998976 (delta: 1.365472)         elapsed: 122.24019 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.165528", "end": "2019-10-11 06:42:26.560526", "rc": 0, "start": "2019-10-11 06:42:21.394998", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
2019-10-11T06:42:26.672538 (delta: 5.673447)         elapsed: 127.913752 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.1.252 9090 < /1.dump\"", "delta": "0:00:07.007133", "end": "2019-10-11 06:42:34.041781", "rc": 0, "start": "2019-10-11 06:42:27.034648", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-10-11T06:42:34.190855 (delta: 7.518209)         elapsed: 135.432069 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.192131", "end": "2019-10-11 06:42:34.742383", "rc": 0, "start": "2019-10-11 06:42:34.550252", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
2019-10-11T06:42:34.859524 (delta: 0.668568)         elapsed: 136.100738 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.195334", "end": "2019-10-11 06:42:40.349378", "rc": 0, "start": "2019-10-11 06:42:35.154044", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
2019-10-11T06:42:40.496463 (delta: 5.636842)         elapsed: 141.737677 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "104802376709.2734", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/104802376709.2734", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
2019-10-11T06:42:41.794555 (delta: 1.29797)         elapsed: 143.035769 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.1.252 9090 < /3.dump\"", "delta": "0:00:06.990925", "end": "2019-10-11 06:42:49.144009", "rc": 0, "start": "2019-10-11 06:42:42.153084", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-10-11T06:42:49.288881 (delta: 7.494206)         elapsed: 150.530095 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.193628", "end": "2019-10-11 06:42:49.844510", "rc": 0, "start": "2019-10-11 06:42:49.650882", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
2019-10-11T06:42:49.953180 (delta: 0.664186)         elapsed: 151.194394 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:00.386118", "end": "2019-10-11 06:42:50.698200", "rc": 0, "start": "2019-10-11 06:42:50.312082", "stderr": "", "stderr_lines": [], "stdout": "3949613b-6b97-4d3a-9083-e99c363d4595", "stdout_lines": ["3949613b-6b97-4d3a-9083-e99c363d4595"]}

TASK [Check for dataset name] **************************************************
2019-10-11T06:42:50.794871 (delta: 0.841601)         elapsed: 152.036085 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- zfs list cstor-3949613b-6b97-4d3a-9083-e99c363d4595/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c", "delta": "0:00:01.121701", "end": "2019-10-11 06:42:52.285779", "rc": 0, "start": "2019-10-11 06:42:51.164078", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-3949613b-6b97-4d3a-9083-e99c363d4595/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c   164K  24.2G   111K  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-3949613b-6b97-4d3a-9083-e99c363d4595/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c   164K  24.2G   111K  -"]}

TASK [Dump snapshot datastream to a file] **************************************
2019-10-11T06:42:52.432593 (delta: 1.637638)         elapsed: 153.673807 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-3949613b-6b97-4d3a-9083-e99c363d4595/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V > /snap.data\"", "delta": "0:00:00.994813", "end": "2019-10-11 06:42:53.746838", "rc": 0, "start": "2019-10-11 06:42:52.752025", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
2019-10-11T06:42:53.908201 (delta: 1.475503)         elapsed: 155.149415 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.047132", "end": "2019-10-11 06:42:55.339168", "rc": 0, "start": "2019-10-11 06:42:54.292036", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
2019-10-11T06:42:55.451622 (delta: 1.543304)         elapsed: 156.692836 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:01.123949", "end": "2019-10-11 06:42:56.873902", "rc": 0, "start": "2019-10-11 06:42:55.749953", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5da0242b\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 89bd8f3e4a053844\n\tfromguid = 0\n\ttoname = cstor-3949613b-6b97-4d3a-9083-e99c363d4595/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V\nEND checksum = 2bc97c1b8b2f/7ea242451d922b22/1169684e6b895015/70f1137217934fdf\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 1649\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 36\n\tTotal DRR_SPILL records = 0\n\tTotal records = 1694\n\tTotal write size = 6750720 (0x670200)\n\tTotal stream length = 7279248 (0x6f1290)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5da0242b", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 89bd8f3e4a053844", "\tfromguid = 0", "\ttoname = cstor-3949613b-6b97-4d3a-9083-e99c363d4595/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V", "END checksum = 2bc97c1b8b2f/7ea242451d922b22/1169684e6b895015/70f1137217934fdf", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 1649", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 36", "\tTotal DRR_SPILL records = 0", "\tTotal records = 1694", "\tTotal write size = 6750720 (0x670200)", "\tTotal stream length = 7279248 (0x6f1290)"]}

TASK [Install netcat on replica pod] *******************************************
2019-10-11T06:42:56.991119 (delta: 1.539403)         elapsed: 158.232333 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:12.401725", "end": "2019-10-11 06:43:09.711474", "rc": 0, "start": "2019-10-11 06:42:57.309749", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead.", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (This frontend requires a controlling tty.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:2 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:1 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 3s (84.6 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  netcat-traditional\nThe following NEW packages will be installed:\n  netcat netcat-traditional\n0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.\nNeed to get 64.1 kB of archives.\nAfter this operation, 191 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]\nFetched 64.1 kB in 0s (74.7 kB/s)\nSelecting previously unselected package netcat-traditional.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 9575 files and directories currently installed.)\r\nPreparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...\r\nUnpacking netcat-traditional (1.10-41) ...\r\nSelecting previously unselected package netcat.\r\nPreparing to unpack .../netcat_1.10-41_all.deb ...\r\nUnpacking netcat (1.10-41) ...\r\nSetting up netcat-traditional (1.10-41) ...\r\nupdate-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode\r\nSetting up netcat (1.10-41) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:1 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 3s (84.6 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  netcat-traditional", "The following NEW packages will be installed:", "  netcat netcat-traditional", "0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.", "Need to get 64.1 kB of archives.", "After this operation, 191 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]", "Fetched 64.1 kB in 0s (74.7 kB/s)", "Selecting previously unselected package netcat-traditional.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 9575 files and directories currently installed.)", "Preparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...", "Unpacking netcat-traditional (1.10-41) ...", "Selecting previously unselected package netcat.", "Preparing to unpack .../netcat_1.10-41_all.deb ...", "Unpacking netcat (1.10-41) ...", "Setting up netcat-traditional (1.10-41) ...", "update-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode", "Setting up netcat (1.10-41) ..."]}

TASK [Start receiver to receive data object from replica pod] ******************
2019-10-11T06:43:09.858078 (delta: 12.866861)         elapsed: 171.099292 ***** 
changed: [127.0.0.1] => {"ansible_job_id": "67220644773.3058", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/67220644773.3058", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
2019-10-11T06:43:11.348865 (delta: 1.490705)         elapsed: 172.590079 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.173713", "end": "2019-10-11 06:43:16.856121", "rc": 0, "start": "2019-10-11 06:43:11.682408", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
2019-10-11T06:43:16.983135 (delta: 5.634175)         elapsed: 178.224349 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.1.252 9090 < /1.dump\"", "delta": "0:00:06.925269", "end": "2019-10-11 06:43:24.212616", "rc": 0, "start": "2019-10-11 06:43:17.287347", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-10-11T06:43:24.335114 (delta: 7.351905)         elapsed: 185.576328 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.177682", "end": "2019-10-11 06:43:24.835072", "rc": 0, "start": "2019-10-11 06:43:24.657390", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
2019-10-11T06:43:24.931107 (delta: 0.595901)         elapsed: 186.172321 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.215492", "end": "2019-10-11 06:43:30.461540", "rc": 0, "start": "2019-10-11 06:43:25.246048", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
2019-10-11T06:43:30.597842 (delta: 5.666635)         elapsed: 191.839056 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "560515734511.3205", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/560515734511.3205", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
2019-10-11T06:43:31.937172 (delta: 1.339241)         elapsed: 193.178386 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.1.252 9090 < /3.dump\"", "delta": "0:00:07.155482", "end": "2019-10-11 06:43:39.464182", "rc": 0, "start": "2019-10-11 06:43:32.308700", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-10-11T06:43:39.579190 (delta: 7.641915)         elapsed: 200.820404 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.188188", "end": "2019-10-11 06:43:40.080513", "rc": 0, "start": "2019-10-11 06:43:39.892325", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
2019-10-11T06:43:40.206697 (delta: 0.627401)         elapsed: 201.447911 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:00.363156", "end": "2019-10-11 06:43:40.879873", "rc": 0, "start": "2019-10-11 06:43:40.516717", "stderr": "", "stderr_lines": [], "stdout": "c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f", "stdout_lines": ["c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f"]}

TASK [Check for dataset name] **************************************************
2019-10-11T06:43:40.982550 (delta: 0.775766)         elapsed: 202.223764 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- zfs list cstor-c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c", "delta": "0:00:01.021300", "end": "2019-10-11 06:43:42.367727", "rc": 0, "start": "2019-10-11 06:43:41.346427", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c   162K  28.8G   110K  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c   162K  28.8G   110K  -"]}

TASK [Dump snapshot datastream to a file] **************************************
2019-10-11T06:43:42.491591 (delta: 1.508912)         elapsed: 203.732805 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- bash -c \"zfs send cstor-c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V > /snap.data\"", "delta": "0:00:01.093073", "end": "2019-10-11 06:43:43.908695", "rc": 0, "start": "2019-10-11 06:43:42.815622", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
2019-10-11T06:43:44.048953 (delta: 1.557239)         elapsed: 205.290167 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.083909", "end": "2019-10-11 06:43:45.500986", "rc": 0, "start": "2019-10-11 06:43:44.417077", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
2019-10-11T06:43:45.619733 (delta: 1.57068)         elapsed: 206.860947 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:01.083910", "end": "2019-10-11 06:43:47.023187", "rc": 0, "start": "2019-10-11 06:43:45.939277", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5da0242b\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 93fa7f5ece3fd45b\n\tfromguid = 0\n\ttoname = cstor-c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V\nEND checksum = 2fd28092fb22/b790dea4e8e8895a/c2f940d8073be616/9350ff013f45ef33\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 1649\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 36\n\tTotal DRR_SPILL records = 0\n\tTotal records = 1694\n\tTotal write size = 6750720 (0x670200)\n\tTotal stream length = 7279248 (0x6f1290)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5da0242b", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 93fa7f5ece3fd45b", "\tfromguid = 0", "\ttoname = cstor-c40516e0-3b6e-4dbc-86bd-cff3b0f8a43f/pvc-80bcad89-1243-4b78-ab49-387717f4ad1c@smDH0kCuLK2ssbIfYouzHlSEInOW4g2V", "END checksum = 2fd28092fb22/b790dea4e8e8895a/c2f940d8073be616/9350ff013f45ef33", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 1649", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 36", "\tTotal DRR_SPILL records = 0", "\tTotal records = 1694", "\tTotal write size = 6750720 (0x670200)", "\tTotal stream length = 7279248 (0x6f1290)"]}

TASK [Install netcat on replica pod] *******************************************
2019-10-11T06:43:47.169102 (delta: 1.549294)         elapsed: 208.410316 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:09.464966", "end": "2019-10-11 06:43:56.915167", "rc": 0, "start": "2019-10-11 06:43:47.450201", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead.", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (This frontend requires a controlling tty.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:2 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (197 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  netcat-traditional\nThe following NEW packages will be installed:\n  netcat netcat-traditional\n0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.\nNeed to get 64.1 kB of archives.\nAfter this operation, 191 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]\nFetched 64.1 kB in 0s (67.7 kB/s)\nSelecting previously unselected package netcat-traditional.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 9575 files and directories currently installed.)\r\nPreparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...\r\nUnpacking netcat-traditional (1.10-41) ...\r\nSelecting previously unselected package netcat.\r\nPreparing to unpack .../netcat_1.10-41_all.deb ...\r\nUnpacking netcat (1.10-41) ...\r\nSetting up netcat-traditional (1.10-41) ...\r\nupdate-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode\r\nSetting up netcat (1.10-41) ...", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:2 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (197 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  netcat-traditional", "The following NEW packages will be installed:", "  netcat netcat-traditional", "0 upgraded, 2 newly installed, 0 to remove and 23 not upgraded.", "Need to get 64.1 kB of archives.", "After this operation, 191 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]", "Fetched 64.1 kB in 0s (67.7 kB/s)", "Selecting previously unselected package netcat-traditional.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 9575 files and directories currently installed.)", "Preparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...", "Unpacking netcat-traditional (1.10-41) ...", "Selecting previously unselected package netcat.", "Preparing to unpack .../netcat_1.10-41_all.deb ...", "Unpacking netcat (1.10-41) ...", "Setting up netcat-traditional (1.10-41) ...", "update-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode", "Setting up netcat (1.10-41) ..."]}

TASK [Start receiver to receive data object from replica pod] ******************
2019-10-11T06:43:57.040929 (delta: 9.871737)         elapsed: 218.282143 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "275154236061.3532", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/275154236061.3532", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
2019-10-11T06:43:58.355958 (delta: 1.31495)         elapsed: 219.597172 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.157249", "end": "2019-10-11 06:44:03.822892", "rc": 0, "start": "2019-10-11 06:43:58.665643", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
2019-10-11T06:44:03.935136 (delta: 5.579078)         elapsed: 225.17635 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.1.252 9090 < /1.dump\"", "delta": "0:00:07.006809", "end": "2019-10-11 06:44:11.259717", "rc": 0, "start": "2019-10-11 06:44:04.252908", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-10-11T06:44:11.373825 (delta: 7.438617)         elapsed: 232.615039 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.172758", "end": "2019-10-11 06:44:11.855047", "rc": 0, "start": "2019-10-11 06:44:11.682289", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
2019-10-11T06:44:11.947093 (delta: 0.573195)         elapsed: 233.188307 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.195819", "end": "2019-10-11 06:44:17.453329", "rc": 0, "start": "2019-10-11 06:44:12.257510", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
2019-10-11T06:44:17.572029 (delta: 5.624842)         elapsed: 238.813243 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "62260050381.3681", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/62260050381.3681", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
2019-10-11T06:44:18.878504 (delta: 1.306391)         elapsed: 240.119718 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.1.252 9090 < /3.dump\"", "delta": "0:00:06.991802", "end": "2019-10-11 06:44:26.155727", "rc": 0, "start": "2019-10-11 06:44:19.163925", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-10-11T06:44:26.272019 (delta: 7.393424)         elapsed: 247.513233 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.188153", "end": "2019-10-11 06:44:26.773146", "rc": 0, "start": "2019-10-11 06:44:26.584993", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2019-10-11T06:44:26.892632 (delta: 0.620518)         elapsed: 248.133846 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"base_replica": "cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx"}, "changed": false}

TASK [compare data object] *****************************************************
2019-10-11T06:44:27.046733 (delta: 0.154017)         elapsed: 248.287947 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.1.dump cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.1.dump", "delta": "0:00:00.181474", "end": "2019-10-11 06:44:27.517673", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx", "start": "2019-10-11 06:44:27.336199", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9.1.dump cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.1.dump", "delta": "0:00:00.183747", "end": "2019-10-11 06:44:27.998482", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9", "start": "2019-10-11 06:44:27.814735", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j.1.dump cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.1.dump", "delta": "0:00:00.202211", "end": "2019-10-11 06:44:28.505462", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j", "start": "2019-10-11 06:44:28.303251", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [compare meta data object] ************************************************
2019-10-11T06:44:28.621794 (delta: 1.574972)         elapsed: 249.863008 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.3.dump cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.3.dump", "delta": "0:00:00.183903", "end": "2019-10-11 06:44:29.101351", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx", "start": "2019-10-11 06:44:28.917448", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9.3.dump cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.3.dump", "delta": "0:00:00.182004", "end": "2019-10-11 06:44:29.606480", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-q2ae-6f8449c864-7mjk9", "start": "2019-10-11 06:44:29.424476", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j.3.dump cstor-block-disk-pool-stripe-lm2l-d49b8967c-xv5nx.3.dump", "delta": "0:00:00.230205", "end": "2019-10-11 06:44:30.114154", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-wg2s-7d7974d5f4-gsd2j", "start": "2019-10-11 06:44:29.883949", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Destroy snapshot created for data verification] **************************
2019-10-11T06:44:30.219738 (delta: 1.597854)         elapsed: 251.460952 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-80bcad89-1243-4b78-ab49-387717f4ad1c-target-84648b6c9bhdpp2 -n openebs --container cstor-istgt -- istgtcontrol snapdestroy pvc-80bcad89-1243-4b78-ab49-387717f4ad1c smDH0kCuLK2ssbIfYouzHlSEInOW4g2V 30 30", "delta": "0:00:01.001040", "end": "2019-10-11 06:44:31.515357", "rc": 0, "start": "2019-10-11 06:44:30.514317", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPDESTROY command", "stdout_lines": ["DONE SNAPDESTROY command"]}

TASK [set_fact] ****************************************************************
2019-10-11T06:44:31.638972 (delta: 1.419135)         elapsed: 252.880186 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-10-11T06:44:31.792990 (delta: 0.153928)         elapsed: 253.034204 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-11T06:44:32.011270 (delta: 0.21819)         elapsed: 253.252484 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-11T06:44:32.109006 (delta: 0.09764)         elapsed: 253.35022 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-11T06:44:32.208405 (delta: 0.099312)         elapsed: 253.449619 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-11T06:44:32.311836 (delta: 0.103338)         elapsed: 253.55305 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "6a9d31aa1f547d2b46eea33253028a6eb1daf19c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "96b8bc4bcf5e28ee4aa8097eb27a650c", "mode": "0644", "owner": "root", "size": 429, "src": "/root/.ansible/tmp/ansible-tmp-1570776272.4-107414804190244/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-11T06:44:33.333024 (delta: 1.021114)         elapsed: 254.574238 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.162080", "end": "2019-10-11 06:44:33.817294", "rc": 0, "start": "2019-10-11 06:44:33.655214", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-volume-replica-migration \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-volume-replica-migration ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-11T06:44:33.918208 (delta: 0.585111)         elapsed: 255.159422 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.693306", "end": "2019-10-11 06:44:34.952682", "failed_when_result": false, "rc": 0, "start": "2019-10-11 06:44:34.259376", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cstor-volume-replica-migration configured", "stdout_lines": ["litmusresult.litmus.io/cstor-volume-replica-migration configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=114  changed=101  unreachable=0    failed=0   

2019-10-11T06:44:35.017943 (delta: 1.099639)         elapsed: 256.259157 ****** 
=============================================================================== 
```