### PR TITLE
refactor(yaml):update deprovision util to pick application status

### DIFF
--- a/utils/k8s/deprovision_deployment.yml
+++ b/utils/k8s/deprovision_deployment.yml
@@ -9,15 +9,13 @@
 #
 - block:
 
-    - name: Check if the application to be deleted is running.
+    - name: Check if the application to be deleted is available.
       shell: kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers -o custom-columns=:status.phase
       args:
         executable: /bin/bash
       register: result
-      until: "'Running' in result.stdout"
-      delay: 5
-      retries: 60
-    
+      failed_when: 'result.stdout == ""'
+
     - name: Obtaining the PVC name using application label.
       shell: kubectl get pods -n {{ app_ns }} -l {{ app_label }} -o custom-columns=:..claimName --no-headers
       args:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Current util fails to delete application if its state is other than 'running'.
  Modified the condition not to check if application is running.
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
