### PR TITLE
Add litmusbook for cstor-volume-replica scaleup

### DIFF
--- a/apps/busybox/cvr_scaleup/cvr.yml
+++ b/apps/busybox/cvr_scaleup/cvr.yml
@@ -1,0 +1,26 @@
+apiVersion: openebs.io/v1alpha1
+kind: CStorVolumeReplica
+metadata:
+  annotations:
+    cstorpool.openebs.io/hostname: <node_name>
+    isRestoreVol: "false"
+    openebs.io/storage-class-ref: |
+      name: <storage-class>
+  finalizers:
+  - cstorvolumereplica.openebs.io/finalizer
+  generation: 1
+  labels:
+    cstorpool.openebs.io/name: <csp-name>
+    cstorpool.openebs.io/uid: "<csp-uid>"
+    cstorvolume.openebs.io/name: <cstor-volume-name>
+    openebs.io/cas-template-name: cstor-volume-create-default-1.3.0
+    openebs.io/persistent-volume: <cstor-volume-name>
+    openebs.io/version: 1.3.0
+  name: <cstor-volume-name>-<csp-name>
+  namespace: openebs
+spec:
+  capacity: <initial_capacity>
+  targetIP: "<target-ip>"
+  replicaid: ""
+status:
+  phase: Recreate

--- a/apps/busybox/cvr_scaleup/cvr.yml
+++ b/apps/busybox/cvr_scaleup/cvr.yml
@@ -13,9 +13,9 @@ metadata:
     cstorpool.openebs.io/name: <csp-name>
     cstorpool.openebs.io/uid: "<csp-uid>"
     cstorvolume.openebs.io/name: <cstor-volume-name>
-    openebs.io/cas-template-name: cstor-volume-create-default-1.3.0
+    openebs.io/cas-template-name: cstor-volume-create-default-<openebs-version>
     openebs.io/persistent-volume: <cstor-volume-name>
-    openebs.io/version: 1.3.0
+    openebs.io/version: <openebs-version>
   name: <cstor-volume-name>-<csp-name>
   namespace: openebs
 spec:

--- a/apps/busybox/cvr_scaleup/patch_cstorvolume.yml
+++ b/apps/busybox/cvr_scaleup/patch_cstorvolume.yml
@@ -1,0 +1,2 @@
+spec:
+  desiredReplicationFactor: <desired-replication-factor>

--- a/apps/busybox/cvr_scaleup/patch_cvr.yml
+++ b/apps/busybox/cvr_scaleup/patch_cvr.yml
@@ -1,0 +1,2 @@
+spec:
+  replicaid: <md5-sum-uid>

--- a/apps/busybox/cvr_scaleup/prerequisites.yml
+++ b/apps/busybox/cvr_scaleup/prerequisites.yml
@@ -1,0 +1,56 @@
+---
+
+- name: Replace the pvc placeholder with provider
+  replace:
+    path: "{{ application_deployment }}"
+    regexp: "testclaim"
+    replace: "{{ lookup('env','APP_PVC') }}"
+
+- include_tasks: /utils/scm/openebs/fetch_replica_values.yml
+  when: lookup('env', 'APP_REPLICA')
+
+- name: Get the application label values from env
+  set_fact:
+     app_lkey: "{{ app_label.split('=')[0] }}"
+     app_lvalue: "{{ app_label.split('=')[1] }}"
+
+- name: Replace the application label placeholder in deployment spec
+  replace:
+    path: "{{ application_deployment }}"
+    regexp: "lkey: lvalue"
+    replace: "{{ app_lkey }}: {{ app_lvalue }}"
+
+- include_tasks: /utils/k8s/create_ns.yml
+
+- name: Replace the affinity label annotation in statefulset yml
+  replace:
+    path: "{{ application_deployment }}"
+    regexp: "affinity_label"
+    replace: "{{ affinity_label }}"
+ 
+- name: Replacing the volume capcity placeholder with provider
+  replace:
+    path: "{{ application_deployment }}"
+    regexp: "teststorage"
+    replace: "{{ lookup('env','PV_CAPACITY') }}"
+
+- name: Replacing the SPC name in storage class yml
+  replace:
+    path: "./storage_class.yml"
+    regexp: "spc-name"
+    replace: "{{ lookup('env','SPC_NAME') }}"
+
+- name: Replacing the replica count in spc yml
+  replace:
+    path: "./storage_class.yml"
+    regexp: "replica-count"
+    replace: "{{ lookup('env','VOLUME_REPLICAS') }}"
+
+- name: Creating storage class
+  shell: kubectl apply -f storage_class.yml
+
+- name: Replace the storageclass placeholder with provider
+  replace:
+    path: "{{ application_deployment }}"
+    regexp: "testclass"
+    replace: "openebs-cstor-cvr-scale" 

--- a/apps/busybox/cvr_scaleup/run_litmus_test.yml
+++ b/apps/busybox/cvr_scaleup/run_litmus_test.yml
@@ -25,6 +25,9 @@ spec:
           - name: SPC_NAME
             value: cstor-sparse-pool
 
+          - name: OPENEBS_VERSION
+            value: "1.3.0"
+
           - name: VOLUME_REPLICAS
             value: "2"
 

--- a/apps/busybox/cvr_scaleup/run_litmus_test.yml
+++ b/apps/busybox/cvr_scaleup/run_litmus_test.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-cvr-scaleup
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: busybox-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: SPC_NAME
+            value: cstor-sparse-pool
+
+          - name: VOLUME_REPLICAS
+            value: "2"
+
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+
+            # Application label
+            # Use different 'LABEL' for deployment and statefulset application
+          - name: APP_LABEL
+            value: 'app=busybox'
+
+            # Affinity Label for Application
+            # openebs.io/target-affinity if for deployment and statefulset
+            # openebs.io/replica-anti-affinity if for statefulset application
+            # openebs.io/replica-anti-affinity needs to be added in order to distribute volume replicas.
+          - name: AFFINITY_LABEL
+            value: openebs.io/target-affinity
+
+            # Application namespace
+            # Use different 'namespace' for deployment and statefulset application
+          - name: APP_NAMESPACE
+            value: app-busybox-cvr-scale
+
+            # Use 'deployment'  for Busybox deployment application
+            # Use 'statefulset' for Busybox statefulset application
+          - name: DEPLOY_TYPE
+            value: deployment
+            
+            #Persistent Volume storage capacity
+          - name: PV_CAPACITY
+            value: 5G
+            
+          # Use 'deprovision' for app-clean up
+          - name: ACTION
+            value: provision
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./apps/busybox/cvr_scaleup/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/busybox/cvr_scaleup/storage_class.yml
+++ b/apps/busybox/cvr_scaleup/storage_class.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-cvr-scale
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "spc-name"
+      - name: ReplicaCount
+        value: "replica-count"
+provisioner: openebs.io/provisioner-iscsi

