### PR TITLE
refactor(yaml): include containerd based chaos util in app-failure litmus experiment

### DIFF
--- a/chaoslib/containerd_chaos/crictl-chaos.yml
+++ b/chaoslib/containerd_chaos/crictl-chaos.yml
@@ -44,6 +44,21 @@
       register: chaos_pod
       failed_when: chaos_pod is failed
 
+    - block:
+
+      - name: Record the application container
+        shell: >
+          kubectl get pods -l {{ label }} -n {{ namespace }} -o jsonpath='{.items[0].spec.containers[0].name}'
+        args:
+          executable: /bin/bash
+        register: container
+
+      - name: Record the app_container
+        set_fact:
+          app_container: "{{ container.stdout }}"
+
+      when: app_container is undefined
+
     - name: Obtain the pod ID through Pod name
       shell: >
         kubectl exec {{ chaos_pod.stdout}} -n {{ namespace }} -- 

--- a/chaoslib/openebs/cstor_pool_health_check.yml
+++ b/chaoslib/openebs/cstor_pool_health_check.yml
@@ -70,14 +70,3 @@
   register: result
   with_items: "{{ pool_pod_named_list }}"
   failed_when: result.rc == 0
-
-- name: Verify there are no restarts of cstor pool containers
-  shell: >
-    kubectl get pods {{ item }} -n {{ operator_ns }}
-    -o jsonpath='{.status.containerStatuses[*].restartCount}'
-    | tr ' ' '\n' | sort | uniq
-  args:
-    executable: /bin/bash
-  register: result
-  with_items: "{{ pool_pod_named_list }}"
-  failed_when: result.stdout != "0"

--- a/experiments/chaos/app_pod_failure/README.md
+++ b/experiments/chaos/app_pod_failure/README.md
@@ -33,7 +33,6 @@
 | ------------- | ------------------------------------------------------------ |
 | APP_NAMESPACE | Namespace in which application pods are deployed             |
 | APP_LABEL     | Unique Labels in `key=value` format of application deployment |
-| APP_PVC       | Name of persistent volume claim used for app's volume mounts |
 
 ### Health Checks 
 
@@ -41,5 +40,31 @@
 | ---------------------- | ------------------------------------------------------------ |
 | LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
 | LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
-| DATA_PERSISTENCY       | Data accessibility & integrity verification post recovery (enabled, disabled) |
+| DATA_PERSISTENCE       | Specify the application name against which data consistency has to be ensured. Example: busybox,mysql |
 
+
+## Procedure
+
+This experiment kills the application container and verifies if the container is scheduled back and the data is intact. Based on CRI used, uses the relevant util to kill the application container.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+### Data consistency check
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+
+Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.

--- a/experiments/chaos/app_pod_failure/data_persistence.j2
+++ b/experiments/chaos/app_pod_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/app_pod_failure/run_litmus_test.yml
+++ b/experiments/chaos/app_pod_failure/run_litmus_test.yml
@@ -22,7 +22,7 @@ spec:
             value: default
 
           - name: APP_NAMESPACE
-            value: app-jenkins-ns 
+            value: app-jenkins-ns
 
           - name: APP_LABEL
             value: 'app=jenkins-app'
@@ -35,6 +35,10 @@ spec:
 
           - name: DEPLOY_TYPE
             value: deployment
+
+          # Specify the container runtime used , to pick the relevant chaos util
+          - name: CONTAINER_RUNTIME
+            value: docker
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/app_pod_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/chaos/app_pod_failure/run_litmus_test.yml
+++ b/experiments/chaos/app_pod_failure/run_litmus_test.yml
@@ -1,4 +1,12 @@
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,6 +48,16 @@ spec:
           - name: CONTAINER_RUNTIME
             value: docker
 
+            #Specify app pod name to check if the data is consistent. Currently supported values are 'mysql' and 'busybox'
+          - name: DATA_PERSISTENCE
+            value: ""
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/app_pod_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
-
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: app-failure

--- a/experiments/chaos/app_pod_failure/test.yml
+++ b/experiments/chaos/app_pod_failure/test.yml
@@ -4,6 +4,7 @@
 
   vars_files:
     - test_vars.yml
+    - /mnt/parameters.yml
 
   tasks:
     - block:
@@ -31,6 +32,19 @@
             chaostype: "app-failure"
             app: ""
 
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
+
+        - include_vars:
+            file: data_persistence.yml
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
+
         ## DISPLAY APP INFORMATION
 
         - name: Display the app information passed via the test job
@@ -45,6 +59,7 @@
           include_tasks: /utils/k8s/check_deployment_status.yml
 
         - block:
+
             - name: Get application pod name
               shell: >
                 kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
@@ -52,6 +67,14 @@
               args:
                 executable: /bin/bash
               register: app_pod_name
+
+            - name: Create some test data
+              include: "{{ data_consistency_util_path }}"
+              vars:
+                status: 'LOAD'
+                ns: "{{ app_ns }}"
+                pod_name: "{{ app_pod_name.stdout }}"
+              when: data_persistence != ''
 
              ## APPLICATION FAULT INJECTION
 
@@ -70,6 +93,15 @@
                 namespace: "{{ app_ns }}"
                 label: "{{ app_label }}"
               when: cri == 'containerd'
+
+            - name: Verify application data persistence
+              include: "{{ data_consistency_util_path }}"
+              vars:
+                status: 'VERIFY'
+                ns: "{{ app_ns }}"
+                label: "{{ app_label }}"
+                pod_name: "{{ app_pod_name.stdout }}"                 
+              when: data_persistence != ''
 
           when: lookup('env','DEPLOY_TYPE') == 'deployment'
 

--- a/experiments/chaos/app_pod_failure/test.yml
+++ b/experiments/chaos/app_pod_failure/test.yml
@@ -16,46 +16,26 @@
               until: "'Running' in liveness_pod.stdout"
               delay: 10
               retries: 10
-             
-          when: liveness_label != ''  
 
-        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+          when: liveness_label != ''
 
-        - block:
- 
-            - name: Record test instance/run ID 
-              set_fact: 
-                run_id: "{{ lookup('env','RUN_ID') }}"
-           
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
+        ## Creating test name
 
-          when: lookup('env','RUN_ID')
+        - include_tasks: /utils/fcm/create_testname.yml
 
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
-            src: /litmus-result.j2
-            dest: litmus-result.yaml
-          vars: 
-            test: "{{ test_name }}"
-            chaostype: ""
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "app-failure"
             app: ""
-            phase: in-progress
-            verdict: none
 
-        - name: Apply the litmus result CR
-          shell: kubectl apply -f litmus-result.yaml
-          args:
-            executable: /bin/bash
-          register: lr_status 
-          failed_when: "lr_status.rc != 0"
+        ## DISPLAY APP INFORMATION
 
-        ## DISPLAY APP INFORMATION 
- 
         - name: Display the app information passed via the test job
-          debug: 
-            msg: 
+          debug:
+            msg:
               - "The application info is as follows:"
               - "Namespace    : {{ app_ns }}"
               - "Label        : {{ app_label }}"
@@ -65,14 +45,14 @@
           include_tasks: /utils/k8s/check_deployment_status.yml
 
         - block:
-            - name: Get application pod name 
+            - name: Get application pod name
               shell: >
                 kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
                 -o=custom-columns=NAME:".metadata.name" | shuf -n 1
               args:
                 executable: /bin/bash
               register: app_pod_name
-  
+
              ## APPLICATION FAULT INJECTION
 
             - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
@@ -81,6 +61,15 @@
                 app_pod: "{{ app_pod_name.stdout }}"
                 namespace: "{{ app_ns }}"
                 label: "{{ app_label }}"
+              when: cri == 'docker'
+
+            - include_tasks: /chaoslib/containerd_chaos/crictl-chaos.yml
+              vars:
+                action: "killapp"
+                app_pod: "{{ app_pod_name.stdout }}"
+                namespace: "{{ app_ns }}"
+                label: "{{ app_label }}"
+              when: cri == 'containerd'
 
           when: lookup('env','DEPLOY_TYPE') == 'deployment'
 
@@ -101,6 +90,15 @@
                 app_pod: "{{ app_pod_name.stdout }}"
                 namespace: "{{ app_ns }}"
                 label: "{{ app_label }}"
