### PR TITLE
refactor[yaml]: Modified jiva snapshot deletion litmus experiment to wait for the PVC status

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test.yml
@@ -53,12 +53,23 @@
            pvc_label: demo-vol1-claim
            execute: 1
 
+       - name: Confirm pvc status is bound
+         shell: >
+           kubectl get pvc --no-headers -n {{ app_ns }} -l name={{ pvc_label }} -o custom-columns=:.status.phase
+         args:
+           executable: /bin/bash
+         register: pvc_status
+         until: "'Bound' in pvc_status.stdout"
+         delay: 5
+         retries: 60 
+
        - name: Get pv name
          shell: >
            kubectl get pvc --no-headers -n {{ app_ns }} -l name={{ pvc_label }} -o jsonpath='{range .items[*]}{.spec.volumeName}'
          args:
            executable: /bin/bash
          register: result
+         failed_when: 'result.stdout == ""'
 
        - set_fact:
            pv_name: "{{ result.stdout }}"


### PR DESCRIPTION

Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- After appyling PVC, wait for PVC status if it is Bound or not. 

- Added a failed_when condition in getting PV Name. Task fails when there is no output in PV name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2019-10-18T06:19:45.933517 (delta: 0.072335)         elapsed: 0.072335 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-10-18T06:19:45.956585 (delta: 0.022979)         elapsed: 0.095403 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2019-10-18T06:19:56.975687 (delta: 11.01906)         elapsed: 11.114505 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-10-18T06:19:57.058086 (delta: 0.082342)         elapsed: 11.196904 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-18T06:19:57.160523 (delta: 0.102372)         elapsed: 11.299341 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-18T06:19:57.293152 (delta: 0.132569)         elapsed: 11.43197 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4f7f39fd2db6a0c714c6b7ce7c1ab581a1bc8178", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cbbaaefff371dec0810f1845792a5639", "mode": "0644", "owner": "root", "size": 429, "src": "/root/.ansible/tmp/ansible-tmp-1571379597.36-273233415009500/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-18T06:19:58.212890 (delta: 0.919682)         elapsed: 12.351708 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.259486", "end": "2019-10-18 06:19:59.884068", "rc": 0, "start": "2019-10-18 06:19:58.624582", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-di-delete-jiva-snapshots \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-di-delete-jiva-snapshots ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-18T06:19:59.950482 (delta: 1.73752)         elapsed: 14.0893 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.996774", "end": "2019-10-18 06:20:02.239406", "failed_when_result": false, "rc": 0, "start": "2019-10-18 06:20:00.242632", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-di-delete-jiva-snapshots created", "stdout_lines": ["litmusresult.litmus.io/fio-di-delete-jiva-snapshots created"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-18T06:20:02.320464 (delta: 2.369909)         elapsed: 16.459282 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-18T06:20:02.403006 (delta: 0.082472)         elapsed: 16.541824 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-18T06:20:02.484433 (delta: 0.081362)         elapsed: 16.623251 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2019-10-18T06:20:02.557050 (delta: 0.072538)         elapsed: 16.695868 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default", "delta": "0:00:01.762289", "end": "2019-10-18 06:20:04.624739", "rc": 0, "start": "2019-10-18 06:20:02.862450", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-jiva-default   openebs.io/provisioner-iscsi   3d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-jiva-default   openebs.io/provisioner-iscsi   3d"]}

TASK [Replace the storageclass placeholder with provider] **********************
2019-10-18T06:20:04.696397 (delta: 2.139283)         elapsed: 18.835215 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-10-18T06:20:05.228730 (delta: 0.532275)         elapsed: 19.367548 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-10-18T06:20:05.342865 (delta: 0.114051)         elapsed: 19.481683 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.513294", "end": "2019-10-18 06:20:07.105964", "rc": 0, "start": "2019-10-18 06:20:05.592670", "stderr": "", "stderr_lines": [], "stdout": "ag\naman\naman-percona\naman12\napp-busybox-ns\napp-percona-jiva\napp-percona-ns\nbusybox-cstor\nbusybox-cstor-sts\nbusybox-jiva\nbusybox-jiva-sts\ndefault\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\npercona-cstor\npercona-jiva\npercona1", "stdout_lines": ["ag", "aman", "aman-percona", "aman12", "app-busybox-ns", "app-percona-jiva", "app-percona-ns", "busybox-cstor", "busybox-cstor-sts", "busybox-jiva", "busybox-jiva-sts", "default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "percona-cstor", "percona-jiva", "percona1"]}