--- a/apps/busybox/cvr_scaleup/test.yml
+++ b/apps/busybox/cvr_scaleup/test.yml
@@ -1,0 +1,247 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - block:
+           
+            - include_tasks: ./prerequisites.yml 
+
+              ## Deploying the application
+              # application_deployment: "{{ application_deployment }}"
+            - include_tasks: /utils/k8s/deploy_single_app.yml
+              vars:
+                check_app_pod: 'no'
+                delay: 10
+                retries: 20 
+
+            - name: Checking the status of application pod
+              shell: kubectl get pod -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].status.phase}'
+              register: app_pod_status
+              until: "'Running' in app_pod_status.stdout"
+              delay: 5
+              retries: 30
+
+            - name: Getting the pod name of Application
+              shell: kubectl get pod -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+              register: app_pod_name
+
+            - name: Geting the PV name
+              shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
+              register: volume_name
+              until: "volume_name is defined"
+              delay: 5
+              retries: 10
+ 
+            - name: Verify cvr health status
+              shell: kubectl get cvr -n openebs -l openebs.io/persistent-volume={{ volume_name.stdout }} -o jsonpath='{.items[*].status.phase}'
+              register: initial_status
+              until: "((initial_status.stdout.split()|unique)|length) == 1 and 'Healthy' in initial_status.stdout"
+              delay: 3
+              retries: 30
+             
+            - name: Create some test data in the Busybox
+              include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+              vars:
+                status: 'LOAD'
+                ns: "{{ app_ns }}"
+                pod_name: "{{ app_pod_name.stdout }}"
+                testfile: "busybox_data.txt"
+                blocksize: "4k"
+                blockcount: "400000"
+
+            - name: Getting the list of csp name correspond to provided spc
+              shell: kubectl get csp -l openebs.io/storage-pool-claim={{ spc_name }} -o jsonpath='{.items[*].metadata.name}'
+              register: csp_all
+
+            - name: Create a file to store CSP name
+              lineinfile:
+                create: yes
+                state: present
+                path: "./csp_all.tmp"
+                line: "{{ item.stdout }}"
+                mode: 0755
+              with_items:
+                - "{{ csp_all }}"
+
+            - name: Getting the list of csp on which cvr is created
+              shell:  kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ volume_name.stdout }} -o jsonpath='{.items[*].metadata.labels.cstorpool\.openebs\.io/name}'
+              register: csp_cvr
+
+            - name: Create a file to store CSP name
+              lineinfile:
+                create: yes
+                state: present
+                path: "./csp_cvr.tmp"
+                line: "{{ item.stdout }}"
+                mode: 0755
+              with_items:
+                - "{{ csp_cvr }}"
+
+            - name: Getting the csp where no cvr is created
+              shell: |
+                cat csp_all.tmp | tr " " "\n" > csp_all
+                cat csp_cvr.tmp | tr " " "\n" > csp_cvr
+                comm -3 <(sort csp_all) <(sort csp_cvr)
+              args: 
+                executable: /bin/bash
+              register: csp_name
+
+            - name: Getting the target IP from cvr
+              shell: kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ volume_name.stdout }} -o jsonpath='{.items[0].spec.targetIP}'
+              register: target_ip
+
+            - name: Getting the Node IP of CSP
+              shell: kubectl get csp {{ csp_name.stdout_lines[0] }} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}'
+              register: node_name
+
+            - name: Getting csp uid 
+              shell: kubectl get csp {{ csp_name.stdout_lines[0] }} -o jsonpath='{.metadata.uid}'
+              register: uid
+
+            - name: Replacing the storage class in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<storage-class>"
+                replace: "openebs-cstor-cvr-scale"
+            
+            - name: Replacing the Node name in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<node_name>"
+                replace: "{{ node_name.stdout }}"
+
+            - name: Replacing the CSP name in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<csp-name>"
+                replace: "{{ csp_name.stdout_lines[0] }}"
+
+            - name: Replacing the uid in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<csp-uid>"
+                replace: "{{ uid.stdout }}"
+              
+            - name: Replacing the volume name in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<cstor-volume-name>"
+                replace: "{{ volume_name.stdout }}"
+
+            - name: Replacing the volume capacity in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<initial_capacity>"
+                replace: "{{ lookup('env','PV_CAPACITY') }}"
+
+            - name: Replacing the target IP in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<target-ip>"
+                replace: "{{ target_ip.stdout }}"
+
+            - name: Replacing the DRF in patch_cstorvolume yml
+              replace:
+                path: "./patch_cstorvolume.yml"
+                regexp: "<desired-replication-factor>"
+                replace: "3"
+
+            - name: Patching the cstorvolume's desired rep count
+              shell: kubectl patch cstorvolume {{ volume_name.stdout }} -n {{ operator_ns }} --type merge --patch "$(cat patch_cstorvolume.yml)"
+              register: patch_cstorvolume_result
+              failed_when: "'patched' not in patch_cstorvolume_result.stdout"
+            
+            - name: Creating new cvr
+              shell: kubectl apply -f cvr.yml
+
+            - name: Getting the uid of newly created cvr
+              shell: kubectl get cvr -n {{ operator_ns }} -l cstorpool.openebs.io/name={{ csp_name.stdout_lines[0] }},cstorvolume.openebs.io/name={{ volume_name.stdout }} -o jsonpath='{.items[0].metadata.uid}'
+              register: new_uid
+
+            - name: Creating MD5SUM of new-uid
+              shell: echo {{ new_uid.stdout }} | md5sum | awk '{print toupper($1)}' 
+              register: md5sum
+
+            - name: Replacing the md5sum value in patch yml
+              replace:
+                path: "./patch_cvr.yml"
+                regexp: "<md5-sum-uid>"
+                replace: "{{ md5sum.stdout }}"
+
+            - name: Patching the cvr's replica id with md5sum
+              shell: kubectl patch cvr {{ volume_name.stdout }}-{{ csp_name.stdout_lines[0] }} -n {{ operator_ns }} --type merge --patch "$(cat patch_cvr.yml)"
+              register: patch_cvr_result
+              failed_when: "'patched' not in patch_cvr_result.stdout"
+            
+            - name: Getting the cstor pool pod name
+              shell: kubectl get pod -n {{ operator_ns }} -l app=cstor-pool,openebs.io/cstor-pool={{ csp_name.stdout_lines[0] }} -o jsonpath='{.items[0].metadata.name}'
+              register: pool_pod_name
+
+            - name: Restarting the pool pod
+              shell: kubectl delete pod {{ pool_pod_name.stdout }} -n {{ operator_ns }}
+
+            - name: Checking for the pool pod to be in running state
+              shell: kubectl get pod -n {{ operator_ns }} -l app=cstor-pool,openebs.io/cstor-pool={{ csp_name.stdout_lines[0] }} -o jsonpath='{.items[0].status.phase}'
+              register: pod_status
+              until: "'Running' in pod_status.stdout"
+              delay: 5
+              retries: 10
+
+            - name: Verify cvr health status
+              shell: kubectl get cvr -n openebs -l openebs.io/persistent-volume={{ volume_name.stdout }} -o jsonpath='{.items[*].status.phase}'
+              register: final_status
+              until: "((final_status.stdout.split()|unique)|length) == 1 and 'Healthy' in final_status.stdout"
+              delay: 10
+              retries: 100
+
+            - name: Verify data persistence
+              include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+              vars:
+                status: 'VERIFY'
+                ns: "{{ app_ns }}"
+                pod_name: "{{ app_pod_name.stdout }}"
+                label: "{{ app_label }}"
+                testfile: "busybox_data.txt"
+
+            - set_fact:
+                flag: "Pass"
+
+          rescue:
+            - name: Setting fail flag
+              set_fact:
+                flag: "Fail"  
+
+          always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+            - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+              vars:
+                status: 'EOT'
+
+            - name: Deprovisioning test related resources
+              shell: |
+                kubectl delete deploy,svc --all {{ app_ns }}
+                kubectl delete pvc {{ app_pvc }} -n {{ app_ns }}
+            
+            - name: Deleting storage class
+              shell: kubectl delete sc openebs-cstor-cvr-scale
+
+
+                
+
+            
+
+            