+              when: cri == 'docker'
+
+            - include_tasks: /chaoslib/containerd_chaos/crictl-chaos.yml
+              vars:
+                action: "killapp"
+                app_pod: "{{ app_pod_name.stdout }}"
+                namespace: "{{ app_ns }}"
+                label: "{{ app_label }}"
+              when: cri == 'containerd'
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 
@@ -108,7 +106,7 @@
 
         - name: Verify AUT liveness post fault-injection
           include_tasks: /utils/k8s/check_deployment_status.yml
-  
+
         - block:
 
             - name: Checking status of liveness pod
@@ -117,39 +115,34 @@
               until: "'Running' in liveness_pod.stdout"
               delay: 10
               retries: 10
-             
-          when: liveness_label != ''  
+
+          when: liveness_label != ''
 
         - set_fact:
             flag: "Pass"
 
-      rescue: 
-        - set_fact: 
+      rescue:
+        - set_fact:
             flag: "Fail"
 
-      always: 
+      always:
 
         ## RECORD END-OF-TEST IN LITMUS RESULT CR
- 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
-            src: /litmus-result.j2
-            dest: litmus-result.yaml
-          vars: 
-            test: "{{ test_name }}"
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
             chaostype: ""
             app: ""
-            phase: completed
-            verdict: "{{ flag }}"
-           
-        - name: Apply the litmus result CR
-          shell: kubectl apply -f litmus-result.yaml
-          args:
-            executable: /bin/bash
-          register: lr_status 
-          failed_when: "lr_status.rc != 0"
-           
-        - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml 
+
+        - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
           vars:
             action: "deletepumba"
             namespace: "{{ app_ns }}"
+          when: cri == 'docker'
+
+        - include_tasks: /chaoslib/containerd_chaos/crictl-chaos.yml
+          vars:
+            action: "delete-containerd"
+            namespace: "{{ app_ns }}"
+          when: cri == 'containerd'
+

--- a/experiments/chaos/app_pod_failure/test_vars.yml
+++ b/experiments/chaos/app_pod_failure/test_vars.yml
@@ -10,3 +10,4 @@ liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 
 cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
 
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"

--- a/experiments/chaos/app_pod_failure/test_vars.yml
+++ b/experiments/chaos/app_pod_failure/test_vars.yml
@@ -1,7 +1,12 @@
 test_name: application-pod-failure
+
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
 app_label: "{{ lookup('env','APP_LABEL') }}"
+
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 
+cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
 

--- a/utils/scm/applications/mysql/mysql_data_persistence.yml
+++ b/utils/scm/applications/mysql/mysql_data_persistence.yml
@@ -24,7 +24,7 @@
      args:
        executable: /bin/bash
 
-   - name: Verify if the applicaion pod is deleted
+   - name: Verify if the application pod is deleted
      shell: >
        kubectl get pods -n {{ ns }}
      args:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Included containerd chaos into app-pod-failure litmus experiment.
- Modularised the playbook by incorporating reusable utils.
- Made it work for both docker and containerd based applications.
- Included data persistence check.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #39 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [x] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [x] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/app_pod_failure/test.yml