TASK [Create test specific namespace.] *****************************************
2019-10-18T06:20:07.234822 (delta: 1.891899)         elapsed: 21.37364 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns fio", "delta": "0:00:01.496892", "end": "2019-10-18 06:20:09.031504", "rc": 0, "start": "2019-10-18 06:20:07.534612", "stderr": "", "stderr_lines": [], "stdout": "namespace/fio created", "stdout_lines": ["namespace/fio created"]}

TASK [include_tasks] ***********************************************************
2019-10-18T06:20:09.152555 (delta: 1.91767)         elapsed: 23.291373 ******** 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-10-18T06:20:09.258498 (delta: 0.105875)         elapsed: 23.397316 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns fio -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.506584", "end": "2019-10-18 06:20:11.021360", "rc": 0, "start": "2019-10-18 06:20:09.514776", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deploy PVC to get size of volume requested application namespace] ********
2019-10-18T06:20:11.146614 (delta: 1.888052)         elapsed: 25.285432 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n fio", "delta": "0:00:01.800372", "end": "2019-10-18 06:20:13.229983", "rc": 0, "start": "2019-10-18 06:20:11.429611", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["persistentvolumeclaim/demo-vol1-claim created"]}

TASK [set_fact] ****************************************************************
2019-10-18T06:20:13.310649 (delta: 2.163966)         elapsed: 27.449467 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"execute": 1, "pvc_label": "demo-vol1-claim"}, "changed": false}

TASK [Confirm pvc status is bound] *********************************************
2019-10-18T06:20:13.440337 (delta: 0.129617)         elapsed: 27.579155 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc --no-headers -n fio -l name=demo-vol1-claim -o custom-columns=:.status.phase", "delta": "0:00:02.378051", "end": "2019-10-18 06:20:16.141765", "rc": 0, "start": "2019-10-18 06:20:13.763714", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Get pv name] *************************************************************
2019-10-18T06:20:16.283999 (delta: 2.843594)         elapsed: 30.422817 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc --no-headers -n fio -l name=demo-vol1-claim -o jsonpath='{range .items[*]}{.spec.volumeName}'", "delta": "0:00:01.932339", "end": "2019-10-18 06:20:18.571976", "failed_when_result": false, "rc": 0, "start": "2019-10-18 06:20:16.639637", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20"]}

TASK [set_fact] ****************************************************************
2019-10-18T06:20:18.659902 (delta: 2.375834)         elapsed: 32.79872 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"pv_name": "pvc-58090517-f16f-11e9-9496-005056985c20"}, "changed": false}

TASK [Replace the data sample size with the provider sample size in fio-write.yml] ***
2019-10-18T06:20:18.763060 (delta: 0.103098)         elapsed: 32.901878 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy fio write test job] ***********************************************
2019-10-18T06:20:19.144922 (delta: 0.381794)         elapsed: 33.28374 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-write.yml -n fio", "delta": "0:00:02.050590", "end": "2019-10-18 06:20:21.442303", "rc": 0, "start": "2019-10-18 06:20:19.391713", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic created\njob.batch/fio created", "stdout_lines": ["configmap/basic created", "job.batch/fio created"]}

TASK [Fetch the pod name in fio] ***********************************************
2019-10-18T06:20:21.536595 (delta: 2.391593)         elapsed: 35.675413 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-write -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.461548", "end": "2019-10-18 06:20:23.274630", "rc": 0, "start": "2019-10-18 06:20:21.813082", "stderr": "", "stderr_lines": [], "stdout": "fio-drmbk", "stdout_lines": ["fio-drmbk"]}

