### PR TITLE
refactor[test]: Modified target network loss litmusbook 

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -99,13 +99,35 @@
         - include_tasks: /utils/k8s/application_liveness_check.yml
           when: liveness_label != ''
 
-        - name: Verify application data persistence
-          include: "{{ data_consistency_util_path }}"
-          vars:
-            status: 'VERIFY'
-            ns: "{{ namespace }}"
-            pod_name: "{{ app_pod_name.stdout }}"
-          when: data_persistence != ''
+        - name: Kill the application pod
+          shell: >
+            kubectl delete pod {{ app_pod_name.stdout }} -n {{ namespace }}
+          args:
+            executable: /bin/bash
+
+        - name: Verify if the application pod is deleted
+          shell: >
+            kubectl get pods -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: podstatus
+          until: '"{{ app_pod_name.stdout }}" not in podstatus.stdout'
+          retries: 2
+          delay: 150
+
+        - name: Obtain the newly created pod name for application
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} -o jsonpath='{.items[].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: newpod_name
+
+        - name: Checking application pod is in running state
+          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.phase}'
+          register: result
+          until: "((result.stdout.split()|unique)|length) == 1 and 'Running' not in result.stdout"
+          delay: 2
+          retries: 150
 
         - set_fact:
             flag: "Pass"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the target network loss litmusbook to check the application status.
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Jul  9 2019, 16:51:35) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_loss/test.yml

PLAY [localhost] ***************************************************************
2019-10-11T08:32:27.798658 (delta: 0.066942)         elapsed: 0.066942 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:2
2019-10-11T08:32:27.814429 (delta: 0.015708)         elapsed: 0.082713 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:12
2019-10-11T08:32:39.185530 (delta: 11.371071)         elapsed: 11.453814 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:2
2019-10-11T08:32:39.300411 (delta: 0.114826)         elapsed: 11.568695 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n target-loss --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.448607", "end": "2019-10-11 08:32:41.243833", "rc": 0, "start": "2019-10-11 08:32:39.795226", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:10
2019-10-11T08:32:41.335004 (delta: 2.034502)         elapsed: 13.603288 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.462794", "end": "2019-10-11 08:32:43.096988", "rc": 0, "start": "2019-10-11 08:32:41.634194", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:18
2019-10-11T08:32:43.207148 (delta: 1.872064)         elapsed: 15.475432 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-disk"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:22
2019-10-11T08:32:43.394998 (delta: 0.187736)         elapsed: 15.663282 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:27
2019-10-11T08:32:43.499929 (delta: 0.104851)         elapsed: 15.768213 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n target-loss --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.578975", "end": "2019-10-11 08:32:45.361808", "rc": 0, "start": "2019-10-11 08:32:43.782833", "stderr": "", "stderr_lines": [], "stdout": "pvc-97968e6e-ebfe-11e9-a8ef-005056985c20", "stdout_lines": ["pvc-97968e6e-ebfe-11e9-a8ef-005056985c20"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:35
2019-10-11T08:32:45.476074 (delta: 1.976083)         elapsed: 17.744358 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-97968e6e-ebfe-11e9-a8ef-005056985c20 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.385086", "end": "2019-10-11 08:32:47.129529", "rc": 0, "start": "2019-10-11 08:32:45.744443", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:43
2019-10-11T08:32:47.193839 (delta: 1.717574)         elapsed: 19.462123 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:48
2019-10-11T08:32:47.286245 (delta: 0.092341)         elapsed: 19.554529 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1570782767.36-12592461123651/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:53
2019-10-11T08:32:48.227350 (delta: 0.941045)         elapsed: 20.495634 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1570782768.29-90411691598003/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:19
2019-10-11T08:32:48.784798 (delta: 0.557374)         elapsed: 21.053082 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:22
2019-10-11T08:32:48.891407 (delta: 0.106545)         elapsed: 21.159691 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:25
2019-10-11T08:32:49.009291 (delta: 0.117801)         elapsed: 21.277575 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:29
2019-10-11T08:32:49.172249 (delta: 0.162876)         elapsed: 21.440533 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:36
2019-10-11T08:32:49.395630 (delta: 0.223255)         elapsed: 21.663914 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-10-11T08:32:49.634996 (delta: 0.239231)         elapsed: 21.90328 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-10-11T08:32:49.712601 (delta: 0.077522)         elapsed: 21.980885 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:38
2019-10-11T08:32:49.785535 (delta: 0.072876)         elapsed: 22.053819 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-10-11T08:32:49.909756 (delta: 0.124168)         elapsed: 22.17804 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d9860de79e81adfa6880e9749445e534e4d83205", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7802862277f22fe3145e79fb5cb57dce", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1570782769.98-172482666294513/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-10-11T08:32:50.503806 (delta: 0.593991)         elapsed: 22.77209 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.199813", "end": "2019-10-11 08:32:51.917092", "rc": 0, "start": "2019-10-11 08:32:50.717279", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-10-11T08:32:51.972813 (delta: 1.468929)         elapsed: 24.241097 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.852318", "end": "2019-10-11 08:32:54.068682", "failed_when_result": false, "rc": 0, "start": "2019-10-11 08:32:52.216364", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss unchanged", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-10-11T08:32:54.148016 (delta: 2.175148)         elapsed: 26.4163 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-10-11T08:32:54.215447 (delta: 0.06737)         elapsed: 26.483731 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-10-11T08:32:54.275828 (delta: 0.060311)         elapsed: 26.544112 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:45
2019-10-11T08:32:54.345734 (delta: 0.069838)         elapsed: 26.614018 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : target-loss", 
        "Label        : app=busybox-sts", 
        "PVC          : openebs-busybox", 
        "StorageClass : openebs-cstor-disk"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:55