PLAY [localhost] ***************************************************************
2019-10-25T01:18:17.179893 (delta: 0.078039)         elapsed: 0.078039 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:2
2019-10-25T01:18:17.196066 (delta: 0.016104)         elapsed: 0.094212 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [Checking status of liveness pod] *****************************************
task path: /experiments/chaos/app_pod_failure/test.yml:14
2019-10-25T01:18:20.000594 (delta: 2.804436)         elapsed: 2.89874 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:25
2019-10-25T01:18:20.120736 (delta: 0.120065)         elapsed: 3.018882 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-10-25T01:18:20.321616 (delta: 0.200792)         elapsed: 3.219762 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-10-25T01:18:20.436891 (delta: 0.115177)         elapsed: 3.335037 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:29
2019-10-25T01:18:20.566696 (delta: 0.129703)         elapsed: 3.464842 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-10-25T01:18:20.838296 (delta: 0.271485)         elapsed: 3.736442 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "ce7920d8e29f2ff5a763555b6bfc9326188a3ac0", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8def1132959ad719bdd501c955700bab", "mode": "0644", "owner": "root", "size": 435, "src": "/root/.ansible/tmp/ansible-tmp-1571966300.9-9493672902203/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-10-25T01:18:21.825808 (delta: 0.987433)         elapsed: 4.723954 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.170969", "end": "2019-10-25 01:18:22.511952", "rc": 0, "start": "2019-10-25 01:18:22.340983", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: application-pod-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: app-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: application-pod-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: app-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-10-25T01:18:22.603412 (delta: 0.777507)         elapsed: 5.501558 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"litmus.io/v1alpha1\",\"kind\":\"LitmusResult\",\"metadata\":{\"annotations\":{},\"name\":\"application-pod-failure\"},\"spec\":{\"testMetadata\":{\"app\":null,\"chaostype\":null},\"testStatus\":{\"phase\":\"completed\",\"result\":\"Fail\"}}}\n"}, "creationTimestamp": "2019-10-24T23:23:02Z", "generation": 21, "name": "application-pod-failure", "resourceVersion": "131042", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/application-pod-failure", "uid": "dc90b999-8169-4482-975b-ed4c575d06e7"}, "spec": {"testMetadata": {"chaostype": "app-failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-10-25T01:18:24.065656 (delta: 1.462156)         elapsed: 6.963802 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-10-25T01:18:24.146410 (delta: 0.080683)         elapsed: 7.044556 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-10-25T01:18:24.254704 (delta: 0.108222)         elapsed: 7.15285 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/app_pod_failure/test.yml:35
2019-10-25T01:18:24.379805 (delta: 0.124994)         elapsed: 7.277951 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1571966304.47-233488124421380/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:40
2019-10-25T01:18:25.063923 (delta: 0.684016)         elapsed: 7.962069 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/app_pod_failure/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/app_pod_failure/test.yml:43
2019-10-25T01:18:25.202299 (delta: 0.138298)         elapsed: 8.100445 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/app_pod_failure/test.yml:50
2019-10-25T01:18:25.354981 (delta: 0.15259)         elapsed: 8.253127 ********* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : percona-ns", 
        "Label        : name=percona"
    ]
}

TASK [Verify that the AUT is running] ******************************************
task path: /experiments/chaos/app_pod_failure/test.yml:58
2019-10-25T01:18:25.526757 (delta: 0.171652)         elapsed: 8.424903 ******** 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2019-10-25T01:18:25.687469 (delta: 0.160617)         elapsed: 8.585615 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.589538", "end": "2019-10-25 01:18:26.547582", "rc": 0, "start": "2019-10-25 01:18:25.958044", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2019-10-25T01:18:26.669014 (delta: 0.981482)         elapsed: 9.56716 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2019-10-25T01:18:26.786198 (delta: 0.117064)         elapsed: 9.684344 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:63
2019-10-25T01:18:26.875694 (delta: 0.089411)         elapsed: 9.77384 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\" | shuf -n 1", "delta": "0:00:00.399056", "end": "2019-10-25 01:18:27.595882", "rc": 0, "start": "2019-10-25 01:18:27.196826", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-f9p5b", "stdout_lines": ["percona-7c6969cf78-f9p5b"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:71
2019-10-25T01:18:27.694332 (delta: 0.818553)         elapsed: 10.592478 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-10-25T01:18:27.877463 (delta: 0.183048)         elapsed: 10.775609 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database aish;') => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-f9p5b -n percona-ns -- mysql -uroot -pk8sDem0 -e 'create database aish;'", "delta": "0:00:01.049633", "end": "2019-10-25 01:18:29.232231", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database aish;'", "rc": 0, "start": "2019-10-25 01:18:28.182598", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' aish) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-f9p5b -n percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' aish", "delta": "0:00:01.243255", "end": "2019-10-25 01:18:30.740130", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' aish", "rc": 0, "start": "2019-10-25 01:18:29.496875", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' aish) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-f9p5b -n percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' aish", "delta": "0:00:01.096932", "end": "2019-10-25 01:18:32.110050", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' aish", "rc": 0, "start": "2019-10-25 01:18:31.013118", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-10-25T01:18:32.217432 (delta: 4.339891)         elapsed: 15.115578 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-10-25T01:18:32.304172 (delta: 0.086654)         elapsed: 15.202318 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-10-25T01:18:32.387461 (delta: 0.083221)         elapsed: 15.285607 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-10-25T01:18:32.468045 (delta: 0.080521)         elapsed: 15.366191 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-10-25T01:18:32.555394 (delta: 0.087269)         elapsed: 15.45354 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-10-25T01:18:32.685304 (delta: 0.129835)         elapsed: 15.58345 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-10-25T01:18:32.792651 (delta: 0.107247)         elapsed: 15.690797 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-10-25T01:18:32.919484 (delta: 0.126757)         elapsed: 15.81763 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-10-25T01:18:33.037597 (delta: 0.118035)         elapsed: 15.935743 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:81
2019-10-25T01:18:33.164802 (delta: 0.127095)         elapsed: 16.062948 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:89
2019-10-25T01:18:33.303005 (delta: 0.138122)         elapsed: 16.201151 ******* 
included: /chaoslib/containerd_chaos/crictl-chaos.yml for 127.0.0.1