TASK [Check the status of pod] *************************************************
2019-10-18T06:20:23.333744 (delta: 1.797073)         elapsed: 37.472562 ******* 
FAILED - RETRYING: Check the status of pod (100 retries left).
FAILED - RETRYING: Check the status of pod (99 retries left).
FAILED - RETRYING: Check the status of pod (98 retries left).
FAILED - RETRYING: Check the status of pod (97 retries left).
FAILED - RETRYING: Check the status of pod (96 retries left).
FAILED - RETRYING: Check the status of pod (95 retries left).
FAILED - RETRYING: Check the status of pod (94 retries left).
FAILED - RETRYING: Check the status of pod (93 retries left).
FAILED - RETRYING: Check the status of pod (92 retries left).
FAILED - RETRYING: Check the status of pod (91 retries left).
FAILED - RETRYING: Check the status of pod (90 retries left).
FAILED - RETRYING: Check the status of pod (89 retries left).
FAILED - RETRYING: Check the status of pod (88 retries left).
FAILED - RETRYING: Check the status of pod (87 retries left).
FAILED - RETRYING: Check the status of pod (86 retries left).
FAILED - RETRYING: Check the status of pod (85 retries left).
changed: [127.0.0.1] => {"attempts": 17, "changed": true, "cmd": "kubectl get po fio-drmbk -n fio -o jsonpath={.status.phase}", "delta": "0:00:01.903906", "end": "2019-10-18 06:22:17.224656", "rc": 0, "start": "2019-10-18 06:22:15.320750", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Populate the iterator with the values to loop] ***************************
2019-10-18T06:22:17.350336 (delta: 114.016517)         elapsed: 151.489154 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "shuf -i 1-20 -n 15", "delta": "0:00:01.687175", "end": "2019-10-18 06:22:19.559327", "rc": 0, "start": "2019-10-18 06:22:17.872152", "stderr": "", "stderr_lines": [], "stdout": "1\n14\n4\n20\n2\n8\n13\n19\n15\n12\n5\n10\n11\n17\n9", "stdout_lines": ["1", "14", "4", "20", "2", "8", "13", "19", "15", "12", "5", "10", "11", "17", "9"]}

