### PR TITLE
util(yaml):chaos util to kill containers based on containerd CRI

### DIFF
--- a/chaoslib/containerd_chaos/containerd-chaos-ds.yml
+++ b/chaoslib/containerd_chaos/containerd-chaos-ds.yml
@@ -1,19 +1,19 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: crictl-chaos
+  name: containerd-chaos
 spec:
   template:
     metadata:
       labels:
         app: crictl
-      name: cri-chaos
+      name: containerd-chaos
     spec:
       containers:
       - image: gprasath/crictl:ci
         imagePullPolicy: Always
-        name: crictl-chaos
-        command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 12000']
+        name: containerd-chaos
+        command: ['sh', '-c', 'echo Hello! && sleep 1800']
         volumeMounts:
           - name: cri-socket
             mountPath: /run/containerd/containerd.sock

--- a/chaoslib/containerd_chaos/containerd-chaos-ds.yml
+++ b/chaoslib/containerd_chaos/containerd-chaos-ds.yml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: crictl-chaos
+spec:
+  template:
+    metadata:
+      labels:
+        app: crictl
+      name: cri-chaos
+    spec:
+      containers:
+      - image: gprasath/crictl:ci
+        imagePullPolicy: Always
+        name: crictl-chaos
+        command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 12000']
+        volumeMounts:
+          - name: cri-socket
+            mountPath: /run/containerd/containerd.sock
+          - name: cri-config
+            mountPath: /etc/crictl.yaml
+      volumes:
+        - hostPath:
+            path: /run/containerd/containerd.sock
+          name: cri-socket
+        - hostPath:
+            path: /etc/crictl.yaml 
+          name: cri-config
+

--- a/chaoslib/containerd_chaos/crictl-chaos.yml
+++ b/chaoslib/containerd_chaos/crictl-chaos.yml
@@ -110,7 +110,7 @@
       args:
         executable: /bin/bash
       register: result
-      until: "'Running' not in result.stdout"
+      until: "result.stdout == ''"
       delay: 3
       retries: 50
 

--- a/chaoslib/containerd_chaos/crictl-chaos.yml
+++ b/chaoslib/containerd_chaos/crictl-chaos.yml
@@ -28,6 +28,7 @@
       args:
         executable: /bin/bash
       register: result
+      failed_when: result is failed
 
     - name: Record the application node name
       set_fact:
@@ -41,6 +42,7 @@
       args:
         executable: /bin/bash
       register: chaos_pod
+      failed_when: chaos_pod is failed
 
     - name: Obtain the pod ID through Pod name
       shell: >