--- a/apps/busybox/cvr_scaleup/test.yml
+++ b/apps/busybox/cvr_scaleup/test.yml
@@ -41,13 +41,20 @@
 
             - name: Geting the PV name
               shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
-              register: volume_name
-              until: "volume_name is defined"
+              register: pv
+              until: "pv is defined"
               delay: 5
               retries: 10
- 
+
+            - name: Checking the cstorvolume status
+              shell: kubectl get cstorvolume -n {{ operator_ns }} {{ pv.stdout }} -o jsonpath='{.status.phase}'
+              register: cstor_volume_status
+              until: "'Healthy' in cstor_volume_status.stdout"
+              delay: 5
+              retries: 30
+
             - name: Verify cvr health status
-              shell: kubectl get cvr -n openebs -l openebs.io/persistent-volume={{ volume_name.stdout }} -o jsonpath='{.items[*].status.phase}'
+              shell: kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} -o jsonpath='{.items[*].status.phase}'
               register: initial_status
               until: "((initial_status.stdout.split()|unique)|length) == 1 and 'Healthy' in initial_status.stdout"
               delay: 3
@@ -78,7 +85,7 @@
                 - "{{ csp_all }}"
 
             - name: Getting the list of csp on which cvr is created
-              shell:  kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ volume_name.stdout }} -o jsonpath='{.items[*].metadata.labels.cstorpool\.openebs\.io/name}'
+              shell:  kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} -o jsonpath='{.items[*].metadata.labels.cstorpool\.openebs\.io/name}'
               register: csp_cvr
 
             - name: Create a file to store CSP name
@@ -101,10 +108,10 @@
               register: csp_name
 
             - name: Getting the target IP from cvr
-              shell: kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ volume_name.stdout }} -o jsonpath='{.items[0].spec.targetIP}'
+              shell: kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} -o jsonpath='{.items[0].spec.targetIP}'
               register: target_ip
 
-            - name: Getting the Node IP of CSP
+            - name: Getting the Node name from CSP where CVR need to create
               shell: kubectl get csp {{ csp_name.stdout_lines[0] }} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}'
               register: node_name
 
@@ -140,7 +147,7 @@
               replace:
                 path: "./cvr.yml"
                 regexp: "<cstor-volume-name>"
-                replace: "{{ volume_name.stdout }}"
+                replace: "{{ pv.stdout }}"
 
             - name: Replacing the volume capacity in cvr yml
               replace:
@@ -161,7 +168,7 @@
                 replace: "3"
 
             - name: Patching the cstorvolume's desired rep count
-              shell: kubectl patch cstorvolume {{ volume_name.stdout }} -n {{ operator_ns }} --type merge --patch "$(cat patch_cstorvolume.yml)"
+              shell: kubectl patch cstorvolume {{ pv.stdout }} -n {{ operator_ns }} --type merge --patch "$(cat patch_cstorvolume.yml)"
               register: patch_cstorvolume_result
               failed_when: "'patched' not in patch_cstorvolume_result.stdout"
             
@@ -169,7 +176,7 @@
               shell: kubectl apply -f cvr.yml
 
             - name: Getting the uid of newly created cvr