TASK [Include replica restart test] ********************************************
2019-10-18T06:22:19.709313 (delta: 2.358904)         elapsed: 153.848131 ****** 
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=1)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=14)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=4)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=20)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=2)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=8)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=13)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=19)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=15)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=12)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=5)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=10)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=11)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=17)
included: /experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml for 127.0.0.1 => (item=9)

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:22:20.428542 (delta: 0.719159)         elapsed: 154.56736 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:02.210790", "end": "2019-10-18 06:22:23.022963", "rc": 0, "start": "2019-10-18 06:22:20.812173", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-h5r8z\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-h5r8z", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:22:23.168995 (delta: 2.740388)         elapsed: 157.307813 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-h5r8z"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:22:23.315006 (delta: 0.145947)         elapsed: 157.453824 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-h5r8z -n fio", "delta": "0:00:12.621585", "end": "2019-10-18 06:22:36.318343", "rc": 0, "start": "2019-10-18 06:22:23.696758", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-h5r8z\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-h5r8z\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:22:36.513715 (delta: 13.198647)         elapsed: 170.652533 ***** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:22:36.627509", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:23:36.627788", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:23:36.682499 (delta: 60.168638)         elapsed: 230.821317 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:02.094034", "end": "2019-10-18 06:23:39.091701", "rc": 0, "start": "2019-10-18 06:23:36.997667", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-j2z7s\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-j2z7s", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:23:39.214213 (delta: 2.531622)         elapsed: 233.353031 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-j2z7s"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:23:39.430221 (delta: 0.215937)         elapsed: 233.569039 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-j2z7s -n fio", "delta": "0:00:06.454947", "end": "2019-10-18 06:23:46.291073", "rc": 0, "start": "2019-10-18 06:23:39.836126", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-j2z7s\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-j2z7s\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:23:46.379999 (delta: 6.949685)         elapsed: 240.518817 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:23:46.468765", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:24:46.469723", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:24:46.540407 (delta: 60.160313)         elapsed: 300.679225 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.875205", "end": "2019-10-18 06:24:48.718550", "rc": 0, "start": "2019-10-18 06:24:46.843345", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-2v9hn\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-2v9hn", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:24:48.834682 (delta: 2.294211)         elapsed: 302.9735 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-2v9hn"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:24:49.101536 (delta: 0.266763)         elapsed: 303.240354 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-2v9hn -n fio", "delta": "0:00:06.774931", "end": "2019-10-18 06:24:56.302760", "rc": 0, "start": "2019-10-18 06:24:49.527829", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-2v9hn\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-2v9hn\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:24:56.451960 (delta: 7.350331)         elapsed: 310.590778 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:24:56.600242", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:25:56.600536", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:25:56.656507 (delta: 60.204463)         elapsed: 370.795325 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.835909", "end": "2019-10-18 06:25:58.959324", "rc": 0, "start": "2019-10-18 06:25:57.123415", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8jxk5\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8jxk5", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:25:59.084668 (delta: 2.428067)         elapsed: 373.223486 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8jxk5"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:25:59.308652 (delta: 0.223889)         elapsed: 373.44747 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8jxk5 -n fio", "delta": "0:00:03.666798", "end": "2019-10-18 06:26:03.314137", "rc": 0, "start": "2019-10-18 06:25:59.647339", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8jxk5\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8jxk5\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:26:03.475871 (delta: 4.166992)         elapsed: 377.614689 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:26:03.579590", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:27:03.579919", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:27:03.653640 (delta: 60.177646)         elapsed: 437.792458 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.423239", "end": "2019-10-18 06:27:05.276184", "rc": 0, "start": "2019-10-18 06:27:03.852945", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-zm9wc\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-zm9wc", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:27:05.370096 (delta: 1.716389)         elapsed: 439.508914 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-zm9wc"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:27:05.539373 (delta: 0.169203)         elapsed: 439.678191 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-zm9wc -n fio", "delta": "0:00:10.415517", "end": "2019-10-18 06:27:16.301482", "rc": 0, "start": "2019-10-18 06:27:05.885965", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-zm9wc\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-zm9wc\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:27:16.406176 (delta: 10.866722)         elapsed: 450.544994 ***** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:27:16.479877", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:28:16.480116", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:28:16.513406 (delta: 60.10715)         elapsed: 510.652224 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.591612", "end": "2019-10-18 06:28:18.344031", "rc": 0, "start": "2019-10-18 06:28:16.752419", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-c4tp9\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-c4tp9", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:28:18.428063 (delta: 1.914605)         elapsed: 512.566881 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-c4tp9"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:28:18.537757 (delta: 0.109568)         elapsed: 512.676575 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-c4tp9 -n fio", "delta": "0:00:04.329008", "end": "2019-10-18 06:28:23.139546", "rc": 0, "start": "2019-10-18 06:28:18.810538", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-c4tp9\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-c4tp9\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:28:23.224064 (delta: 4.686225)         elapsed: 517.362882 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:28:23.278657", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:29:23.278889", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:29:23.316981 (delta: 60.092854)         elapsed: 577.455799 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.655966", "end": "2019-10-18 06:29:25.195997", "rc": 0, "start": "2019-10-18 06:29:23.540031", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-4f7tx\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-4f7tx", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:29:25.276577 (delta: 1.95949)         elapsed: 579.415395 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-4f7tx"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:29:25.399312 (delta: 0.122671)         elapsed: 579.53813 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-4f7tx -n fio", "delta": "0:00:03.335365", "end": "2019-10-18 06:29:29.002994", "rc": 0, "start": "2019-10-18 06:29:25.667629", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-4f7tx\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-4f7tx\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:29:29.110524 (delta: 3.71113)         elapsed: 583.249342 ******* 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:29:29.215691", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:30:29.217890", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:30:29.274549 (delta: 60.163962)         elapsed: 643.413367 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.321818", "end": "2019-10-18 06:30:30.844867", "rc": 0, "start": "2019-10-18 06:30:29.523049", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8vt67\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8vt67", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:30:30.922105 (delta: 1.647477)         elapsed: 645.060923 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8vt67"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:30:31.071122 (delta: 0.148939)         elapsed: 645.20994 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8vt67 -n fio", "delta": "0:00:03.195352", "end": "2019-10-18 06:30:34.570829", "rc": 0, "start": "2019-10-18 06:30:31.375477", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8vt67\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-8vt67\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:30:34.658245 (delta: 3.587052)         elapsed: 648.797063 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:30:34.735489", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:31:34.735833", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:31:34.778288 (delta: 60.119964)         elapsed: 708.917106 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.532421", "end": "2019-10-18 06:31:36.591441", "rc": 0, "start": "2019-10-18 06:31:35.059020", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-tttq4\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-tttq4", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:31:36.685470 (delta: 1.907123)         elapsed: 710.824288 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-tttq4"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:31:36.810850 (delta: 0.125298)         elapsed: 710.949668 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-tttq4 -n fio", "delta": "0:00:03.158136", "end": "2019-10-18 06:31:40.387883", "rc": 0, "start": "2019-10-18 06:31:37.229747", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-tttq4\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-tttq4\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:31:40.452104 (delta: 3.641148)         elapsed: 714.590922 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:31:40.511314", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:32:40.511520", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:32:40.563585 (delta: 60.111405)         elapsed: 774.702403 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.474642", "end": "2019-10-18 06:32:42.359367", "rc": 0, "start": "2019-10-18 06:32:40.884725", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-jq2vz\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-jq2vz", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:32:42.444669 (delta: 1.881008)         elapsed: 776.583487 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-jq2vz"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:32:42.591162 (delta: 0.146427)         elapsed: 776.72998 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-jq2vz -n fio", "delta": "0:00:13.476716", "end": "2019-10-18 06:32:56.297925", "rc": 0, "start": "2019-10-18 06:32:42.821209", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-jq2vz\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-jq2vz\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:32:56.416977 (delta: 13.825744)         elapsed: 790.555795 ***** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:32:56.475908", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:33:56.476104", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:33:56.525869 (delta: 60.108821)         elapsed: 850.664687 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.587935", "end": "2019-10-18 06:33:58.334051", "rc": 0, "start": "2019-10-18 06:33:56.746116", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dqfp6\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dqfp6", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:33:58.427858 (delta: 1.901927)         elapsed: 852.566676 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dqfp6"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:33:58.523973 (delta: 0.096007)         elapsed: 852.662791 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dqfp6 -n fio", "delta": "0:00:07.520371", "end": "2019-10-18 06:34:06.290082", "rc": 0, "start": "2019-10-18 06:33:58.769711", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dqfp6\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dqfp6\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:34:06.361206 (delta: 7.837172)         elapsed: 860.500024 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:34:06.417960", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:35:06.418174", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:35:06.471459 (delta: 60.110194)         elapsed: 920.610277 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.524203", "end": "2019-10-18 06:35:08.255639", "rc": 0, "start": "2019-10-18 06:35:06.731436", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-svh4k\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-svh4k", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:35:08.323972 (delta: 1.852442)         elapsed: 922.46279 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-svh4k"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:35:08.456998 (delta: 0.132959)         elapsed: 922.595816 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-svh4k -n fio", "delta": "0:00:07.597710", "end": "2019-10-18 06:35:16.302264", "rc": 0, "start": "2019-10-18 06:35:08.704554", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-svh4k\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-svh4k\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:35:16.480886 (delta: 8.023772)         elapsed: 930.619704 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:35:16.569681", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:36:16.569908", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:36:16.606292 (delta: 60.125336)         elapsed: 990.74511 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.517378", "end": "2019-10-18 06:36:18.395975", "rc": 0, "start": "2019-10-18 06:36:16.878597", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-fs2zr\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-fs2zr", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:36:18.474783 (delta: 1.868428)         elapsed: 992.613601 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-fs2zr"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:36:18.616972 (delta: 0.142094)         elapsed: 992.75579 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-fs2zr -n fio", "delta": "0:00:04.323935", "end": "2019-10-18 06:36:23.271359", "rc": 0, "start": "2019-10-18 06:36:18.947424", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-fs2zr\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-fs2zr\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:36:23.412895 (delta: 4.795847)         elapsed: 997.551713 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:36:23.477706", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:37:23.478028", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:37:23.541425 (delta: 60.128468)         elapsed: 1057.680243 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:02.459672", "end": "2019-10-18 06:37:26.240458", "rc": 0, "start": "2019-10-18 06:37:23.780786", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-kd45m\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-kd45m", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:37:26.334309 (delta: 2.792823)         elapsed: 1060.473127 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-kd45m"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:37:26.515480 (delta: 0.181094)         elapsed: 1060.654298 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-kd45m -n fio", "delta": "0:00:09.554959", "end": "2019-10-18 06:37:36.353349", "rc": 0, "start": "2019-10-18 06:37:26.798390", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-kd45m\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-kd45m\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:37:36.468261 (delta: 9.952722)         elapsed: 1070.607079 ***** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:37:36.545893", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:38:36.546145", "user_input": ""}