2019-10-11T08:32:54.473470 (delta: 0.127645)         elapsed: 26.741754 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-10-11T08:32:54.589429 (delta: 0.115878)         elapsed: 26.857713 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n target-loss -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.415546", "end": "2019-10-11 08:32:56.225635", "rc": 0, "start": "2019-10-11 08:32:54.810089", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-10-11T08:22:21Z]]", "stdout_lines": ["map[running:map[startedAt:2019-10-11T08:22:21Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-10-11T08:32:56.372540 (delta: 1.783034)         elapsed: 28.640824 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n target-loss -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.274948", "end": "2019-10-11 08:32:57.977556", "rc": 0, "start": "2019-10-11 08:32:56.702608", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:64
2019-10-11T08:32:58.044631 (delta: 1.671959)         elapsed: 30.312915 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n target-loss -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.340979", "end": "2019-10-11 08:32:59.608297", "rc": 0, "start": "2019-10-11 08:32:58.267318", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-scdsz", "stdout_lines": ["app-busybox-546d66979-scdsz"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:72
2019-10-11T08:32:59.670469 (delta: 1.625785)         elapsed: 31.938753 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-10-11T08:32:59.843430 (delta: 0.172902)         elapsed: 32.111714 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/targetnwlosstest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-scdsz -n target-loss -- sh -c \"dd if=/dev/urandom of=/busybox/targetnwlosstest bs=4k count=1024\"", "delta": "0:00:01.694274", "end": "2019-10-11 08:33:01.809411", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/targetnwlosstest bs=4k count=1024", "rc": 0, "start": "2019-10-11 08:33:00.115137", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.034495 seconds, 116.0MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.034495 seconds, 116.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/targetnwlosstest > /busybox/targetnwlosstest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-scdsz -n target-loss -- sh -c \"md5sum /busybox/targetnwlosstest > /busybox/targetnwlosstest-pre-chaos-md5\"", "delta": "0:00:01.654312", "end": "2019-10-11 08:33:03.662334", "failed_when_result": false, "item": "md5sum /busybox/targetnwlosstest > /busybox/targetnwlosstest-pre-chaos-md5", "rc": 0, "start": "2019-10-11 08:33:02.008022", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-10-11T08:33:03.795627 (delta: 3.952141)         elapsed: 36.063911 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-10-11T08:33:03.931706 (delta: 0.135979)         elapsed: 36.19999 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-10-11T08:33:04.075568 (delta: 0.143758)         elapsed: 36.343852 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-10-11T08:33:04.240004 (delta: 0.164331)         elapsed: 36.508288 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-10-11T08:33:04.309960 (delta: 0.069874)         elapsed: 36.578244 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-10-11T08:33:04.391469 (delta: 0.081441)         elapsed: 36.659753 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-10-11T08:33:04.473343 (delta: 0.081801)         elapsed: 36.741627 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-10-11T08:33:04.556805 (delta: 0.083389)         elapsed: 36.825089 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-10-11T08:33:04.650317 (delta: 0.09341)         elapsed: 36.918601 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-10-11T08:33:04.751073 (delta: 0.100671)         elapsed: 37.019357 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:82
2019-10-11T08:33:04.894235 (delta: 0.143026)         elapsed: 37.162519 ******* 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2019-10-11T08:33:05.112574 (delta: 0.218239)         elapsed: 37.380858 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n target-loss", "delta": "0:00:01.755399", "end": "2019-10-11 08:33:07.137236", "rc": 0, "start": "2019-10-11 08:33:05.381837", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba unchanged", "stdout_lines": ["daemonset.extensions/pumba unchanged"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2019-10-11T08:33:07.196984 (delta: 2.084351)         elapsed: 39.465268 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n target-loss | sort | uniq", "delta": "0:00:01.368206", "end": "2019-10-11 08:33:08.882473", "rc": 0, "start": "2019-10-11 08:33:07.514267", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2019-10-11T08:33:08.945572 (delta: 1.74853)         elapsed: 41.213856 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n target-loss --no-headers", "delta": "0:00:01.384151", "end": "2019-10-11 08:33:10.536855", "rc": 0, "start": "2019-10-11 08:33:09.152704", "stderr": "", "stderr_lines": [], "stdout": "pvc-97968e6e-ebfe-11e9-a8ef-005056985c20", "stdout_lines": ["pvc-97968e6e-ebfe-11e9-a8ef-005056985c20"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2019-10-11T08:33:10.608248 (delta: 1.662622)         elapsed: 42.876532 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-97968e6e-ebfe-11e9-a8ef-005056985c20 | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.572950", "end": "2019-10-11 08:33:12.401248", "rc": 0, "start": "2019-10-11 08:33:10.828298", "stderr": "", "stderr_lines": [], "stdout": "pvc-97968e6e-ebfe-11e9-a8ef-005056985c20-target-654449b546rkjhm", "stdout_lines": ["pvc-97968e6e-ebfe-11e9-a8ef-005056985c20-target-654449b546rkjhm"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2019-10-11T08:33:12.464685 (delta: 1.856381)         elapsed: 44.732969 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-97968e6e-ebfe-11e9-a8ef-005056985c20"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
2019-10-11T08:33:12.580156 (delta: 0.115411)         elapsed: 44.84844 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-97968e6e-ebfe-11e9-a8ef-005056985c20-target-654449b546rkjhm -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.404753", "end": "2019-10-11 08:33:14.212964", "rc": 0, "start": "2019-10-11 08:33:12.808211", "stderr": "", "stderr_lines": [], "stdout": "node1-1552853078.mayalabs.io", "stdout_lines": ["node1-1552853078.mayalabs.io"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
2019-10-11T08:33:14.285801 (delta: 1.705561)         elapsed: 46.554085 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n target-loss -o jsonpath='{.items[?(@.spec.nodeName==''\"node1-1552853078.mayalabs.io\"'')].metadata.name}'", "delta": "0:00:01.491781", "end": "2019-10-11 08:33:16.045338", "rc": 0, "start": "2019-10-11 08:33:14.553557", "stderr": "", "stderr_lines": [], "stdout": "pumba-t69lk", "stdout_lines": ["pumba-t69lk"]}

TASK [Inject egress delay of 240000ms on cstor target for 240000ms] ************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
2019-10-11T08:33:16.131476 (delta: 1.845607)         elapsed: 48.39976 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-t69lk -n target-loss -- pumba netem --interface eth0 --duration 240000ms delay --time 240000 re2:k8s_cstor-istgt_pvc-97968e6e-ebfe-11e9-a8ef-005056985c20", "delta": "0:04:04.772190", "end": "2019-10-11 08:37:21.131201", "rc": 0, "start": "2019-10-11 08:33:16.359011", "stderr": "time=\"2019-10-11T08:33:18Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-10-11T08:33:20Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861 for 4m0s\" \ntime=\"2019-10-11T08:33:20Z\" level=info msg=\"Start netem for container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861 on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" \ntime=\"2019-10-11T08:37:20Z\" level=info msg=\"Stopping netem on container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861\" \ntime=\"2019-10-11T08:37:20Z\" level=info msg=\"Stop netem for container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861 on 'eth0'\" ", "stderr_lines": ["time=\"2019-10-11T08:33:18Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-10-11T08:33:20Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861 for 4m0s\" ", "time=\"2019-10-11T08:33:20Z\" level=info msg=\"Start netem for container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861 on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" ", "time=\"2019-10-11T08:37:20Z\" level=info msg=\"Stopping netem on container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861\" ", "time=\"2019-10-11T08:37:20Z\" level=info msg=\"Stop netem for container 134883beb242b73b32bc31aa8b291e36a54b23c25c3a1551c916ccf41b8ac861 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
2019-10-11T08:37:21.257885 (delta: 245.126343)         elapsed: 293.526169 **** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
2019-10-11T08:37:31.852045 (delta: 10.594082)         elapsed: 304.120329 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n target-loss", "delta": "0:00:01.279308", "end": "2019-10-11 08:37:33.416566", "rc": 0, "start": "2019-10-11 08:37:32.137258", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
2019-10-11T08:37:33.509036 (delta: 1.656861)         elapsed: 305.77732 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n target-loss", "delta": "0:00:01.435105", "end": "2019-10-11 08:37:35.218707", "rc": 0, "start": "2019-10-11 08:37:33.783602", "stderr": "", "stderr_lines": [], "stdout": "pumba-f94qn   0/1   Terminating   0     6m\npumba-s2r6z   0/1   Terminating   0     6m", "stdout_lines": ["pumba-f94qn   0/1   Terminating   0     6m", "pumba-s2r6z   0/1   Terminating   0     6m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:90
2019-10-11T08:37:35.367814 (delta: 1.858644)         elapsed: 307.636098 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-10-11T08:37:35.566742 (delta: 0.198792)         elapsed: 307.835026 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n target-loss -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.332059", "end": "2019-10-11 08:37:37.208407", "rc": 0, "start": "2019-10-11 08:37:35.876348", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-10-11T08:22:21Z]]", "stdout_lines": ["map[running:map[startedAt:2019-10-11T08:22:21Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-10-11T08:37:37.281233 (delta: 1.714413)         elapsed: 309.549517 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n target-loss -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.338898", "end": "2019-10-11 08:37:38.882672", "rc": 0, "start": "2019-10-11 08:37:37.543774", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:99
2019-10-11T08:37:38.950790 (delta: 1.6695)         elapsed: 311.219074 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:102
2019-10-11T08:37:39.019356 (delta: 0.068509)         elapsed: 311.28764 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-546d66979-scdsz -n target-loss", "delta": "0:00:41.237910", "end": "2019-10-11 08:38:20.467848", "rc": 0, "start": "2019-10-11 08:37:39.229938", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-546d66979-scdsz\" deleted", "stdout_lines": ["pod \"app-busybox-546d66979-scdsz\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:108
2019-10-11T08:38:20.608548 (delta: 41.589133)         elapsed: 352.876832 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ app_pod_name.stdout }}" not in
podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n target-loss", "delta": "0:00:01.297405", "end": "2019-10-11 08:38:22.237395", "rc": 0, "start": "2019-10-11 08:38:20.939990", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS              RESTARTS   AGE\napp-busybox-546d66979-ljb86    0/1     ContainerCreating   0          42s\nbusybox-liveness-w2pxv-tb5nb   0/1     Completed           0          9m", "stdout_lines": ["NAME                           READY   STATUS              RESTARTS   AGE", "app-busybox-546d66979-ljb86    0/1     ContainerCreating   0          42s", "busybox-liveness-w2pxv-tb5nb   0/1     Completed           0          9m"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:118
2019-10-11T08:38:22.382197 (delta: 1.773511)         elapsed: 354.650481 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n target-loss -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:02.333074", "end": "2019-10-11 08:38:24.990490", "rc": 0, "start": "2019-10-11 08:38:22.657416", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-ljb86", "stdout_lines": ["app-busybox-546d66979-ljb86"]}

TASK [Checking application pod is in running state] ****************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:125
2019-10-11T08:38:25.141741 (delta: 2.759451)         elapsed: 357.410025 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n target-loss -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-ljb86\")].status.phase}'", "delta": "0:00:01.245210", "end": "2019-10-11 08:38:26.614510", "rc": 0, "start": "2019-10-11 08:38:25.369300", "stderr": "", "stderr_lines": [], "stdout": "Pending", "stdout_lines": ["Pending"]}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:132
2019-10-11T08:38:26.728153 (delta: 1.58633)         elapsed: 358.996437 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:143
2019-10-11T08:38:26.822890 (delta: 0.094651)         elapsed: 359.091174 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-10-11T08:38:26.953221 (delta: 0.130272)         elapsed: 359.221505 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-10-11T08:38:27.037168 (delta: 0.083857)         elapsed: 359.305452 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-10-11T08:38:27.108966 (delta: 0.071724)         elapsed: 359.37725 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-10-11T08:38:27.185037 (delta: 0.076005)         elapsed: 359.453321 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "cd521ba3834fdc7ebdaaaf2b9d1245702cd7227c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "40fdc05ee57c44d3b9159f71bf44c775", "mode": "0644", "owner": "root", "size": 460, "src": "/root/.ansible/tmp/ansible-tmp-1570783107.3-103766131813002/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-10-11T08:38:30.087498 (delta: 2.902363)         elapsed: 362.355782 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.139762", "end": "2019-10-11 08:38:31.554070", "rc": 0, "start": "2019-10-11 08:38:30.414308", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-10-11T08:38:31.628600 (delta: 1.541035)         elapsed: 363.896884 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.447102", "end": "2019-10-11 08:38:33.350057", "failed_when_result": false, "rc": 0, "start": "2019-10-11 08:38:31.902955", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=50   changed=31   unreachable=0    failed=0   

2019-10-11T08:38:33.392222 (delta: 1.763515)         elapsed: 365.660506 ****** 
=============================================================================== 
```
