### PR TITLE
refactor(test): modified target network loss litmusbook to get the ap…

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -123,7 +123,7 @@
           register: newpod_name
 
         - name: Checking application pod is in running state
-          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[0].state.waiting.reason}'
+          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[*].state.waiting.reason}'
           register: result
           until: "((result.stdout.split()|unique)|length) == 1 and 'Running' not in result.stdout"
           delay: 2

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -123,7 +123,7 @@
           register: newpod_name
 
         - name: Checking application pod is in running state
-          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.phase}'
+          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[0].state.waiting.reason}'
           register: result
           until: "((result.stdout.split()|unique)|length) == 1 and 'Running' not in result.stdout"
           delay: 2


### PR DESCRIPTION
…plication status

- Fetch application status from status.containerStatuses.state.waiting.reason instead of status.phase


Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
Logs:

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_loss/test.yml

PLAY [localhost] ***************************************************************
2019-10-15T07:14:04.984643 (delta: 0.119449)         elapsed: 0.119449 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:2
2019-10-15T07:14:05.010472 (delta: 0.025782)         elapsed: 0.145278 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:12
2019-10-15T07:14:12.849014 (delta: 7.838492)         elapsed: 7.98382 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:2
2019-10-15T07:14:12.966118 (delta: 0.117051)         elapsed: 8.100924 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n shubham --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:00.966142", "end": "2019-10-15 07:14:14.566719", "rc": 0, "start": "2019-10-15 07:14:13.600577", "stderr": "", "stderr_lines": [], "stdout": "openebs-sparse-sc-statefulset", "stdout_lines": ["openebs-sparse-sc-statefulset"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:10
2019-10-15T07:14:14.657401 (delta: 1.691219)         elapsed: 9.792207 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-sparse-sc-statefulset --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.822324", "end": "2019-10-15 07:14:15.786601", "rc": 0, "start": "2019-10-15 07:14:14.964277", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:18
2019-10-15T07:14:15.878487 (delta: 1.221024)         elapsed: 11.013293 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-sparse-sc-statefulset"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:22
2019-10-15T07:14:16.058117 (delta: 0.17957)         elapsed: 11.192923 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:27
2019-10-15T07:14:16.203258 (delta: 0.145081)         elapsed: 11.338064 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n shubham --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.889497", "end": "2019-10-15 07:14:17.412912", "rc": 0, "start": "2019-10-15 07:14:16.523415", "stderr": "", "stderr_lines": [], "stdout": "pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8", "stdout_lines": ["pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:35
2019-10-15T07:14:17.503106 (delta: 1.299681)         elapsed: 12.637912 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:00.853445", "end": "2019-10-15 07:14:18.669707", "rc": 0, "start": "2019-10-15 07:14:17.816262", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:43
2019-10-15T07:14:18.761075 (delta: 1.257861)         elapsed: 13.895881 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:48
2019-10-15T07:14:18.908037 (delta: 0.146901)         elapsed: 14.042843 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1571123659.0-154441209265067/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:53
2019-10-15T07:14:20.179596 (delta: 1.2715)         elapsed: 15.314402 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "68b329da9893e34099c7d8ad5cb9c940", "mode": "0644", "owner": "root", "size": 1, "src": "/root/.ansible/tmp/ansible-tmp-1571123660.26-279785660962883/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:19
2019-10-15T07:14:20.797980 (delta: 0.618327)         elapsed: 15.932786 ******* 
ok: [127.0.0.1] => {"ansible_facts": {}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:22
2019-10-15T07:14:20.945006 (delta: 0.146963)         elapsed: 16.079812 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:25
2019-10-15T07:14:21.084645 (delta: 0.139578)         elapsed: 16.219451 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:29
2019-10-15T07:14:21.229560 (delta: 0.144858)         elapsed: 16.364366 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:36
2019-10-15T07:14:21.342665 (delta: 0.113043)         elapsed: 16.477471 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-10-15T07:14:21.499958 (delta: 0.157234)         elapsed: 16.634764 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-10-15T07:14:21.631745 (delta: 0.131725)         elapsed: 16.766551 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:38
2019-10-15T07:14:21.759710 (delta: 0.127892)         elapsed: 16.894516 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-10-15T07:14:21.957855 (delta: 0.198082)         elapsed: 17.092661 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d9860de79e81adfa6880e9749445e534e4d83205", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7802862277f22fe3145e79fb5cb57dce", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1571123662.05-124714687668373/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-10-15T07:14:22.571357 (delta: 0.613437)         elapsed: 17.706163 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.663188", "end": "2019-10-15 07:14:23.528165", "rc": 0, "start": "2019-10-15 07:14:22.864977", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-10-15T07:14:23.617462 (delta: 1.046043)         elapsed: 18.752268 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.159176", "end": "2019-10-15 07:14:25.118675", "failed_when_result": false, "rc": 0, "start": "2019-10-15 07:14:23.959499", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-10-15T07:14:25.222351 (delta: 1.604789)         elapsed: 20.357157 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-10-15T07:14:25.314557 (delta: 0.09212)         elapsed: 20.449363 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-10-15T07:14:25.404810 (delta: 0.090188)         elapsed: 20.539616 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:45
2019-10-15T07:14:25.495421 (delta: 0.090549)         elapsed: 20.630227 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : shubham", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-sparse-sc-statefulset"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:55
2019-10-15T07:14:25.668896 (delta: 0.173412)         elapsed: 20.803702 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-10-15T07:14:25.841854 (delta: 0.172899)         elapsed: 20.97666 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n shubham -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.886824", "end": "2019-10-15 07:14:27.048337", "rc": 0, "start": "2019-10-15 07:14:26.161513", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-10-15T07:05:13Z]]", "stdout_lines": ["map[running:map[startedAt:2019-10-15T07:05:13Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-10-15T07:14:27.159506 (delta: 1.317591)         elapsed: 22.294312 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n shubham -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.834528", "end": "2019-10-15 07:14:28.339966", "rc": 0, "start": "2019-10-15 07:14:27.505438", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:64
2019-10-15T07:14:28.469313 (delta: 1.309748)         elapsed: 23.604119 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n shubham -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.915600", "end": "2019-10-15 07:14:29.696326", "rc": 0, "start": "2019-10-15 07:14:28.780726", "stderr": "", "stderr_lines": [], "stdout": "percona-598c987dc8-vc9jn", "stdout_lines": ["percona-598c987dc8-vc9jn"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:72
2019-10-15T07:14:29.789504 (delta: 1.320125)         elapsed: 24.92431 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:82
2019-10-15T07:14:29.900714 (delta: 0.11115)         elapsed: 25.03552 ********* 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2019-10-15T07:14:30.135718 (delta: 0.234943)         elapsed: 25.270524 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n shubham", "delta": "0:00:01.067535", "end": "2019-10-15 07:14:31.514369", "rc": 0, "start": "2019-10-15 07:14:30.446834", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2019-10-15T07:14:31.660464 (delta: 1.524684)         elapsed: 26.79527 ******** 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n shubham | sort | uniq", "delta": "0:00:00.884838", "end": "2019-10-15 07:14:54.054016", "rc": 0, "start": "2019-10-15 07:14:53.169178", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2019-10-15T07:14:54.156448 (delta: 22.495917)         elapsed: 49.291254 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n shubham --no-headers", "delta": "0:00:00.860207", "end": "2019-10-15 07:14:55.348842", "rc": 0, "start": "2019-10-15 07:14:54.488635", "stderr": "", "stderr_lines": [], "stdout": "pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8", "stdout_lines": ["pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2019-10-15T07:14:55.440845 (delta: 1.284331)         elapsed: 50.575651 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8 | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.874089", "end": "2019-10-15 07:14:56.684407", "rc": 0, "start": "2019-10-15 07:14:55.810318", "stderr": "", "stderr_lines": [], "stdout": "pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8-target-58dc65845dmlrwg", "stdout_lines": ["pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8-target-58dc65845dmlrwg"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2019-10-15T07:14:56.780136 (delta: 1.33923)         elapsed: 51.914942 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
2019-10-15T07:14:56.924883 (delta: 0.144686)         elapsed: 52.059689 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8-target-58dc65845dmlrwg -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.918118", "end": "2019-10-15 07:14:58.177625", "rc": 0, "start": "2019-10-15 07:14:57.259507", "stderr": "", "stderr_lines": [], "stdout": "node-dev-setup01", "stdout_lines": ["node-dev-setup01"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
2019-10-15T07:14:58.272294 (delta: 1.347341)         elapsed: 53.4071 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n shubham -o jsonpath='{.items[?(@.spec.nodeName==''\"node-dev-setup01\"'')].metadata.name}'", "delta": "0:00:00.906419", "end": "2019-10-15 07:14:59.487374", "rc": 0, "start": "2019-10-15 07:14:58.580955", "stderr": "", "stderr_lines": [], "stdout": "pumba-mxcn7", "stdout_lines": ["pumba-mxcn7"]}

TASK [Inject egress delay of 240000ms on cstor target for 240000ms] ************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
2019-10-15T07:14:59.609625 (delta: 1.33727)         elapsed: 54.744431 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-mxcn7 -n shubham -- pumba netem --interface eth0 --duration 240000ms delay --time 240000 re2:k8s_cstor-istgt_pvc-115cf077-ef1a-11e9-89a5-0cc47ab587b8", "delta": "0:04:02.678835", "end": "2019-10-15 07:19:02.604328", "rc": 0, "start": "2019-10-15 07:14:59.925493", "stderr": "time=\"2019-10-15T07:15:01Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-10-15T07:15:02Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0 for 4m0s\" \ntime=\"2019-10-15T07:15:02Z\" level=info msg=\"Start netem for container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0 on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" \ntime=\"2019-10-15T07:19:02Z\" level=info msg=\"Stopping netem on container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0\" \ntime=\"2019-10-15T07:19:02Z\" level=info msg=\"Stop netem for container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0 on 'eth0'\" ", "stderr_lines": ["time=\"2019-10-15T07:15:01Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-10-15T07:15:02Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0 for 4m0s\" ", "time=\"2019-10-15T07:15:02Z\" level=info msg=\"Start netem for container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0 on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" ", "time=\"2019-10-15T07:19:02Z\" level=info msg=\"Stopping netem on container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0\" ", "time=\"2019-10-15T07:19:02Z\" level=info msg=\"Stop netem for container 387af5831626e363c96029ac223f5bf16609b2499213a8e7393a6d31c1d590e0 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
2019-10-15T07:19:02.694637 (delta: 243.084948)         elapsed: 297.829443 **** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
2019-10-15T07:19:13.470100 (delta: 10.775407)         elapsed: 308.604906 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n shubham", "delta": "0:00:00.869546", "end": "2019-10-15 07:19:14.634686", "rc": 0, "start": "2019-10-15 07:19:13.765140", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
2019-10-15T07:19:14.729839 (delta: 1.259681)         elapsed: 309.864645 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n shubham", "delta": "0:00:00.909820", "end": "2019-10-15 07:19:15.966406", "rc": 0, "start": "2019-10-15 07:19:15.056586", "stderr": "", "stderr_lines": [], "stdout": "pumba-mxcn7   1/1   Terminating   0     4m44s\npumba-swm9l   0/1   Terminating   0     4m44s\npumba-tc8tq   0/1   Terminating   0     4m44s", "stdout_lines": ["pumba-mxcn7   1/1   Terminating   0     4m44s", "pumba-swm9l   0/1   Terminating   0     4m44s", "pumba-tc8tq   0/1   Terminating   0     4m44s"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:90
2019-10-15T07:19:16.071185 (delta: 1.341287)         elapsed: 311.205991 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-10-15T07:19:16.253945 (delta: 0.1827)         elapsed: 311.388751 ******** 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
FAILED - RETRYING: Get the container status of application. (134 retries left).
FAILED - RETRYING: Get the container status of application. (133 retries left).
FAILED - RETRYING: Get the container status of application. (132 retries left).
FAILED - RETRYING: Get the container status of application. (131 retries left).
changed: [127.0.0.1] => {"attempts": 21, "changed": true, "cmd": "kubectl get pod -n shubham -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.868748", "end": "2019-10-15 07:20:20.286372", "rc": 0, "start": "2019-10-15 07:20:19.417624", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-10-15T07:20:19Z]]", "stdout_lines": ["map[running:map[startedAt:2019-10-15T07:20:19Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-10-15T07:20:20.391921 (delta: 64.137894)         elapsed: 375.526727 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n shubham -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.871673", "end": "2019-10-15 07:20:21.569458", "rc": 0, "start": "2019-10-15 07:20:20.697785", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:99
2019-10-15T07:20:21.683745 (delta: 1.291767)         elapsed: 376.818551 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:102
2019-10-15T07:20:21.779919 (delta: 0.096114)         elapsed: 376.914725 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-598c987dc8-vc9jn -n shubham", "delta": "0:00:08.144106", "end": "2019-10-15 07:20:30.224724", "rc": 0, "start": "2019-10-15 07:20:22.080618", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-598c987dc8-vc9jn\" deleted", "stdout_lines": ["pod \"percona-598c987dc8-vc9jn\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:108
2019-10-15T07:20:30.316740 (delta: 8.536762)         elapsed: 385.451546 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ app_pod_name.stdout }}" not in
podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n shubham", "delta": "0:00:00.883121", "end": "2019-10-15 07:20:31.501391", "rc": 0, "start": "2019-10-15 07:20:30.618270", "stderr": "", "stderr_lines": [], "stdout": "NAME                                      READY   STATUS      RESTARTS   AGE\nlitmus-9764dd5f6-286rz                    1/1     Running     0          25h\nopenebs-target-network-loss-5vld4-xksvl   1/1     Running     0          6m56s\nopenebs-target-network-loss-pzcx5-l8b47   0/1     Completed   0          13m\npercona-598c987dc8-xh5zm                  0/1     Error       1          8s", "stdout_lines": ["NAME                                      READY   STATUS      RESTARTS   AGE", "litmus-9764dd5f6-286rz                    1/1     Running     0          25h", "openebs-target-network-loss-5vld4-xksvl   1/1     Running     0          6m56s", "openebs-target-network-loss-pzcx5-l8b47   0/1     Completed   0          13m", "percona-598c987dc8-xh5zm                  0/1     Error       1          8s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:118
2019-10-15T07:20:31.628448 (delta: 1.311635)         elapsed: 386.763254 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n shubham -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:00.854817", "end": "2019-10-15 07:20:32.787207", "rc": 0, "start": "2019-10-15 07:20:31.932390", "stderr": "", "stderr_lines": [], "stdout": "percona-598c987dc8-xh5zm", "stdout_lines": ["percona-598c987dc8-xh5zm"]}

TASK [Checking application pod is in running state] ****************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:125
2019-10-15T07:20:32.879169 (delta: 1.250658)         elapsed: 388.013975 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n shubham -o jsonpath='{.items[?(@.metadata.name==\"percona-598c987dc8-xh5zm\")].status.containerStatuses[0].state.waiting.reason}'", "delta": "0:00:01.052019", "end": "2019-10-15 07:20:34.252620", "rc": 0, "start": "2019-10-15 07:20:33.200601", "stderr": "", "stderr_lines": [], "stdout": "CrashLoopBackOff", "stdout_lines": ["CrashLoopBackOff"]}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:132
2019-10-15T07:20:34.357230 (delta: 1.477992)         elapsed: 389.492036 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:143
2019-10-15T07:20:34.493484 (delta: 0.136192)         elapsed: 389.62829 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-10-15T07:20:34.682149 (delta: 0.188608)         elapsed: 389.816955 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-10-15T07:20:34.773434 (delta: 0.091225)         elapsed: 389.90824 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-10-15T07:20:34.863960 (delta: 0.090441)         elapsed: 389.998766 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-10-15T07:20:34.956514 (delta: 0.092493)         elapsed: 390.09132 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cd521ba3834fdc7ebdaaaf2b9d1245702cd7227c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "40fdc05ee57c44d3b9159f71bf44c775", "mode": "0644", "owner": "root", "size": 460, "src": "/root/.ansible/tmp/ansible-tmp-1571124035.05-198970658977693/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-10-15T07:20:36.905281 (delta: 1.948703)         elapsed: 392.040087 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.673363", "end": "2019-10-15 07:20:37.895379", "rc": 0, "start": "2019-10-15 07:20:37.222016", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-10-15T07:20:37.986670 (delta: 1.081326)         elapsed: 393.121476 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.140292", "end": "2019-10-15 07:20:39.422608", "failed_when_result": false, "rc": 0, "start": "2019-10-15 07:20:38.282316", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=47   changed=30   unreachable=0    failed=0   

2019-10-15T07:20:39.477034 (delta: 1.490275)         elapsed: 394.61184 ******* 
=============================================================================== 
```