TASK [Get the name of replica pods] ********************************************
2019-10-18T06:38:36.596136 (delta: 60.127814)         elapsed: 1130.734954 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}}'", "delta": "0:00:01.533924", "end": "2019-10-18 06:38:38.379692", "rc": 0, "start": "2019-10-18 06:38:36.845768", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v\npvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-qcxb9\n}", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-b7m54", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-dfw8v", "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-qcxb9", "}"]}

TASK [Set the replica pod name to variable based on latest creation timestamp] ***
2019-10-18T06:38:38.494124 (delta: 1.897902)         elapsed: 1132.632942 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-qcxb9"}, "changed": false}

TASK [Delete replica with latest creation timestamp] ***************************
2019-10-18T06:38:38.714612 (delta: 0.220408)         elapsed: 1132.85343 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-qcxb9 -n fio", "delta": "0:00:03.388523", "end": "2019-10-18 06:38:42.489176", "rc": 0, "start": "2019-10-18 06:38:39.100653", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-qcxb9\" deleted", "stdout_lines": ["pod \"pvc-58090517-f16f-11e9-9496-005056985c20-rep-6c7749d88d-qcxb9\" deleted"]}

TASK [Pause for some time for a new replica to come up] ************************
2019-10-18T06:38:42.554742 (delta: 3.840054)         elapsed: 1136.69356 ****** 
Pausing for 60 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [127.0.0.1] => {"changed": false, "delta": 60, "echo": true, "rc": 0, "start": "2019-10-18 06:38:42.614449", "stderr": "", "stdout": "Paused for 1.0 minutes", "stop": "2019-10-18 06:39:42.614694", "user_input": ""}