-              shell: kubectl get cvr -n {{ operator_ns }} -l cstorpool.openebs.io/name={{ csp_name.stdout_lines[0] }},cstorvolume.openebs.io/name={{ volume_name.stdout }} -o jsonpath='{.items[0].metadata.uid}'
+              shell: kubectl get cvr -n {{ operator_ns }} -l cstorpool.openebs.io/name={{ csp_name.stdout_lines[0] }},cstorvolume.openebs.io/name={{ pv.stdout }} -o jsonpath='{.items[0].metadata.uid}'
               register: new_uid
 
             - name: Creating MD5SUM of new-uid
@@ -183,30 +190,124 @@
                 replace: "{{ md5sum.stdout }}"
 
             - name: Patching the cvr's replica id with md5sum
-              shell: kubectl patch cvr {{ volume_name.stdout }}-{{ csp_name.stdout_lines[0] }} -n {{ operator_ns }} --type merge --patch "$(cat patch_cvr.yml)"
+              shell: kubectl patch cvr {{ pv.stdout }}-{{ csp_name.stdout_lines[0] }} -n {{ operator_ns }} --type merge --patch "$(cat patch_cvr.yml)"
               register: patch_cvr_result
               failed_when: "'patched' not in patch_cvr_result.stdout"
-            
+       
             - name: Getting the cstor pool pod name
               shell: kubectl get pod -n {{ operator_ns }} -l app=cstor-pool,openebs.io/cstor-pool={{ csp_name.stdout_lines[0] }} -o jsonpath='{.items[0].metadata.name}'
               register: pool_pod_name
 
-            - name: Restarting the pool pod
-              shell: kubectl delete pod {{ pool_pod_name.stdout }} -n {{ operator_ns }}
+            - name: Restarting the cstor-pool-mgmt container
+              shell: kubectl exec -it {{ pool_pod_name.stdout }} -n {{ operator_ns }} -c cstor-pool-mgmt -- pkill -f /usr/local/bin/
+              ignore_errors: true
 
             - name: Checking for the pool pod to be in running state
               shell: kubectl get pod -n {{ operator_ns }} -l app=cstor-pool,openebs.io/cstor-pool={{ csp_name.stdout_lines[0] }} -o jsonpath='{.items[0].status.phase}'
               register: pod_status
               until: "'Running' in pod_status.stdout"
