### PR TITLE
feat(experiment): Litmusbook for provisioning mayastor

### DIFF
--- a/providers/mayastor/bootstrap_nodes.yml
+++ b/providers/mayastor/bootstrap_nodes.yml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nsenter
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bootstrap-config
+  namespace: nsenter
+data:
+  install.sh: |
+    echo 512 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+    modprobe nbd
+    modprobe xfs
+    echo "nbd
+    xfs" >> /etc/modules-load.d/modules.conf
+    echo "vm.nr_hugepages = 512" >> /etc/sysctl.conf
+    systemctl restart kubelet
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: bootstrap
+  namespace: nsenter
+spec:
+  selector:
+    matchLabels:
+      job: bootstrap
+  template:
+    metadata:
+      labels:
+        job: bootstrap
+    spec:
+      hostPID: true
+      restartPolicy: Always
+      containers:
+      - image: ranjnshashank855/nsenter:v1
+        imagePullPolicy: Always
+        name: bootstrap
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bootstrap-script
+          mountPath: /tmp
+        - name: host-mount
+          mountPath: /host
+      volumes:
+      - name: bootstrap-script
+        configMap:
+          name: bootstrap-config
+      - name: host-mount
+        hostPath:
+          path: /tmp/install

--- a/providers/mayastor/run_litmus_test.yml
+++ b/providers/mayastor/run_litmus_test.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: mayastor-provision
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: mayastor-provision
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/mayastor/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/mayastor/test.yml
+++ b/providers/mayastor/test.yml
@@ -1,0 +1,82 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+    
+         # GENERATING THE TEST NAME
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ##  RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Getting the number of compute nodes
+          shell: kubectl get nodes --no-headers | grep none | wc -l
+          register: compute_nodes
+
+        - name: Getting the node names
+          shell: kubectl get nodes --no-headers | grep none | awk '{print $1}'
+          register: node_names
+
+        - name: Bootsrapping compute nodes using nsenter daemonset
+          shell: kubectl apply -f bootstrap_nodes.yml
+
+        - name: Checking for demon pods in running state
+          shell: kubectl get pod -n nsenter -l job=bootstrap -o jsonpath='{.items[*].status.phase}' | grep Running | wc -w
+          register: demon_count
+          until: (compute_nodes.stdout)|int == (demon_count.stdout)|int
+          delay: 5
+          retries: 50
+
+        - name: Labeling the nodes
+          shell: kubectl label node {{item}} openebs.io/engine=mayastor
+          with_items: "{{ node_names.stdout_lines }}"
+
+        - name: Creating namespace holding MayaStor resources
+          shell: kubectl apply -f {{ maya_namespace_link }}
+          register: namespace_status
+          failed_when: "'created' not in namespace_status.stdout"
+
+        - name: Creating moac deployment
+          shell: kubectl apply -f {{ maya_moac_deployment_link }}
+
+        - name: Checking moac pod status
+          shell: kubectl get pod -n mayastor -l app=moac -o jsonpath='{.items[0].status.phase}'
+          register: moac_status
+          until: "'Running' in moac_status.stdout"
+          delay: 5
+          retries: 120
+
+        - name: Creating MayaStor daemonset
+          shell: kubectl apply -f {{ maya_demonset_link }}      
+          
+        - name: Checking the status of MataStor Daemonset
+          shell: kubectl get pod -n mayastor -l app=mayastor -o jsonpath='{.items[*].status.phase}' | grep Running | wc -w
+          register: mayastor_demon_count
+          until: (compute_nodes.stdout)|int == (mayastor_demon_count.stdout)|int
+          delay: 5
+          retries: 50
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+          
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+
+        - name: Deprovisioning nsenter
+          shell: |
+            kubectl delete daemonset --all -n nsenter
+            kubectl delete namespace nsenter