TASK [Include replica count test] **********************************************
2019-10-18T06:39:42.657017 (delta: 60.102201)         elapsed: 1196.795835 **** 
included: /experiments/functional/snapshot_deletion/jiva/check_replica_count.yml for 127.0.0.1

TASK [Get controller svc] ******************************************************
2019-10-18T06:39:42.821642 (delta: 0.164558)         elapsed: 1196.96046 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc -n fio --no-headers -o custom-columns=:spec.clusterIP", "delta": "0:00:01.470111", "end": "2019-10-18 06:39:44.606530", "failed_when_result": false, "rc": 0, "start": "2019-10-18 06:39:43.136419", "stderr": "", "stderr_lines": [], "stdout": "172.24.242.101", "stdout_lines": ["172.24.242.101"]}

TASK [Get total replica count from controller] *********************************
2019-10-18T06:39:44.687531 (delta: 1.865825)         elapsed: 1198.826349 ***** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "connection": "close", "content": "{\"data\":[{\"actions\":{\"deleteSnapshot\":\"http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=deleteSnapshot\",\"revert\":\"http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=revert\",\"shutdown\":\"http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=shutdown\",\"snapshot\":\"http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=snapshot\"},\"id\":\"cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==\",\"links\":{\"self\":\"http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==\"},\"name\":\"pvc-58090517-f16f-11e9-9496-005056985c20\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}],\"links\":{\"self\":\"http://172.24.242.101:9501/v1/volumes\"},\"resourceType\":\"volume\",\"type\":\"collection\"}\n", "content_length": "910", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Fri, 18 Oct 2019 06:39:45 GMT", "json": {"data": [{"actions": {"deleteSnapshot": "http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=deleteSnapshot", "revert": "http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=revert", "shutdown": "http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=shutdown", "snapshot": "http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==?action=snapshot"}, "id": "cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA==", "links": {"self": "http://172.24.242.101:9501/v1/volumes/cHZjLTU4MDkwNTE3LWYxNmYtMTFlOS05NDk2LTAwNTA1Njk4NWMyMA=="}, "name": "pvc-58090517-f16f-11e9-9496-005056985c20", "readOnly": "false", "replicaCount": 3, "type": "volume"}], "links": {"self": "http://172.24.242.101:9501/v1/volumes"}, "resourceType": "volume", "type": "collection"}, "msg": "OK (910 bytes)", "redirected": false, "status": 200, "url": "http://172.24.242.101:9501/v1/volumes", "x_api_schemas": "http://172.24.242.101:9501/v1/schemas"}