TASK [Setup containerd chaos infrastructure.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:3
2019-10-25T01:18:33.542513 (delta: 0.239395)         elapsed: 16.440659 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/containerd_chaos/containerd-chaos-ds.yml -n percona-ns", "delta": "0:00:01.757303", "end": "2019-10-25 01:18:35.562146", "rc": 0, "start": "2019-10-25 01:18:33.804843", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/containerd-chaos created", "stdout_lines": ["daemonset.extensions/containerd-chaos created"]}

TASK [Confirm that the containerd-chaos ds is running on all nodes.] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:11
2019-10-25T01:18:35.680100 (delta: 2.137521)         elapsed: 18.578246 ******* 
FAILED - RETRYING: Confirm that the containerd-chaos ds is running on all nodes. (60 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos ds is running on all nodes. (59 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos ds is running on all nodes. (58 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get pod -l app=crictl --no-headers -o custom-columns=:status.phase -n percona-ns | sort | uniq", "delta": "0:00:00.379746", "end": "2019-10-25 01:18:47.311778", "rc": 0, "start": "2019-10-25 01:18:46.932032", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Identify the node where application is running] **************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:24
2019-10-25T01:18:47.414320 (delta: 11.734138)         elapsed: 30.312466 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-7c6969cf78-f9p5b -n percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.323315", "end": "2019-10-25 01:18:48.116904", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:18:47.793589", "stderr": "", "stderr_lines": [], "stdout": "node1-konvoy.mayalabs.io", "stdout_lines": ["node1-konvoy.mayalabs.io"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:33
2019-10-25T01:18:48.240752 (delta: 0.826349)         elapsed: 31.138898 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "node1-konvoy.mayalabs.io"}, "changed": false}

TASK [Record the containerd-chaos pod on app node] *****************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:37
2019-10-25T01:18:48.423749 (delta: 0.182915)         elapsed: 31.321895 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=crictl -o wide -n percona-ns | grep node1-konvoy.mayalabs.io | awk '{print $1}'", "delta": "0:00:00.411547", "end": "2019-10-25 01:18:49.246649", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:18:48.835102", "stderr": "", "stderr_lines": [], "stdout": "containerd-chaos-hw29l", "stdout_lines": ["containerd-chaos-hw29l"]}

TASK [Record the application container] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:49
2019-10-25T01:18:49.346039 (delta: 0.922212)         elapsed: 32.244185 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l name=percona -n percona-ns -o jsonpath='{.items[0].spec.containers[0].name}'", "delta": "0:00:00.348003", "end": "2019-10-25 01:18:50.017156", "rc": 0, "start": "2019-10-25 01:18:49.669153", "stderr": "", "stderr_lines": [], "stdout": "percona", "stdout_lines": ["percona"]}

TASK [Record the app_container] ************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:56
2019-10-25T01:18:50.116767 (delta: 0.770631)         elapsed: 33.014913 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_container": "percona"}, "changed": false}

TASK [Obtain the pod ID through Pod name] **************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:62
2019-10-25T01:18:50.330688 (delta: 0.213845)         elapsed: 33.228834 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec containerd-chaos-hw29l -n percona-ns -- crictl pods | grep \"percona-7c6969cf78-f9p5b\" | awk '{print $1}'", "delta": "0:00:00.999724", "end": "2019-10-25 01:18:51.766052", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:18:50.766328", "stderr": "", "stderr_lines": [], "stdout": "8eadbf693b32d", "stdout_lines": ["8eadbf693b32d"]}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:71
2019-10-25T01:18:51.866610 (delta: 1.535822)         elapsed: 34.764756 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec containerd-chaos-hw29l -n percona-ns -- crictl ps | grep 8eadbf693b32d | grep percona | awk '{print $1}'", "delta": "0:00:00.943933", "end": "2019-10-25 01:18:53.127833", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:18:52.183900", "stderr": "", "stderr_lines": [], "stdout": "0b76972826be5", "stdout_lines": ["0b76972826be5"]}