-              delay: 5
-              retries: 10
+              delay: 10
+              retries: 50
+
+            - name: Verify newly Created replicaID exists in cstorVolume or not
+              shell: kubectl get cstorvolume {{ pv.stdout }} -n {{ operator_ns }} -o jsonpath='{.status.replicaDetails.knownReplicas.{{ md5sum.stdout }}}'
+              register: replica_status
+              until: "replica_status.stdout != ''"
+              delay: 10
+              retries: 100
+
+            - name: Checking for the desired replication factor in cstorvolume
+              shell: kubectl get cstorvolume {{ pv.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.replicationFactor}'
+              register: replication_factor
+              failed_when: "'3' not in replication_factor.stdout"
+
+            - name: Checking for the consistancy factor in cstorvolume
+              shell: kubectl get cstorvolume {{ pv.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.consistencyFactor}'
+              register: consistancy_factor
+              failed_when: "'2' not in consistancy_factor.stdout"
 
             - name: Verify cvr health status
-              shell: kubectl get cvr -n openebs -l openebs.io/persistent-volume={{ volume_name.stdout }} -o jsonpath='{.items[*].status.phase}'
+              shell: kubectl get cvr -n openebs -l openebs.io/persistent-volume={{ pv.stdout }} -o jsonpath='{.items[*].status.phase}'
               register: final_status
               until: "((final_status.stdout.split()|unique)|length) == 1 and 'Healthy' in final_status.stdout"
               delay: 10
               retries: 100
+
+            - name: Get istgt target pod details
+              shell: >
+                kubectl get pods  -l openebs.io/persistent-volume={{ pv.stdout }} 
+                -n {{ operator_ns }} -o custom-columns=:metadata.name --no-headers
+              register: istgt_replica
+              failed_when: 'istgt_replica.stdout == ""'
+
+            - name: Create an empty list of replica pods.
+              set_fact:
+                cstor_replicas_pod : []         
+
+            - name: Obtaining the pool deployments from cvr
+              shell: >
+                 kubectl get cvr -n {{ operator_ns }}
+                 -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+                 -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+              args:
+                 executable: /bin/bash
+              register: pool_deployment
+              failed_when: 'pool_deployment.stdout == ""'
+     
+            - name: Obtaining the pool pods
+              shell: >
+                kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool={{ item }} 
+                -n {{ operator_ns }} --no-headers -o custom-columns=:.metadata.name
+              register: pool_pods
+              failed_when: 'pool_pods.stdout == ""'
+              with_items:
+                - "{{ pool_deployment.stdout_lines }}"
+     
+            - name: Build a list of replica pods
+              set_fact:
+                cstor_replicas_pod : "{{ cstor_replicas_pod }} + [ '{{ item.stdout }}' ]"
+              with_items: "{{ pool_pods.results }}"
+     
+            - name: Generate snapshot name
+              shell: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
+              register: snapname
+     
+            - set_fact:
+                snap_name: "{{ snapname.stdout }}"
+     
+            - name: Take snapshot for data verification
+              shell: >
+                 kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol snapcreate {{ pv.stdout }} {{ snap_name }} 30 30
+              register: snap_status
+     
+            - name: Install netcat on current host
+              shell: apt-get update && apt-get -y install netcat iproute2
+              register: dataset
+     
+            - include: /chaoslib/openebs/fetch_data_from_replica.yml
+              loop: "{{ cstor_replicas_pod }}"
+              loop_control:
+                loop_var: rpod       
+     
+            - set_fact:
+                 base_replica: "{{ cstor_replicas_pod | list | first }}"
+     
+            - name: compare data object
+              shell: diff {{ rpod }}.1.dump {{ base_replica }}.1.dump
+              loop: "{{ cstor_replicas_pod }}"
+              loop_control:
+                loop_var: rpod
+     
+            - name: compare meta data object
+              shell: diff {{ rpod }}.3.dump {{ base_replica }}.3.dump
+              loop: "{{ cstor_replicas_pod }}"
+              loop_control:
+                 loop_var: rpod
+     
+            - name: Destroy snapshot created for data verification
+              shell: >
+                kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol snapdestroy {{ pv.stdout }} {{ snap_name }} 30 30
+              register: snap_status                            
 
             - name: Verify data persistence
               include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
@@ -231,13 +332,14 @@
               vars:
                 status: 'EOT'
 
-            - name: Deprovisioning test related resources
-              shell: |
-                kubectl delete deploy,svc --all {{ app_ns }}
-                kubectl delete pvc {{ app_pvc }} -n {{ app_ns }}
+            # - name: Deprovisioning test related resources
+            #   shell: |
+            #     kubectl delete deploy,svc --all -n {{ app_ns }}
+            #     kubectl delete pvc {{ app_pvc }} -n {{ app_ns }}
+            #     kubectl delete namespace {{ app_ns }}
             
-            - name: Deleting storage class
-              shell: kubectl delete sc openebs-cstor-cvr-scale
+            # - name: Deleting storage class
+            #   shell: kubectl delete sc openebs-cstor-cvr-scale
 
 
                 

--- a/apps/busybox/cvr_scaleup/test.yml
+++ b/apps/busybox/cvr_scaleup/test.yml
@@ -155,6 +155,12 @@
                 regexp: "<initial_capacity>"
                 replace: "{{ lookup('env','PV_CAPACITY') }}"
 
+            - name: Replacing OpenEBS version in cvr yml
+              replace:
+                path: "./cvr.yml"
+                regexp: "<openebs-version>"
+                replace: "{{ lookup('env','OPENEBS_VERSION') }}"
+
             - name: Replacing the target IP in cvr yml
               replace:
                 path: "./cvr.yml"

--- a/apps/busybox/cvr_scaleup/test_vars.yml
+++ b/apps/busybox/cvr_scaleup/test_vars.yml
@@ -1,0 +1,11 @@
+application_deployment: ../deployers/busybox_deployment.yml
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+app_label: "{{ lookup('env','APP_LABEL') }}"
+test_name: "openebs-cvr-scaleup"
+deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"
+app_replica: "{{ lookup('env','APP_REPLICA') }}"
+affinity_label: "{{ lookup('env','AFFINITY_LABEL') }}"
+application_name: "busybox"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+operator_ns: openebs
+spc_name: "{{ lookup('env','SPC_NAME') }}"


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

**What this PR does / why we need it**:
- Add a litmus experiment for cstor-volume-replica scale up, performed against Busybox with data persistence enabled. 

**Following is the log of ansible test container:**
```

PLAY [localhost] ***************************************************************
2019-10-09T07:42:56.356263 (delta: 0.068753)         elapsed: 0.068753 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-10-09T07:42:56.374889 (delta: 0.018565)         elapsed: 0.087379 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-10-09T07:42:58.960353 (delta: 2.585416)         elapsed: 2.672843 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-10-09T07:42:59.066162 (delta: 0.105756)         elapsed: 2.778652 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-10-09T07:42:59.141015 (delta: 0.074789)         elapsed: 2.853505 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-09T07:42:59.238286 (delta: 0.097209)         elapsed: 2.950776 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-09T07:42:59.409827 (delta: 0.171465)         elapsed: 3.122317 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "1f5327c5dde8d1e2c091ff2a03e17f9c47c51a34", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3b94830ec2c7ec52ee939db0aac74b6a", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1570606979.47-233482901195401/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-09T07:43:00.142773 (delta: 0.732889)         elapsed: 3.855263 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.162094", "end": "2019-10-09 07:43:00.751751", "rc": 0, "start": "2019-10-09 07:43:00.589657", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-cvr-scaleup \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-cvr-scaleup ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-09T07:43:00.825775 (delta: 0.682947)         elapsed: 4.538265 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.115116", "end": "2019-10-09 07:43:02.196647", "failed_when_result": false, "rc": 0, "start": "2019-10-09 07:43:01.081531", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-cvr-scaleup configured", "stdout_lines": ["litmusresult.litmus.io/openebs-cvr-scaleup configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-09T07:43:02.282106 (delta: 1.45627)         elapsed: 5.994596 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-09T07:43:02.350580 (delta: 0.068409)         elapsed: 6.06307 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-09T07:43:02.418309 (delta: 0.067674)         elapsed: 6.130799 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:02.488866 (delta: 0.070503)         elapsed: 6.201356 ******** 
included: /apps/busybox/cvr_scaleup/prerequisites.yml for 127.0.0.1

TASK [Replace the pvc placeholder with provider] *******************************
2019-10-09T07:43:02.624091 (delta: 0.135173)         elapsed: 6.336581 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:03.138903 (delta: 0.514758)         elapsed: 6.851393 ******** 
included: /utils/scm/openebs/fetch_replica_values.yml for 127.0.0.1

TASK [Get the application replica values from env] *****************************
2019-10-09T07:43:03.309107 (delta: 0.170141)         elapsed: 7.021597 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "2"}, "changed": false}

TASK [Replace the application replica placeholder in statefulset spec.] ********
2019-10-09T07:43:03.451000 (delta: 0.141831)         elapsed: 7.16349 ********* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Get the application label values from env] *******************************
2019-10-09T07:43:03.775414 (delta: 0.324341)         elapsed: 7.487904 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-10-09T07:43:03.894542 (delta: 0.119065)         elapsed: 7.607032 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:04.242026 (delta: 0.347423)         elapsed: 7.954516 ******** 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-10-09T07:43:04.438370 (delta: 0.19626)         elapsed: 8.15086 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.317471", "end": "2019-10-09 07:43:04.971912", "rc": 0, "start": "2019-10-09 07:43:04.654441", "stderr": "", "stderr_lines": [], "stdout": "default\nkommander\nkube-node-lease\nkube-public\nkube-system\nkubeaddons\nlitmus\nopenebs\npercona-5g\npercona-5g-csi\npercona-bd", "stdout_lines": ["default", "kommander", "kube-node-lease", "kube-public", "kube-system", "kubeaddons", "litmus", "openebs", "percona-5g", "percona-5g-csi", "percona-bd"]}

TASK [Create test specific namespace.] *****************************************
2019-10-09T07:43:05.035125 (delta: 0.596687)         elapsed: 8.747615 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-busybox-cvr-scale", "delta": "0:00:00.325448", "end": "2019-10-09 07:43:05.624687", "rc": 0, "start": "2019-10-09 07:43:05.299239", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-busybox-cvr-scale created", "stdout_lines": ["namespace/app-busybox-cvr-scale created"]}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:05.729807 (delta: 0.694629)         elapsed: 9.442297 ******** 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-10-09T07:43:05.873316 (delta: 0.143432)         elapsed: 9.585806 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-busybox-cvr-scale -o custom-columns=:status.phase --no-headers", "delta": "0:00:00.372291", "end": "2019-10-09 07:43:06.468957", "rc": 0, "start": "2019-10-09 07:43:06.096666", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the affinity label annotation in statefulset yml] ****************
2019-10-09T07:43:06.551589 (delta: 0.678205)         elapsed: 10.264079 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the volume capcity placeholder with provider] ******************
2019-10-09T07:43:06.871191 (delta: 0.319543)         elapsed: 10.583681 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the SPC name in storage class yml] *****************************
2019-10-09T07:43:07.155341 (delta: 0.284093)         elapsed: 10.867831 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the replica count in spc yml] **********************************
2019-10-09T07:43:07.429564 (delta: 0.274161)         elapsed: 11.142054 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Creating storage class] **************************************************
2019-10-09T07:43:07.710650 (delta: 0.281031)         elapsed: 11.42314 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f storage_class.yml", "delta": "0:00:00.537355", "end": "2019-10-09 07:43:08.488864", "rc": 0, "start": "2019-10-09 07:43:07.951509", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-cvr-scale unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-cvr-scale unchanged"]}

TASK [Replace the storageclass placeholder with provider] **********************
2019-10-09T07:43:08.579916 (delta: 0.869205)         elapsed: 12.292406 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:08.893296 (delta: 0.313304)         elapsed: 12.605786 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying busybox] *******************************************************
2019-10-09T07:43:09.030884 (delta: 0.137526)         elapsed: 12.743374 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f ../deployers/busybox_deployment.yml -n app-busybox-cvr-scale", "delta": "0:00:00.769559", "end": "2019-10-09 07:43:10.016522", "rc": 0, "start": "2019-10-09 07:43:09.246963", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/app-busybox created\npersistentvolumeclaim/openebs-busybox created", "stdout_lines": ["deployment.apps/app-busybox created", "persistentvolumeclaim/openebs-busybox created"]}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:10.106535 (delta: 1.07559)         elapsed: 13.819025 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-09T07:43:10.184358 (delta: 0.077758)         elapsed: 13.896848 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the pod name of Application] *************************************
2019-10-09T07:43:10.297732 (delta: 0.113307)         elapsed: 14.010222 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-busybox-cvr-scale -l app=busybox -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.370045", "end": "2019-10-09 07:43:10.987889", "rc": 0, "start": "2019-10-09 07:43:10.617844", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-69fb5bfff8-b8p2w", "stdout_lines": ["app-busybox-69fb5bfff8-b8p2w"]}

TASK [Geting the cstor-volume name] ********************************************
2019-10-09T07:43:11.065180 (delta: 0.767364)         elapsed: 14.77767 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-cvr-scale -o jsonpath='{.spec.volumeName}'", "delta": "0:00:00.299295", "end": "2019-10-09 07:43:11.613534", "rc": 0, "start": "2019-10-09 07:43:11.314239", "stderr": "", "stderr_lines": [], "stdout": "pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64", "stdout_lines": ["pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64"]}

TASK [Verify cvr health status] ************************************************
2019-10-09T07:43:11.687885 (delta: 0.622643)         elapsed: 15.400375 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.items[*].status.phase}'", "delta": "0:00:00.334527", "end": "2019-10-09 07:43:12.266596", "rc": 0, "start": "2019-10-09 07:43:11.932069", "stderr": "", "stderr_lines": [], "stdout": "Healthy Healthy", "stdout_lines": ["Healthy Healthy"]}

TASK [Getting the list of csp name correspond to provided spc] *****************
2019-10-09T07:43:12.347618 (delta: 0.659666)         elapsed: 16.060108 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o jsonpath='{.items[*].metadata.name}'", "delta": "0:00:00.396096", "end": "2019-10-09 07:43:12.950086", "rc": 0, "start": "2019-10-09 07:43:12.553990", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-bd0z cstor-block-disk-pool-hoc7 cstor-block-disk-pool-nfo0 cstor-block-disk-pool-p2wi cstor-block-disk-pool-w4bi", "stdout_lines": ["cstor-block-disk-pool-bd0z cstor-block-disk-pool-hoc7 cstor-block-disk-pool-nfo0 cstor-block-disk-pool-p2wi cstor-block-disk-pool-w4bi"]}

TASK [Create a file to store CSP name] *****************************************
2019-10-09T07:43:13.036381 (delta: 0.6887)         elapsed: 16.748871 ********* 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u"kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o jsonpath='{.items[*].metadata.name}'", u'end': u'2019-10-09 07:43:12.950086', u'stdout': u'cstor-block-disk-pool-bd0z cstor-block-disk-pool-hoc7 cstor-block-disk-pool-nfo0 cstor-block-disk-pool-p2wi cstor-block-disk-pool-w4bi', u'changed': True, 'failed': False, u'delta': u'0:00:00.396096', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'cstor-block-disk-pool-bd0z cstor-block-disk-pool-hoc7 cstor-block-disk-pool-nfo0 cstor-block-disk-pool-p2wi cstor-block-disk-pool-w4bi'], u'start': u'2019-10-09 07:43:12.553990'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o jsonpath='{.items[*].metadata.name}'", "delta": "0:00:00.396096", "end": "2019-10-09 07:43:12.950086", "failed": false, "rc": 0, "start": "2019-10-09 07:43:12.553990", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-bd0z cstor-block-disk-pool-hoc7 cstor-block-disk-pool-nfo0 cstor-block-disk-pool-p2wi cstor-block-disk-pool-w4bi", "stdout_lines": ["cstor-block-disk-pool-bd0z cstor-block-disk-pool-hoc7 cstor-block-disk-pool-nfo0 cstor-block-disk-pool-p2wi cstor-block-disk-pool-w4bi"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the list of csp on which cvr is created] *************************
2019-10-09T07:43:13.674869 (delta: 0.63841)         elapsed: 17.387359 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", "delta": "0:00:00.411645", "end": "2019-10-09 07:43:14.335762", "rc": 0, "start": "2019-10-09 07:43:13.924117", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-bd0z cstor-block-disk-pool-nfo0", "stdout_lines": ["cstor-block-disk-pool-bd0z cstor-block-disk-pool-nfo0"]}

TASK [Create a file to store CSP name] *****************************************
2019-10-09T07:43:14.463506 (delta: 0.788581)         elapsed: 18.175996 ******* 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u"kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", u'end': u'2019-10-09 07:43:14.335762', u'stdout': u'cstor-block-disk-pool-bd0z cstor-block-disk-pool-nfo0', u'changed': True, 'failed': False, u'delta': u'0:00:00.411645', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'cstor-block-disk-pool-bd0z cstor-block-disk-pool-nfo0'], u'start': u'2019-10-09 07:43:13.924117'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", "delta": "0:00:00.411645", "end": "2019-10-09 07:43:14.335762", "failed": false, "rc": 0, "start": "2019-10-09 07:43:13.924117", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-bd0z cstor-block-disk-pool-nfo0", "stdout_lines": ["cstor-block-disk-pool-bd0z cstor-block-disk-pool-nfo0"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the csp where no cvr is created] *********************************
2019-10-09T07:43:14.750477 (delta: 0.286918)         elapsed: 18.462967 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat csp_all.tmp | tr \" \" \"\\n\" > csp_all\n cat csp_cvr.tmp | tr \" \" \"\\n\" > csp_cvr\n comm -3 <(sort csp_all) <(sort csp_cvr)", "delta": "0:00:00.151205", "end": "2019-10-09 07:43:15.137974", "rc": 0, "start": "2019-10-09 07:43:14.986769", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-hoc7\ncstor-block-disk-pool-p2wi\ncstor-block-disk-pool-w4bi", "stdout_lines": ["cstor-block-disk-pool-hoc7", "cstor-block-disk-pool-p2wi", "cstor-block-disk-pool-w4bi"]}

TASK [Getting the target IP from cvr] ******************************************
2019-10-09T07:43:15.218673 (delta: 0.468122)         elapsed: 18.931163 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.items[0].spec.targetIP}'", "delta": "0:00:00.391306", "end": "2019-10-09 07:43:15.882741", "rc": 0, "start": "2019-10-09 07:43:15.491435", "stderr": "", "stderr_lines": [], "stdout": "172.21.182.18", "stdout_lines": ["172.21.182.18"]}

TASK [Getting the Node IP of CSP] **********************************************
2019-10-09T07:43:15.969688 (delta: 0.750936)         elapsed: 19.682178 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-hoc7 -o jsonpath='{.metadata.labels.kubernetes\\.io/hostname}'", "delta": "0:00:00.317665", "end": "2019-10-09 07:43:16.595263", "rc": 0, "start": "2019-10-09 07:43:16.277598", "stderr": "", "stderr_lines": [], "stdout": "node5-konvoy.mayalabs.io", "stdout_lines": ["node5-konvoy.mayalabs.io"]}

TASK [Getting csp uid] *********************************************************
2019-10-09T07:43:16.680934 (delta: 0.711165)         elapsed: 20.393424 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-hoc7 -o jsonpath='{.metadata.uid}'", "delta": "0:00:00.303464", "end": "2019-10-09 07:43:17.210647", "rc": 0, "start": "2019-10-09 07:43:16.907183", "stderr": "", "stderr_lines": [], "stdout": "451abe48-defd-4d94-a725-74de288f7014", "stdout_lines": ["451abe48-defd-4d94-a725-74de288f7014"]}

TASK [Replacing the storage class in cvr yml] **********************************
2019-10-09T07:43:17.302983 (delta: 0.621976)         elapsed: 21.015473 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the Node name in cvr yml] **************************************
2019-10-09T07:43:17.639207 (delta: 0.336165)         elapsed: 21.351697 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the CSP name in cvr yml] ***************************************
2019-10-09T07:43:18.088807 (delta: 0.449536)         elapsed: 21.801297 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replacing the uid in cvr yml] ********************************************
2019-10-09T07:43:18.417105 (delta: 0.328233)         elapsed: 22.129595 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the volume name in cvr yml] ************************************
2019-10-09T07:43:18.761820 (delta: 0.344655)         elapsed: 22.47431 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the volume capacity in cvr yml] ********************************
2019-10-09T07:43:19.092017 (delta: 0.330126)         elapsed: 22.804507 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the target IP in cvr yml] **************************************
2019-10-09T07:43:19.410906 (delta: 0.318838)         elapsed: 23.123396 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the target IP in cvr yml] **************************************
2019-10-09T07:43:19.726875 (delta: 0.315896)         elapsed: 23.439365 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Pathing the cstorvolume's desired rep count] *****************************
2019-10-09T07:43:20.026004 (delta: 0.299062)         elapsed: 23.738494 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cstorvolume pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -n openebs --type merge --patch \"$(cat patch_cstorvolume.yml)\"", "delta": "0:00:00.335567", "end": "2019-10-09 07:43:20.626225", "failed_when_result": false, "rc": 0, "start": "2019-10-09 07:43:20.290658", "stderr": "", "stderr_lines": [], "stdout": "cstorvolume.openebs.io/pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 patched", "stdout_lines": ["cstorvolume.openebs.io/pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 patched"]}

TASK [Creating new cvr] ********************************************************
2019-10-09T07:43:20.718789 (delta: 0.692718)         elapsed: 24.431279 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cvr.yml", "delta": "0:00:00.759492", "end": "2019-10-09 07:43:21.720817", "rc": 0, "start": "2019-10-09 07:43:20.961325", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io/pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64-cstor-block-disk-pool-hoc7 created", "stdout_lines": ["cstorvolumereplica.openebs.io/pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64-cstor-block-disk-pool-hoc7 created"]}

TASK [Getting the uid of newly created cvr] ************************************
2019-10-09T07:43:21.835312 (delta: 1.11645)         elapsed: 25.547802 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorpool.openebs.io/name=cstor-block-disk-pool-hoc7,cstorvolume.openebs.io/name=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.metadata.uid}'", "delta": "0:00:00.333335", "end": "2019-10-09 07:43:22.500165", "rc": 0, "start": "2019-10-09 07:43:22.166830", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Creating MD5SUM of new-uid] **********************************************
2019-10-09T07:43:22.573151 (delta: 0.737752)         elapsed: 26.285641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo  | md5sum | awk '{print $1}' | tr \"[a-z]\" \"[A-z]\"", "delta": "0:00:00.184348", "end": "2019-10-09 07:43:23.040091", "rc": 0, "start": "2019-10-09 07:43:22.855743", "stderr": "", "stderr_lines": [], "stdout": "68B329DA9893E34099C7D8AD5CB9C940", "stdout_lines": ["68B329DA9893E34099C7D8AD5CB9C940"]}

TASK [Replacing the md5sum value in patch yml] *********************************
2019-10-09T07:43:23.104268 (delta: 0.531042)         elapsed: 26.816758 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Pathing the cvr's replica id with md5sum] ********************************
2019-10-09T07:43:23.484262 (delta: 0.379938)         elapsed: 27.196752 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cvr pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64-cstor-block-disk-pool-hoc7 -n openebs --type merge --patch \"$(cat patch_cvr.yml)\"", "delta": "0:00:00.351724", "end": "2019-10-09 07:43:24.109140", "failed_when_result": false, "rc": 0, "start": "2019-10-09 07:43:23.757416", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io/pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64-cstor-block-disk-pool-hoc7 patched", "stdout_lines": ["cstorvolumereplica.openebs.io/pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64-cstor-block-disk-pool-hoc7 patched"]}

TASK [Getting the cstor pool pod name] *****************************************
2019-10-09T07:43:24.181365 (delta: 0.697046)         elapsed: 27.893855 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-hoc7 -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.330634", "end": "2019-10-09 07:43:24.756017", "rc": 0, "start": "2019-10-09 07:43:24.425383", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-hoc7-55d7bfb966-td8v9", "stdout_lines": ["cstor-block-disk-pool-hoc7-55d7bfb966-td8v9"]}

TASK [Restarting the pool pod] *************************************************
2019-10-09T07:43:24.842572 (delta: 0.661149)         elapsed: 28.555062 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod cstor-block-disk-pool-hoc7-55d7bfb966-td8v9 -n openebs", "delta": "0:00:35.285156", "end": "2019-10-09 07:44:00.352778", "rc": 0, "start": "2019-10-09 07:43:25.067622", "stderr": "", "stderr_lines": [], "stdout": "pod \"cstor-block-disk-pool-hoc7-55d7bfb966-td8v9\" deleted", "stdout_lines": ["pod \"cstor-block-disk-pool-hoc7-55d7bfb966-td8v9\" deleted"]}

TASK [Checking for the pool pod to be in running state] ************************
2019-10-09T07:44:00.451099 (delta: 35.608461)         elapsed: 64.163589 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n openebs -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-hoc7 -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:00.381568", "end": "2019-10-09 07:44:01.086235", "rc": 0, "start": "2019-10-09 07:44:00.704667", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify cvr health status] ************************************************
2019-10-09T07:44:01.174835 (delta: 0.723682)         elapsed: 64.887325 ******* 
FAILED - RETRYING: Verify cvr health status (15 retries left).
FAILED - RETRYING: Verify cvr health status (14 retries left).
FAILED - RETRYING: Verify cvr health status (13 retries left).
FAILED - RETRYING: Verify cvr health status (12 retries left).
FAILED - RETRYING: Verify cvr health status (11 retries left).
FAILED - RETRYING: Verify cvr health status (10 retries left).
FAILED - RETRYING: Verify cvr health status (9 retries left).
FAILED - RETRYING: Verify cvr health status (8 retries left).
FAILED - RETRYING: Verify cvr health status (7 retries left).
FAILED - RETRYING: Verify cvr health status (6 retries left).
changed: [127.0.0.1] => {"attempts": 11, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-f9927345-ece4-47e5-b8fc-1f5cd538ea64 -o jsonpath='{.items[*].status.phase}'", "delta": "0:00:00.359360", "end": "2019-10-09 07:44:38.129279", "rc": 0, "start": "2019-10-09 07:44:37.769919", "stderr": "", "stderr_lines": [], "stdout": "Healthy Healthy Healthy", "stdout_lines": ["Healthy Healthy Healthy"]}

TASK [set_fact] ****************************************************************
2019-10-09T07:44:38.278876 (delta: 37.103974)         elapsed: 101.991366 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-10-09T07:44:38.446205 (delta: 0.16724)         elapsed: 102.158695 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-09T07:44:38.675716 (delta: 0.22927)         elapsed: 102.388206 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-09T07:44:38.752768 (delta: 0.076963)         elapsed: 102.465258 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-09T07:44:38.821869 (delta: 0.069004)         elapsed: 102.534359 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-09T07:44:38.892652 (delta: 0.07071)         elapsed: 102.605142 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "29f47af49a2a3a5aa59a27f68d7e0ae0e21bf497", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0c41791561c2cc1d180fe9dc2c7444f6", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1570607078.97-70397936169638/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-09T07:44:39.933956 (delta: 1.041234)         elapsed: 103.646446 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.220555", "end": "2019-10-09 07:44:40.581854", "rc": 0, "start": "2019-10-09 07:44:40.361299", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-cvr-scaleup \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-cvr-scaleup ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-09T07:44:40.650773 (delta: 0.716719)         elapsed: 104.363263 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.852198", "end": "2019-10-09 07:44:41.855040", "failed_when_result": false, "rc": 0, "start": "2019-10-09 07:44:41.002842", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-cvr-scaleup configured", "stdout_lines": ["litmusresult.litmus.io/openebs-cvr-scaleup configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=60   changed=47   unreachable=0    failed=0   

2019-10-09T07:44:41.906193 (delta: 1.255353)         elapsed: 105.618683 ****** 
===============================================================================
```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