TASK [Get rw replica status from controller] ***********************************
2019-10-18T06:39:45.666934 (delta: 0.979332)         elapsed: 1199.805752 ***** 
FAILED - RETRYING: Get rw replica status from controller (20 retries left).
FAILED - RETRYING: Get rw replica status from controller (19 retries left).
FAILED - RETRYING: Get rw replica status from controller (18 retries left).
FAILED - RETRYING: Get rw replica status from controller (17 retries left).
FAILED - RETRYING: Get rw replica status from controller (16 retries left).
FAILED - RETRYING: Get rw replica status from controller (15 retries left).
FAILED - RETRYING: Get rw replica status from controller (14 retries left).
FAILED - RETRYING: Get rw replica status from controller (13 retries left).
ok: [127.0.0.1] => {"attempts": 9, "changed": false, "connection": "close", "content": "{\"createTypes\":{\"replica\":\"http://172.24.242.101:9501/v1/replicas\"},\"data\":[{\"actions\":{\"preparerebuild\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=?action=preparerebuild\",\"verifyrebuild\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=?action=verifyrebuild\"},\"address\":\"tcp://172.23.4.160:9502\",\"id\":\"dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=\",\"links\":{\"self\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=?action=preparerebuild\",\"verifyrebuild\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=?action=verifyrebuild\"},\"address\":\"tcp://172.23.2.103:9502\",\"id\":\"dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=\",\"links\":{\"self\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=?action=preparerebuild\",\"verifyrebuild\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=?action=verifyrebuild\"},\"address\":\"tcp://172.23.6.164:9502\",\"id\":\"dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=\",\"links\":{\"self\":\"http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=\"},\"mode\":\"RW\",\"type\":\"replica\"}],\"links\":{\"self\":\"http://172.24.242.101:9501/v1/replicas\"},\"resourceType\":\"replica\",\"type\":\"collection\"}\n", "content_length": "1483", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Fri, 18 Oct 2019 06:43:49 GMT", "json": {"createTypes": {"replica": "http://172.24.242.101:9501/v1/replicas"}, "data": [{"actions": {"preparerebuild": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=?action=preparerebuild", "verifyrebuild": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=?action=verifyrebuild"}, "address": "tcp://172.23.4.160:9502", "id": "dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI=", "links": {"self": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjQuMTYwOjk1MDI="}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=?action=preparerebuild", "verifyrebuild": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=?action=verifyrebuild"}, "address": "tcp://172.23.2.103:9502", "id": "dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI=", "links": {"self": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjIuMTAzOjk1MDI="}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=?action=preparerebuild", "verifyrebuild": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=?action=verifyrebuild"}, "address": "tcp://172.23.6.164:9502", "id": "dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI=", "links": {"self": "http://172.24.242.101:9501/v1/replicas/dGNwOi8vMTcyLjIzLjYuMTY0Ojk1MDI="}, "mode": "RW", "type": "replica"}], "links": {"self": "http://172.24.242.101:9501/v1/replicas"}, "resourceType": "replica", "type": "collection"}, "msg": "OK (1483 bytes)", "redirected": false, "status": 200, "url": "http://172.24.242.101:9501/v1/replicas", "x_api_schemas": "http://172.24.242.101:9501/v1/schemas"}

TASK [Check if fio write job is completed] *************************************
2019-10-18T06:43:49.380411 (delta: 243.713412)         elapsed: 1443.519229 *** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-write\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:01.583375", "end": "2019-10-18 06:43:51.231112", "rc": 0, "start": "2019-10-18 06:43:49.647737", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the fio logs to check if run is complete w/o errors] **************
2019-10-18T06:43:51.320674 (delta: 1.940164)         elapsed: 1445.459492 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-drmbk -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:01.596414", "end": "2019-10-18 06:43:53.218015", "failed_when_result": false, "rc": 0, "start": "2019-10-18 06:43:51.621601", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Deploy fio read test job] ************************************************
2019-10-18T06:43:53.286360 (delta: 1.965608)         elapsed: 1447.425178 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-read.yml -n fio", "delta": "0:00:01.841034", "end": "2019-10-18 06:43:55.382990", "rc": 0, "start": "2019-10-18 06:43:53.541956", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic-read created\njob.batch/fio-read created", "stdout_lines": ["configmap/basic-read created", "job.batch/fio-read created"]}

TASK [Obtaining the fio read job pod name] *************************************
2019-10-18T06:43:55.444000 (delta: 2.157582)         elapsed: 1449.582818 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-read -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.577537", "end": "2019-10-18 06:43:57.267238", "rc": 0, "start": "2019-10-18 06:43:55.689701", "stderr": "", "stderr_lines": [], "stdout": "fio-read-dr2h5", "stdout_lines": ["fio-read-dr2h5"]}