--- a/chaoslib/containerd_chaos/crictl-chaos.yml
+++ b/chaoslib/containerd_chaos/crictl-chaos.yml
@@ -1,0 +1,117 @@
+- block:
+
+    - name: Setup containerd chaos infrastructure.
+      shell: >
+        kubectl apply -f /chaoslib/containerd_chaos/containerd-chaos-ds.yml
+        -n {{ namespace }}
+      args:
+        executable: /bin/bash
+      register: result
+
+    - name: Confirm that the containerd-chaos ds is running on all nodes.
+      shell: >
+        kubectl get pod -l app=crictl
+        --no-headers -o custom-columns=:status.phase
+        -n {{ namespace }} | sort | uniq
+      args:
+        executable: /bin/bash
+      register: result
+      until: "result.stdout == 'Running'"
+      delay: 3
+      retries: 60
+      ignore_errors: true
+
+    - name: Identify the node where application is running
+      shell: >
+        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.nodeName
+      args:
+        executable: /bin/bash
+      register: result
+
+    - name: Record the application node name
+      set_fact:
+        app_node: "{{ result.stdout }}"
+
+    - name: Record the containerd-chaos pod on app node
+      shell: >
+        kubectl get pod -l app=crictl -o wide
+        -n {{ namespace }} | grep {{ app_node }}
+        | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: chaos_pod
+
+    - name: Obtain the pod ID through Pod name
+      shell: >
+        kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 
+        crictl pods | grep "{{ app_pod }}" | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: pod_id
+      failed_when: pod_id is failed
+
+    - name: Obtain the container ID using pod name and container name
+      shell: >
+        kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 
+        crictl ps | grep {{ pod_id.stdout }} | grep {{ app_container }} | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: container_id
+      failed_when: container_id is failed
+
+    - name: Kill the container
+      shell: >
+        kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 
+        crictl stop "{{ container_id.stdout }}"
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: result is failed
+
+    - name: Obtain the container ID using pod name and container name
+      shell: >
+        kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 
+        crictl ps | grep {{ pod_id.stdout }} | grep {{ app_container }} | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: new_container_id
+      until: "new_container_id.stdout != ''"
+      delay: 5
+      retries: 20
+
+    - name: Check if the new container is running.
+      shell: >
+        kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 
+        crictl ps | grep {{ new_container_id.stdout }}
+      args:
+        executable: /bin/bash
+      register: status
+      until: "'Running' in status.stdout"
+      delay: 3
+      retries: 30
+
+  when: action == "killapp"
+
+- block:
+
+    - name: Delete the crictl-chaos daemonset
+      shell: >
+        kubectl delete -f /chaoslib/containerd_chaos/containerd-chaos-ds.yml 
+        -n {{ namespace }}
+      args:
+        executable: /bin/bash
+      register: result
+
+    - name: Confirm that the containerd-chaos pod is deleted successfully
+      shell: >
+        kubectl get pod -l app=crictl
+        --no-headers -n {{ namespace }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'Running' not in result.stdout"
+      delay: 3
+      retries: 50
+
+  when: action == "delete-containerd"

--- a/chaoslib/openebs/cstor_target_container_kill.yml
+++ b/chaoslib/openebs/cstor_target_container_kill.yml
@@ -30,6 +30,15 @@
     namespace: "{{ target_ns }}"
     app_pod: "{{ cstor_target_pod.stdout }}"
     app_container: "{{ target_container }}"
+  when: cri == 'docker'
+
+- include_tasks: /chaoslib/containerd_chaos/crictl-chaos.yml
+  vars:
+    action: "killapp"
+    namespace: "{{ target_ns }}"
+    app_pod: "{{ cstor_target_pod.stdout }}"
+    app_container: "{{ target_container }}"
+  when: cri == 'containerd'
 
 - name: Check for target pod in running state
   shell: >

--- a/experiments/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_failure/run_litmus_test.yml
@@ -50,7 +50,10 @@ spec:
             value: ""
 
           - name: DATA_PERSISTENCE
-            value: "" 
+            value: ""
+
+          - name: CONTAINER_RUNTIME
+            value: docker 
 
             # CHOS_TYPE values :  target-zrepl-kill , target-kill , target-delete 
           - name: CHAOS_TYPE

--- a/experiments/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_failure/run_litmus_test.yml
@@ -56,7 +56,7 @@ spec:
           - name: CONTAINER_RUNTIME
             value: docker 
 
-            # CHOS_TYPE values :  target-zrepl-kill , target-kill
+            # CHOS_TYPE values :  target-zrepl-kill , target-kill , target-delete
           - name: CHAOS_TYPE
             value: "target-zrepl-kill"
             

--- a/experiments/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_failure/run_litmus_test.yml
@@ -51,11 +51,12 @@ spec:
 
           - name: DATA_PERSISTENCE
             value: ""
-
+       
+          # Specify the container runtime used , to pick the relevant chaos util
           - name: CONTAINER_RUNTIME
             value: docker 
 
-            # CHOS_TYPE values :  target-zrepl-kill , target-kill , target-delete 
+            # CHOS_TYPE values :  target-zrepl-kill , target-kill
           - name: CHAOS_TYPE
             value: "target-zrepl-kill"
             

--- a/experiments/chaos/openebs_target_failure/test_vars.yml
+++ b/experiments/chaos/openebs_target_failure/test_vars.yml
@@ -9,12 +9,23 @@ operator_ns: 'openebs'
 ## TODO: The var names for app labels, pvc, namespace etc., change across tests
 ## Need to make this consistent
 namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
 label: "{{ lookup('env','APP_LABEL') }}"
+
 pvc: "{{ lookup('env','APP_PVC') }}"
+
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
 chaos_type: "{{ lookup('env','CHAOS_TYPE') }}"
+
 target_container: "{{ lookup('env','TARGET_CONTAINER') }}"
-chaos_duration: 360
+
+chaos_duration: 120
+
 deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"
+
+cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- To kill the containers based on containerd CRI

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #30 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [x] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:


- Creating daemonset to do crictl operations on k8s node.
- The above daemonset pod is equipped with kubectl and crictl binaries.
- Picking the pod ID using pod name and the container id using pod ID and its name.
- Then, stopping the specific container by using `crictl stop <container id>` command.
- Ensure that the container is rescheduled again and validate the container restart count.


The litmus experiment which call this util should have env `CONTAINER_RUNTIME` . Based on its value, the relevant(pumba / containerd-chaos) util will be picked.