--- a/providers/mayastor/test_vars.yml
+++ b/providers/mayastor/test_vars.yml
@@ -1,0 +1,4 @@
+test_name: "mayastor-provision"
+maya_namespace_link: "https://raw.githubusercontent.com/openebs/MayaStor/master/deploy/namespace.yaml"
+maya_moac_deployment_link: "https://raw.githubusercontent.com/openebs/MayaStor/master/deploy/moac-deployment.yaml"
+maya_demonset_link: "https://raw.githubusercontent.com/openebs/MayaStor/master/deploy/mayastor-daemonset.yaml"


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Litmusbook for provisioning mayastor
- Contains nsenter demonset for bootstrapping nodes for mayastor installation.

**Following is the log of litmus experiment:**
```
PLAYBOOK: test.yaml **************************************************************************************************************************************************
1 plays in test.yaml

PLAY [localhost] *****************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:1
ok: [localhost]
META: ran handlers

TASK [Getting the number of compute nodes] ***************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:19
changed: [localhost] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep none | wc -l", "delta": "0:00:01.558041", "end": "2019-10-29 07:10:29.922352", "rc": 0, "start": "2019-10-29 07:10:28.364311", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the node names] ****************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:23
changed: [localhost] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep none | awk '{print $1}'", "delta": "0:00:01.071634", "end": "2019-10-29 07:10:31.179226", "rc": 0, "start": "2019-10-29 07:10:30.107592", "stderr": "", "stderr_lines": [], "stdout": "gke-mayastor-default-pool-468179a5-lfhf\ngke-mayastor-default-pool-468179a5-vd26\ngke-mayastor-default-pool-468179a5-ww3f", "stdout_lines": ["gke-mayastor-default-pool-468179a5-lfhf", "gke-mayastor-default-pool-468179a5-vd26", "gke-mayastor-default-pool-468179a5-ww3f"]}

TASK [Bootsraping compute nodes using nsenter demonset] **************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:27
changed: [localhost] => {"changed": true, "cmd": "kubectl apply -f bootstrap_nodes.yml", "delta": "0:00:05.226807", "end": "2019-10-29 07:10:36.617378", "rc": 0, "start": "2019-10-29 07:10:31.390571", "stderr": "", "stderr_lines": [], "stdout": "namespace/nsenter created\nconfigmap/bootstrap-config created\ndaemonset.apps/bootstrap created", "stdout_lines": ["namespace/nsenter created", "configmap/bootstrap-config created", "daemonset.apps/bootstrap created"]}

TASK [Checking for demon pods in running state] **********************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:30
FAILED - RETRYING: Checking for demon pods in running state (50 retries left).
changed: [localhost] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n nsenter -l job=bootstrap -o jsonpath='{.items[*].status.phase}' | grep Running | wc -w", "delta": "0:00:01.329407", "end": "2019-10-29 07:10:44.625800", "rc": 0, "start": "2019-10-29 07:10:43.296393", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Lableing the nodes] ********************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:37
changed: [localhost] => (item=gke-mayastor-default-pool-468179a5-lfhf) => {"changed": true, "cmd": "kubectl label node gke-mayastor-default-pool-468179a5-lfhf openebs.io/engine=mayastor", "delta": "0:00:01.391253", "end": "2019-10-29 07:10:46.213394", "item": "gke-mayastor-default-pool-468179a5-lfhf", "rc": 0, "start": "2019-10-29 07:10:44.822141", "stderr": "", "stderr_lines": [], "stdout": "node/gke-mayastor-default-pool-468179a5-lfhf labeled", "stdout_lines": ["node/gke-mayastor-default-pool-468179a5-lfhf labeled"]}
changed: [localhost] => (item=gke-mayastor-default-pool-468179a5-vd26) => {"changed": true, "cmd": "kubectl label node gke-mayastor-default-pool-468179a5-vd26 openebs.io/engine=mayastor", "delta": "0:00:01.717109", "end": "2019-10-29 07:10:48.045861", "item": "gke-mayastor-default-pool-468179a5-vd26", "rc": 0, "start": "2019-10-29 07:10:46.328752", "stderr": "", "stderr_lines": [], "stdout": "node/gke-mayastor-default-pool-468179a5-vd26 labeled", "stdout_lines": ["node/gke-mayastor-default-pool-468179a5-vd26 labeled"]}
changed: [localhost] => (item=gke-mayastor-default-pool-468179a5-ww3f) => {"changed": true, "cmd": "kubectl label node gke-mayastor-default-pool-468179a5-ww3f openebs.io/engine=mayastor", "delta": "0:00:01.628810", "end": "2019-10-29 07:10:49.796467", "item": "gke-mayastor-default-pool-468179a5-ww3f", "rc": 0, "start": "2019-10-29 07:10:48.167657", "stderr": "", "stderr_lines": [], "stdout": "node/gke-mayastor-default-pool-468179a5-ww3f labeled", "stdout_lines": ["node/gke-mayastor-default-pool-468179a5-ww3f labeled"]}

TASK [Creating namespace holding MayaStor resources] *****************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:41
changed: [localhost] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/MayaStor/master/deploy/namespace.yaml", "delta": "0:00:04.836188", "end": "2019-10-29 07:10:54.826347", "failed_when_result": false, "rc": 0, "start": "2019-10-29 07:10:49.990159", "stderr": "", "stderr_lines": [], "stdout": "namespace/mayastor created", "stdout_lines": ["namespace/mayastor created"]}

TASK [Creating moac deployment] **************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:46
changed: [localhost] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/MayaStor/master/deploy/moac-deployment.yaml", "delta": "0:00:05.802731", "end": "2019-10-29 07:11:00.835872", "rc": 0, "start": "2019-10-29 07:10:55.033141", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount/moac created\nclusterrole.rbac.authorization.k8s.io/moac created\nclusterrolebinding.rbac.authorization.k8s.io/moac created\ndeployment.apps/moac created\nservice/moac created", "stdout_lines": ["serviceaccount/moac created", "clusterrole.rbac.authorization.k8s.io/moac created", "clusterrolebinding.rbac.authorization.k8s.io/moac created", "deployment.apps/moac created", "service/moac created"]}

TASK [Checking moac pod status] **************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:49
FAILED - RETRYING: Checking moac pod status (120 retries left).
FAILED - RETRYING: Checking moac pod status (119 retries left).
FAILED - RETRYING: Checking moac pod status (118 retries left).
FAILED - RETRYING: Checking moac pod status (117 retries left).
FAILED - RETRYING: Checking moac pod status (116 retries left).
FAILED - RETRYING: Checking moac pod status (115 retries left).
changed: [localhost] => {"attempts": 7, "changed": true, "cmd": "kubectl get po -n mayastor -l app=moac -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.064353", "end": "2019-10-29 07:11:39.949791", "rc": 0, "start": "2019-10-29 07:11:38.885438", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Creating MayaStor demonset] ************************************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:56
changed: [localhost] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/MayaStor/master/deploy/mayastor-daemonset.yaml", "delta": "0:00:03.129240", "end": "2019-10-29 07:11:43.258142", "rc": 0, "start": "2019-10-29 07:11:40.128902", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/mayastor created", "stdout_lines": ["daemonset.apps/mayastor created"]}

TASK [Checking the status of MataStor Demonset] **********************************************************************************************************************
task path: /home/shashank/Desktop/workspace/litmus/providers/mayastor/test.yaml:59
FAILED - RETRYING: Checking the status of MataStor Demonset (50 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (49 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (48 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (47 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (46 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (45 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (44 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (43 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (42 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (41 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (40 retries left).
FAILED - RETRYING: Checking the status of MataStor Demonset (39 retries left).
changed: [localhost] => {"attempts": 13, "changed": true, "cmd": "kubectl get pod -n mayastor -l app=mayastor -o jsonpath='{.items[*].status.phase}' | grep Running | wc -w", "delta": "0:00:01.519686", "end": "2019-10-29 07:13:03.638089", "rc": 0, "start": "2019-10-29 07:13:02.118403", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************************************************
localhost                  : ok=11   changed=10   unreachable=0    failed=0 
``` 

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