TASK [Check if fio read job is completed] **************************************
2019-10-18T06:43:57.346112 (delta: 1.902055)         elapsed: 1451.48493 ****** 
FAILED - RETRYING: Check if fio read job is completed (20 retries left).
FAILED - RETRYING: Check if fio read job is completed (19 retries left).
FAILED - RETRYING: Check if fio read job is completed (18 retries left).
FAILED - RETRYING: Check if fio read job is completed (17 retries left).
FAILED - RETRYING: Check if fio read job is completed (16 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-read\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:01.218910", "end": "2019-10-18 06:49:07.851393", "rc": 0, "start": "2019-10-18 06:49:06.632483", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the data integrity check] *****************************************
2019-10-18T06:49:07.922354 (delta: 310.576183)         elapsed: 1762.061172 *** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-read-dr2h5 -n fio | grep -i '\"error\"' | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:01.713653", "end": "2019-10-18 06:49:09.953727", "failed_when_result": false, "rc": 0, "start": "2019-10-18 06:49:08.240074", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Verify Snapshot deletion] ************************************************
2019-10-18T06:49:10.101554 (delta: 2.17913)         elapsed: 1764.240372 ****** 
included: /experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml for 127.0.0.1

TASK [Get the name of controller pod] ******************************************
2019-10-18T06:49:10.286710 (delta: 0.185081)         elapsed: 1764.425528 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=pvc-58090517-f16f-11e9-9496-005056985c20 -n fio -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'", "delta": "0:00:01.459899", "end": "2019-10-18 06:49:11.973363", "rc": 0, "start": "2019-10-18 06:49:10.513464", "stderr": "", "stderr_lines": [], "stdout": "pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-6574b6c5cf-kpdf9", "stdout_lines": ["pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-6574b6c5cf-kpdf9"]}

TASK [Getting number of snapshots] *********************************************
2019-10-18T06:49:12.051593 (delta: 1.764826)         elapsed: 1766.190411 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-6574b6c5cf-kpdf9 -n fio -- jivactl snapshot ls | grep -v ID | wc -l", "delta": "0:00:01.791813", "end": "2019-10-18 06:49:14.137685", "rc": 0, "start": "2019-10-18 06:49:12.345872", "stderr": "Defaulting container name to pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-con.\nUse 'kubectl describe pod/pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-6574b6c5cf-kpdf9 -n fio' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-con.", "Use 'kubectl describe pod/pvc-58090517-f16f-11e9-9496-005056985c20-ctrl-6574b6c5cf-kpdf9 -n fio' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "9", "stdout_lines": ["9"]}

TASK [set_fact] ****************************************************************
2019-10-18T06:49:14.251609 (delta: 2.199953)         elapsed: 1768.390427 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-10-18T06:49:14.374497 (delta: 0.122824)         elapsed: 1768.513315 ***** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-18T06:49:14.535923 (delta: 0.16135)         elapsed: 1768.674741 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-18T06:49:14.595244 (delta: 0.059256)         elapsed: 1768.734062 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-18T06:49:14.661492 (delta: 0.066176)         elapsed: 1768.80031 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-18T06:49:14.736255 (delta: 0.074689)         elapsed: 1768.875073 ***** 
changed: [127.0.0.1] => {"changed": true, "checksum": "7d051c9ab2830b420ab57e65c1a77919cc01ffae", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "27037d02b557dafa06fac7875ada3e9a", "mode": "0644", "owner": "root", "size": 427, "src": "/root/.ansible/tmp/ansible-tmp-1571381354.81-258100762744296/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-18T06:49:17.836713 (delta: 3.100393)         elapsed: 1771.975531 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.193299", "end": "2019-10-18 06:49:19.356757", "rc": 0, "start": "2019-10-18 06:49:18.163458", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-di-delete-jiva-snapshots \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-di-delete-jiva-snapshots ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-18T06:49:19.436709 (delta: 1.599934)         elapsed: 1773.575527 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.623028", "end": "2019-10-18 06:49:21.271292", "failed_when_result": false, "rc": 0, "start": "2019-10-18 06:49:19.648264", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured", "stdout_lines": ["litmusresult.litmus.io/fio-di-delete-jiva-snapshots configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=115  changed=58   unreachable=0    failed=0   

2019-10-18T06:49:21.329438 (delta: 1.892665)         elapsed: 1775.468256 ***** 
```