TASK [Kill the container] ******************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:80
2019-10-25T01:18:53.236577 (delta: 1.369896)         elapsed: 36.134723 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec containerd-chaos-hw29l -n percona-ns -- crictl stop \"0b76972826be5\"", "delta": "0:00:03.783636", "end": "2019-10-25 01:18:57.407381", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:18:53.623745", "stderr": "", "stderr_lines": [], "stdout": "0b76972826be5", "stdout_lines": ["0b76972826be5"]}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:89
2019-10-25T01:18:57.535503 (delta: 4.298847)         elapsed: 40.433649 ******* 
FAILED - RETRYING: Obtain the container ID using pod name and container name (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl exec containerd-chaos-hw29l -n percona-ns -- crictl ps | grep 8eadbf693b32d | grep percona | awk '{print $1}'", "delta": "0:00:00.875096", "end": "2019-10-25 01:19:04.741900", "rc": 0, "start": "2019-10-25 01:19:03.866804", "stderr": "", "stderr_lines": [], "stdout": "cc5045a549095", "stdout_lines": ["cc5045a549095"]}

TASK [Check if the new container is running.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:100
2019-10-25T01:19:04.818703 (delta: 7.28313)         elapsed: 47.716849 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec containerd-chaos-hw29l -n percona-ns -- crictl ps | grep cc5045a549095", "delta": "0:00:00.866743", "end": "2019-10-25 01:19:05.968951", "rc": 0, "start": "2019-10-25 01:19:05.102208", "stderr": "", "stderr_lines": [], "stdout": "cc5045a549095       a6e498ef5ec57       7 seconds ago       Running             percona                        1                   8eadbf693b32d", "stdout_lines": ["cc5045a549095       a6e498ef5ec57       7 seconds ago       Running             percona                        1                   8eadbf693b32d"]}

TASK [Delete the crictl-chaos daemonset] ***************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:115
2019-10-25T01:19:06.072149 (delta: 1.253385)         elapsed: 48.970295 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the containerd-chaos pod is deleted successfully] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:123
2019-10-25T01:19:06.196466 (delta: 0.124243)         elapsed: 49.094612 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/app_pod_failure/test.yml:97
2019-10-25T01:19:06.333547 (delta: 0.136998)         elapsed: 49.231693 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-10-25T01:19:06.568159 (delta: 0.2345)         elapsed: 49.466305 ********* 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database aish;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database aish;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' aish)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' aish", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' aish)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' aish", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-10-25T01:19:06.755972 (delta: 0.187731)         elapsed: 49.654118 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7c6969cf78-f9p5b -n percona-ns", "delta": "0:00:04.900963", "end": "2019-10-25 01:19:11.978705", "rc": 0, "start": "2019-10-25 01:19:07.077742", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7c6969cf78-f9p5b\" deleted", "stdout_lines": ["pod \"percona-7c6969cf78-f9p5b\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-10-25T01:19:12.079324 (delta: 5.323257)         elapsed: 54.97747 ******** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-ns", "delta": "0:00:00.315999", "end": "2019-10-25 01:19:12.731943", "rc": 0, "start": "2019-10-25 01:19:12.415944", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS    RESTARTS   AGE\ncontainerd-chaos-7w6bk     1/1     Running   0          38s\ncontainerd-chaos-hw29l     1/1     Running   0          38s\ncontainerd-chaos-j2lbz     1/1     Running   0          38s\ncontainerd-chaos-lxzlq     1/1     Running   0          38s\ncontainerd-chaos-m66jl     1/1     Running   0          38s\npercona-7c6969cf78-bcxhd   1/1     Running   0          5s", "stdout_lines": ["NAME                       READY   STATUS    RESTARTS   AGE", "containerd-chaos-7w6bk     1/1     Running   0          38s", "containerd-chaos-hw29l     1/1     Running   0          38s", "containerd-chaos-j2lbz     1/1     Running   0          38s", "containerd-chaos-lxzlq     1/1     Running   0          38s", "containerd-chaos-m66jl     1/1     Running   0          38s", "percona-7c6969cf78-bcxhd   1/1     Running   0          5s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-10-25T01:19:12.831657 (delta: 0.75224)         elapsed: 55.729803 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:00.512939", "end": "2019-10-25 01:19:13.710918", "rc": 0, "start": "2019-10-25 01:19:13.197979", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-bcxhd", "stdout_lines": ["percona-7c6969cf78-bcxhd"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-10-25T01:19:13.786274 (delta: 0.954518)         elapsed: 56.68442 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-bcxhd\")].status.phase}'", "delta": "0:00:00.372546", "end": "2019-10-25 01:19:14.466301", "rc": 0, "start": "2019-10-25 01:19:14.093755", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-10-25T01:19:14.567726 (delta: 0.781393)         elapsed: 57.465872 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-bcxhd\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.343026", "end": "2019-10-25 01:19:15.222413", "rc": 0, "start": "2019-10-25 01:19:14.879387", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-10-25T01:19:10Z]]", "stdout_lines": ["map[running:map[startedAt:2019-10-25T01:19:10Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-10-25T01:19:15.318567 (delta: 0.75077)         elapsed: 58.216713 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-bcxhd -n percona-ns -- mysqlcheck -c aish -uroot -pk8sDem0", "delta": "0:00:00.869431", "end": "2019-10-25 01:19:16.513259", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:19:15.643828", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "aish.ttbl                                          OK", "stdout_lines": ["aish.ttbl                                          OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-10-25T01:19:16.632433 (delta: 1.313793)         elapsed: 59.530579 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-bcxhd -n percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' aish;", "delta": "0:00:00.936536", "end": "2019-10-25 01:19:17.912476", "failed_when_result": false, "rc": 0, "start": "2019-10-25 01:19:16.975940", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-10-25T01:19:18.018375 (delta: 1.385843)         elapsed: 60.916521 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-10-25T01:19:18.156735 (delta: 0.13829)         elapsed: 61.054881 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:110
2019-10-25T01:19:18.232212 (delta: 0.075405)         elapsed: 61.130358 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:119
2019-10-25T01:19:18.305018 (delta: 0.072739)         elapsed: 61.203164 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:127
2019-10-25T01:19:18.396311 (delta: 0.091217)         elapsed: 61.294457 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/app_pod_failure/test.yml:139
2019-10-25T01:19:18.484728 (delta: 0.088323)         elapsed: 61.382874 ******* 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2019-10-25T01:19:18.670356 (delta: 0.185554)         elapsed: 61.568502 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.384995", "end": "2019-10-25 01:19:19.327983", "rc": 0, "start": "2019-10-25 01:19:18.942988", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2019-10-25T01:19:19.436188 (delta: 0.765761)         elapsed: 62.334334 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2019-10-25T01:19:19.539756 (delta: 0.103475)         elapsed: 62.437902 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking status of liveness pod] *****************************************
task path: /experiments/chaos/app_pod_failure/test.yml:144
2019-10-25T01:19:19.637655 (delta: 0.097817)         elapsed: 62.535801 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:153
2019-10-25T01:19:19.723181 (delta: 0.085451)         elapsed: 62.621327 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:163
2019-10-25T01:19:19.850200 (delta: 0.126933)         elapsed: 62.748346 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-10-25T01:19:19.987717 (delta: 0.137421)         elapsed: 62.885863 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-10-25T01:19:20.074857 (delta: 0.087079)         elapsed: 62.973003 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-10-25T01:19:20.158483 (delta: 0.083527)         elapsed: 63.056629 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-10-25T01:19:20.254894 (delta: 0.096314)         elapsed: 63.15304 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "aeb9292d9ee23fa35ed460339f012b46a02512e4", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7f4dd582dd4d3f7d7e8d6ac97ad4045f", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1571966360.34-53101745412193/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-10-25T01:19:21.353338 (delta: 1.09837)         elapsed: 64.251484 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.170286", "end": "2019-10-25 01:19:21.823558", "rc": 0, "start": "2019-10-25 01:19:21.653272", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: application-pod-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: application-pod-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-10-25T01:19:21.910116 (delta: 0.556708)         elapsed: 64.808262 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"litmus.io/v1alpha1\",\"kind\":\"LitmusResult\",\"metadata\":{\"annotations\":{},\"name\":\"application-pod-failure\"},\"spec\":{\"testMetadata\":{\"app\":null,\"chaostype\":null},\"testStatus\":{\"phase\":\"completed\",\"result\":\"Fail\"}}}\n"}, "creationTimestamp": "2019-10-24T23:23:02Z", "generation": 22, "name": "application-pod-failure", "resourceVersion": "131413", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/application-pod-failure", "uid": "dc90b999-8169-4482-975b-ed4c575d06e7"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:169
2019-10-25T01:19:23.181719 (delta: 1.271512)         elapsed: 66.079865 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/app_pod_failure/test.yml:175
2019-10-25T01:19:23.273348 (delta: 0.091549)         elapsed: 66.171494 ******* 
included: /chaoslib/containerd_chaos/crictl-chaos.yml for 127.0.0.1

TASK [Setup containerd chaos infrastructure.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:3
2019-10-25T01:19:23.507461 (delta: 0.234015)         elapsed: 66.405607 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the containerd-chaos ds is running on all nodes.] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:11
2019-10-25T01:19:23.616011 (delta: 0.108469)         elapsed: 66.514157 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the node where application is running] **************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:24
2019-10-25T01:19:23.688992 (delta: 0.07288)         elapsed: 66.587138 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application node name] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:33
2019-10-25T01:19:23.754616 (delta: 0.065559)         elapsed: 66.652762 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the containerd-chaos pod on app node] *****************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:37
2019-10-25T01:19:23.822554 (delta: 0.067867)         elapsed: 66.7207 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application container] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:49
2019-10-25T01:19:23.896504 (delta: 0.073882)         elapsed: 66.79465 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:56
2019-10-25T01:19:24.142304 (delta: 0.24573)         elapsed: 67.04045 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the pod ID through Pod name] **************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:62
2019-10-25T01:19:24.212037 (delta: 0.06966)         elapsed: 67.110183 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:71
2019-10-25T01:19:24.287450 (delta: 0.075321)         elapsed: 67.185596 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Kill the container] ******************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:80
2019-10-25T01:19:24.351739 (delta: 0.064226)         elapsed: 67.249885 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:89
2019-10-25T01:19:24.414524 (delta: 0.062728)         elapsed: 67.31267 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the new container is running.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:100
2019-10-25T01:19:24.495730 (delta: 0.081145)         elapsed: 67.393876 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the crictl-chaos daemonset] ***************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:115
2019-10-25T01:19:24.582247 (delta: 0.086424)         elapsed: 67.480393 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/containerd_chaos/containerd-chaos-ds.yml -n percona-ns", "delta": "0:00:00.368197", "end": "2019-10-25 01:19:25.314401", "rc": 0, "start": "2019-10-25 01:19:24.946204", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"containerd-chaos\" deleted", "stdout_lines": ["daemonset.extensions \"containerd-chaos\" deleted"]}

TASK [Confirm that the containerd-chaos pod is deleted successfully] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:123
2019-10-25T01:19:25.422169 (delta: 0.839816)         elapsed: 68.320315 ******* 
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (50 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (49 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (48 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (47 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (46 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (45 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (44 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (43 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (42 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (41 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (40 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (39 retries left).
changed: [127.0.0.1] => {"attempts": 13, "changed": true, "cmd": "kubectl get pod -l app=crictl --no-headers -n percona-ns", "delta": "0:00:00.417055", "end": "2019-10-25 01:20:10.912065", "rc": 0, "start": "2019-10-25 01:20:10.495010", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=46   changed=30   unreachable=0    failed=0   

2019-10-25T01:20:10.955030 (delta: 45.532762)         elapsed: 113.853176 ***** 
=============================================================================== 
```