### PR TITLE
feat[experiment]: Implement litmusbook to replace cvr by node failure

### DIFF
--- a/experiments/chaos/replace_cvr_by_node_failure/README.md
+++ b/experiments/chaos/replace_cvr_by_node_failure/README.md
@@ -1,0 +1,78 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | Storage | K8s Platform      |
+| ----- | ------------------------------------------------------------ | ------- | ----------------- |
+| Chaos | Power off any one of the node where cvr is hosted and migrate the cvr to other nodde where it has pool availabel | OpenEBS | on-premise-VMware |
+
+## Entry-Criteria
+
+- Application services are accessible & pods are healthy
+- All the CVR's are healthy
+- Pools have to be created in all the nodes.
+- Application writes are successful
+
+## Exit-Criteria
+
+- Application and all the CVR's are healthy.
+- Data written prior to chaos is successfully retrieved/read
+- Database consistency is maintained as per db integrity check utils
+- Storage target pods are healthy
+
+## Associated Utils
+
+- `vm_power_operations.yml`,`mysql_data_persistence.yml`,`busybox_data_persistence.yml`,`fetch_data_from_replica.yml`
+
+
+### Procedure
+
+This scenario validates the behaviour of cStor volume Replica have to be migrated to the new node where the pools availabel and that shoul be in healthy state. It is performed by shutting down the node(virtual machine) created on VMware hypervisor. After attaining podevictiontimeout(5 minutes by default).
+
+Based on the value of env `DATA_PERSISTENCE`, the corresponding data consistency util will be executed. At present, only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+```
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+```
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+```
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+```
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+
+Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
+ESX password has to updated through k8s secret created. The litmus runner can retrieve the password from secret as environmental variable and utilize it for performing admin operations on the server.
+
+
+Note: To perform admin operatons on vmware, the VM display name in hypervisor should match its hostname.
+
+## Litmus experiment Environment Variables
+
+### Application
+
+| Parameter        | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| APP_NAMESPACE    | Namespace in which application pods are deployed             |
+| APP_LABEL        | Unique Labels in `key=value` format of application deployment|
+| OPERATOR_NS      | Namespace in which openebs components are deployed           |
+| TARGET_NAMESPACE | Namespace where OpenEBS is installed                         |
+| DATA_PERSISTENCE | Specify the application name against which data consistency has to be ensured. Example: busybox |
+
+### Chaos
+
+| Parameter    | Description                                                  |
+| ------------ | ------------------------------------------------------------ |
+| PLATFORM     | The platform where k8s cluster is created. Currently, only 'vmware' is supported. |
+| ESX_HOST_IP  | The IP address of ESX server where the virtual machines are hosted. |
+| ESX_PASSWORD | To be passed as configmap data.                              |
+

--- a/experiments/chaos/replace_cvr_by_node_failure/chaosutil.j2
+++ b/experiments/chaos/replace_cvr_by_node_failure/chaosutil.j2
@@ -1,0 +1,3 @@
+{% if platform is defined and platform == 'vmware' %}
+  chaosutil: chaoslib/vmware_chaos/vm_power_operations.yml
+{% endif %}

--- a/experiments/chaos/replace_cvr_by_node_failure/cvr.yaml
+++ b/experiments/chaos/replace_cvr_by_node_failure/cvr.yaml
@@ -1,0 +1,26 @@
+apiVersion: openebs.io/v1alpha1
+kind: CStorVolumeReplica
+metadata:
+  annotations:
+    cstorpool.openebs.io/hostname: node_name
+    isRestoreVol: "false"
+    openebs.io/storage-class-ref: |
+      name: storage_class_name
+  finalizers:
+  - cstorvolumereplica.openebs.io/finalizer
+  generation: 1
+  labels:
+    cstorpool.openebs.io/name: csp_name
+    cstorpool.openebs.io/uid: csp_uid
+    cstorvolume.openebs.io/name: cstor_volume_name
+    openebs.io/cas-template-name: cstor-volume-create-default-1.3.0
+    openebs.io/persistent-volume: pv_name
+    openebs.io/version: 1.3.0
+  name: cstor_volume_name-csp_name
+  namespace: openebs
+spec:
+  capacity: initial_capacity
+  targetIP: target_ip
+  replicaid: "replica_id"
+status:
+  phase: Recreate

--- a/experiments/chaos/replace_cvr_by_node_failure/data_persistence.j2
+++ b/experiments/chaos/replace_cvr_by_node_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/replace_cvr_by_node_failure/run_litmus_test.yml
+++ b/experiments/chaos/replace_cvr_by_node_failure/run_litmus_test.yml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: replace-cvr-node-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: host-password
+  namespace: litmus
+type: Opaque
+data:
+  password:
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: replace-cvr-node-failure-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: cvr-node-failure
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      #nodeSelector:
+      #  kubernetes.io/hostname:
+
+      tolerations:
+      - key: "infra-aid"
+        operator: "Equal"
+        value: "observer"
+        effect: "NoSchedule"
+
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: ""
+
+          - name: APP_LABEL
+            value: ""
+
+          - name: APP_PVC
+            value: ""
+
+          # The platform where k8s cluster is created.
+          - name: PLATFORM
+            value: "vmware"
+
+          # The IP address of ESX HOST
+          - name: ESX_HOST_IP
+            value: ""
+
+          - name: ESX_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: host-password 
+                key: password
+
+          # Application name to pick the relevant data persistence check util
+          - name: DATA_PERSISTENCE
+            value: "" 
+
+          - name: OPERATOR_NS
+            value: ""            
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/replace_cvr_by_node_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: replace-cvr-node-failure

--- a/experiments/chaos/replace_cvr_by_node_failure/test.yml
+++ b/experiments/chaos/replace_cvr_by_node_failure/test.yml
@@ -1,0 +1,574 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+
+  tasks:
+
+   - block:
+
+       - include_tasks: /utils/fcm/create_testname.yml
+
+       - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+         vars:
+           status: 'SOT'
+           chaostype: "replace-cvr-node-failure"
+           app: ""
+
+       - name: Identify the chaos util to be invoked
+         template:
+           src: chaosutil.j2
+           dest: chaosutil.yml
+
+       - include_vars:
+           file: chaosutil.yml
+
+       - name: Record the chaos util path
+         set_fact:
+           chaos_util_path: "/{{ chaosutil }}"
+
+       - name: Identify the data consistency util to be invoked
+         template:
+           src: data_persistence.j2
+           dest: data_persistence.yml
+
+       - include_vars:
+           file: data_persistence.yml
+
+       - name: Record the data consistency util path
+         set_fact:
+           data_consistency_util_path: "{{ consistencyutil }}"
+         when: data_persistence != ''
+
+        ## Verify the APPLICATION UNDER TEST PRE CHAOS
+       - name: Verify if the application is running.
+         include_tasks: /utils/k8s/status_app_pod.yml
+         vars:
+           app_ns: "{{ app_namespace }}"
+           app_lkey: "{{ label.split('=')[0] }}"
+           app_lvalue: "{{ label.split('=')[1] }}"
+           delay: '2'
+           retries: '60'
+
+        ## Fetch application pod name
+       - name: Get application pod name
+         shell: >
+           kubectl get pod -n {{ app_namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+         args:
+           executable: /bin/bash
+         register: app_pod_name
+         failed_when: 'app_pod_name.stdout == ""'
+
+        ## Generate data on the application
+       - name: Generate data on the specified application.
+         include: "{{ data_consistency_util_path }}"
+         vars:
+           status: 'LOAD'
+           ns: "{{ app_namespace }}"
+           pod_name: "{{ app_pod_name.stdout }}"
+         when: data_persistence != ''
+
+        ## Obtain the node where application pod is running
+       - name: Get Application pod Node to perform chaos
+         shell: >
+           kubectl get pod {{ app_pod_name.stdout }} -n {{ app_namespace }}
+           --no-headers -o custom-columns=:spec.nodeName
+         args:
+           executable: /bin/bash
+         register: app_node
+         failed_when: 'app_node.stdout == ""'
+
+       - name: Obtain the Persistent Volume name
+         shell: kubectl get pvc {{ app_pvc }} -n {{ app_namespace }} --no-headers -o custom-columns=:.spec.volumeName
+         args:
+           executable: /bin/bash
+         register: pv
+         failed_when: 'pv.stdout == ""'
+
+       - name: Obtain the StorageClass name from PVC
+         shell: kubectl get pvc {{ app_pvc }} -n {{ app_namespace }} --no-headers -o custom-columns=:.spec.storageClassName
+         args:
+           executable: /bin/bash
+         register: sc_name
+         failed_when: 'sc_name.stdout == ""'
+
+       - name: Get the cStorVolume name
+         shell: >
+           kubectl get cstorvolume -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: cv_name
+         failed_when: 'cv_name.stdout == ""'
+
+       - name: Check if the CVRs in healthy state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: cvr_status
+         until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the total number of cvr
+         shell: kubectl get cvr -n {{ operator_ns }} --no-headers -l openebs.io/persistent-volume={{ pv.stdout }} | wc -l
+         args:
+           executable: /bin/bash
+         register: cvr_count
+         failed_when: 'cvr_count.stdout == ""'
+
+       - name: Obtain the ReplicationFactor from cstorvolume and check if it is equal to the cvr count
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.replicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: rf
+         failed_when: "cvr_count.stdout != rf.stdout"
+
+       - name: Obtain the consistencyFactor from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.consistencyFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: cf
+         failed_when: 'cf.stdout == ""'
+
+       - name: Obtain the desiredReplicationFactor from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.desiredReplicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: drf
+         failed_when: 'drf.stdout == ""'
+
+       - name: Get the node name for the cvr
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\.openebs\.io\/hostname}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: cvr_node
+         failed_when: 'cvr_node.stdout == ""'
+
+       - name: Obtain the List of CVR's that not scheduled in application node
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} 
+           -o jsonpath='{range .items[?(@.metadata.annotations.cstorpool\.openebs\.io/hostname!="{{ app_node.stdout }}")]}{.metadata.name}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: cvr_list
+         failed_when: 'cvr_list.stdout == ""'
+
+       - name: Select random cvr from the list of cvr as target cvr to migrate
+         set_fact:
+           target_cvr: "{{ item }}"
+         with_random_choice: "{{ cvr_list.stdout_lines }}"
+
+       - name: Obtain the node name for the target cvr to perform the chaos
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} {{ target_cvr }}
+           -o=jsonpath='{.items[*]}{.metadata.annotations.cstorpool\.openebs\.io\/hostname}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: target_cvr_node
+         failed_when: 'target_cvr_node.stdout == ""'
+
+       - name: Obtain the replica id from the selected replica
+         shell: kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} --no-headers -o custom-columns=:.spec.replicaid
+         args:
+           executable: /bin/bash
+         register: replica_id
+         failed_when: 'replica_id.stdout == ""'
+
+       - name: Obtain the knownreplica id value from the cstor volume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }}
+           -o custom-columns=:.status.replicaDetails.knownReplicas.{{ replica_id.stdout }} --no-headers
+         args:
+           executable: /bin/bash
+         register: rid_value
+         until: 'rid_value.stdout != ""'
+         delay: 10
+         retries: 30
+
+       - name: Obtain the csp name from targeted cvr
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} -o jsonpath='{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: csp_name
+         failed_when: 'csp_name.stdout == ""'
+
+       - name: Obtain the SPC name from csp
+         shell: >
+           kubectl get csp {{ csp_name.stdout }} -o jsonpath='{.metadata.labels.openebs\.io\/storage-pool-claim}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: spc_name
+         failed_when: 'spc_name.stdout == ""'
+
+       - name: Getting the list of csp node name correspond to provided spc
+         shell: >
+           kubectl get csp -l openebs.io/storage-pool-claim={{ spc_name.stdout }}
+           -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\.io\/hostname}{"\n"}{end}'
+         register: csp_all
+         failed_when: 'csp_all.stdout == ""'
+
+       - name: Create a file to store CSP name
+         lineinfile:
+           create: yes
+           state: present
+           path: "./csp_all.tmp"
+           line: "{{ item.stdout }}"
+           mode: 0755
+         with_items:
+           - "{{ csp_all }}"
+
+       - name: Getting the list of nodes cvr is created
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\.openebs\.io\/hostname}{"\n"}{end}'
+         register: csp_cvr
+         failed_when: 'csp_cvr.stdout == ""'
+
+       - name: Create a file to store CSP name
+         lineinfile:
+           create: yes
+           state: present
+           path: "./csp_cvr.tmp"
+           line: "{{ item.stdout }}"
+           mode: 0755
+         with_items:
+           - "{{ csp_cvr }}"
+
+       - name: Getting the node name of the csp where no cvr is created
+         shell: |
+           cat csp_all.tmp | tr " " "\n" > csp_all
+           cat csp_cvr.tmp | tr " " "\n" > csp_cvr
+           comm -3 <(sort csp_all) <(sort csp_cvr)
+         args:
+            executable: /bin/bash
+         register: free_csp_node
+
+       - name: Select random node from the list of nodes as target node
+         set_fact:
+           target_node: "{{ item }}"
+         with_random_choice: "{{ free_csp_node.stdout_lines }}"
+         when: free_csp_node.stdout_lines != ""
+
+       - name: Obtain the CSP from the targeted node
+         shell: >
+           kubectl get csp -l kubernetes.io/hostname={{ target_node }},openebs.io/storage-pool-claim={{ spc_name.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: csp_name
+         failed_when: 'csp_name.stdout == ""'
+
+       - name: Get the csp id
+         shell: kubectl get csp {{ csp_name.stdout }} --no-headers -o custom-columns=:.metadata.uid
+         args:
+           executable: /bin/bash
+         register: csp_uid
+         failed_when: 'csp_uid.stdout == ""'
+
+       - name: Obtain the Initial capacity of the target
+         shell: kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} -o jsonpath='{.spec.capacity}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: initial_capacity
+         failed_when: 'initial_capacity.stdout == ""'
+
+       - name: Get the target ip
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} {{ target_cvr }} -o jsonpath='{.spec.targetIP}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: target_ip
+         failed_when: 'target_ip.stdout == ""'
+
+        ## Execute the chaos util to turn off the target node
+       - include_tasks: "{{ chaos_util_path }}"
+         vars:
+           esx_ip: "{{ host_ip }}"
+           target_node: "{{ target_cvr_node.stdout }}"
+           operation: "off"
+         when: platform == 'vmware'
+
+       - name: Check the node status
+         shell: kubectl get nodes {{ target_cvr_node.stdout }} --no-headers
+         args:
+           executable: /bin/bash
+         register: state
+         until: "'NotReady' in state.stdout"
+         delay: 30
+         retries: 15
+
+       - name: Replace the node-name annotation in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "node_name"
+           replace: "{{ target_node }}"
+
+       - name: Replace the target ip annotations in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "target_ip"
+           replace: "{{ target_ip.stdout }}"
+
+       - name: Replace the replica id in CVR spec configuration
+         replace:
+           path: cvr.yaml
+           regexp: "replica_id"
+           replace: "{{ replica_id.stdout }}"
+
+       - name: Replace the initial capacity annotaion in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "initial_capacity"
+           replace: "{{ initial_capacity.stdout }}"
+
+       - name: Replace the cvr name in cvr spec configuration
+         replace:
+           path: cvr.yaml
+           regexp: "cstor_volume_name-csp_name"
+           replace: "{{ cv_name.stdout }}-{{ csp_name.stdout }}"
+
+       - name: Replace the csp name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "csp_name"
+           replace: "{{ csp_name.stdout }}"
+
+       - name: Replace the csp uid in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "csp_uid"
+           replace: "{{ csp_uid.stdout }}"
+
+       - name: Replace the cstor volume name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "cstor_volume_name"
+           replace: "{{ cv_name.stdout }}"
+
+       - name: Replace the persistent volume name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "pv_name"
+           replace: "{{ pv.stdout }}"
+
+       - name: Replace the storage class name in cvr yaml
+         replace:
+           path: cvr.yaml
+           regexp: "storage_class_name"
+           replace: "{{ sc_name.stdout }}"
+
+       - name: Apply the cvr yaml to migrate the cvr to new pool
+         shell: kubectl apply -f cvr.yaml
+         args:
+           executable: /bin/bash
+
+       - name: Check if the migrated new CVR is in healthy state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o jsonpath='{.items[?(@.metadata.annotations.cstorpool\.openebs\.io/hostname=="{{ target_node }}")].status.phase}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: new_cvr_status
+         until: "((new_cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in new_cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+        # Turn on the k8s node
+       - include_tasks: "{{ chaos_util_path }}"
+         vars:
+           esx_ip: "{{ host_ip }}"
+           target_node: "{{ target_cvr_node.stdout }}"
+           operation: "on"
+         when: platform == 'vmware'
+
+       - name: Check the node status
+         shell: kubectl get nodes {{ target_cvr_node.stdout }} --no-headers
+         args:
+           executable: /bin/bash
+         register: node_state
+         until: "'NotReady' not in node_state.stdout"
+         delay: 30
+         retries: 15
+
+       - name: Check if the old cvr is in OFFLINE state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o jsonpath='{.items[?(@.metadata.annotations.cstorpool\.openebs\.io/hostname=="{{ target_cvr_node.stdout }}")].status.phase}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: old_cvr_status
+         until: "((old_cvr_status.stdout_lines|unique)|length) == 1 and 'Offline' in old_cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Remove the old cvr to migrate
+         shell: kubectl delete cvr -n {{ operator_ns }} {{ target_cvr }}
+         args:
+           executable: /bin/bash
+
+       - name: Check if the cvr got removed
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: new_cvr_list
+         until: "target_cvr not in new_cvr_list.stdout"
+         delay: 5
+         retries: 30
+
+       - name: Verify application data persistence
+         include: "{{ data_consistency_util_path }}"
+         vars:
+           status: 'VERIFY'
+           ns: "{{ app_namespace }}"
+           pod_name: "{{ app_pod_name.stdout }}"
+         when: data_persistence != ''
+
+       - name: Obtain the new replica id value from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }}
+           -o custom-columns=:.status.replicaDetails.knownReplicas.{{ replica_id.stdout }} --no-headers
+         args:
+           executable: /bin/bash
+         register: new_rid_value
+         until: "new_rid_value.stdout != rid_value.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the ReplicationFactor after cvr migration and compare with replication factor obtained before migrate cvr
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.replicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_rf
+         failed_when: "after_rf.stdout != rf.stdout"
+
+       - name: Obtain the consistencyFactor after cvr migration and compare with consistency factor obtained before migrate cvr
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.consistencyFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_cf
+         failed_when: "after_cf.stdout != cf.stdout"
+
+       - name: Obtain the desiredReplicationFactor after cvr migration and compare with desiredReplication factor obtained before migrate cvr
+         shell: >
+           kubectl get cstorvolume {{ cv_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.desiredReplicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_drf
+         failed_when: "after_drf.stdout != drf.stdout"
+
+       - name: Get istgt target pod details
+         shell: >
+           kubectl get pods  -l openebs.io/persistent-volume={{ pv.stdout }}
+           -n {{ operator_ns }} -o custom-columns=:metadata.name --no-headers
+         register: istgt_replica
+         failed_when: 'istgt_replica.stdout == ""'
+
+       - name: Create an empty list of replica pods.
+         set_fact:
+           cstor_replicas_pod : []
+
+       - name: Obtaining the pool deployments from cvr
+         shell: >
+            kubectl get cvr -n {{ operator_ns }}
+            -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+         args:
+            executable: /bin/bash
+         register: pool_deployment
+         failed_when: 'pool_deployment.stdout == ""'
+
+       - name: Obtaining the pool pods
+         shell: >
+           kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool={{ item }}
+           -n {{ operator_ns }} --no-headers -o custom-columns=:.metadata.name
+         register: pool_pods
+         failed_when: 'pool_pods.stdout == ""'
+         with_items:
+           - "{{ pool_deployment.stdout_lines }}"
+
+       - name: Build a list of replica pods
+         set_fact:
+           cstor_replicas_pod : "{{ cstor_replicas_pod }} + [ '{{ item.stdout }}' ]"
+         with_items: "{{ pool_pods.results }}"
+
+       - name: Generate snapshot name
+         shell: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
+         register: snapname
+
+       - set_fact:
+           snap_name: "{{ snapname.stdout }}"
+
+       - name: Take snapshot for data verification
+         shell: >
+            kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} 
+            --container  cstor-istgt -- istgtcontrol snapcreate {{ pv.stdout }} {{ snap_name }} 30 30
+         register: snap_status
+
+       - name: Install netcat on current host
+         shell: apt-get update && apt-get -y install netcat iproute2
+         register: dataset
+
+       - include: /chaoslib/openebs/fetch_data_from_replica.yml
+         loop: "{{ cstor_replicas_pod }}"
+         loop_control:
+           loop_var: rpod
+
+       - set_fact:
+            base_replica: "{{ cstor_replicas_pod | list | first }}"
+
+       - name: compare data object
+         shell: diff {{ rpod }}.1.dump {{ base_replica }}.1.dump
+         loop: "{{ cstor_replicas_pod }}"
+         loop_control:
+           loop_var: rpod
+
+       - name: compare meta data object
+         shell: diff {{ rpod }}.3.dump {{ base_replica }}.3.dump
+         loop: "{{ cstor_replicas_pod }}"
+         loop_control:
+            loop_var: rpod
+
+       - name: Destroy snapshot created for data verification
+         shell: >
+           kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }}
+           --container  cstor-istgt -- istgtcontrol snapdestroy {{ pv.stdout }} {{ snap_name }} 30 30
+         register: snap_status
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue:
+
+        # Turn on the k8s node
+       - include_tasks: "{{ chaos_util_path }}"
+         vars:
+           esx_ip: "{{ host_ip }}"
+           target_node: "{{ target_cvr_node.stdout }}"
+           operation: "on"
+         when: platform == 'vmware'
+
+       - set_fact:
+           flag: "Fail"
+
+     always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/chaos/replace_cvr_by_node_failure/test_vars.yml
+++ b/experiments/chaos/replace_cvr_by_node_failure/test_vars.yml
@@ -1,0 +1,20 @@
+---
+# Test specific parameters
+
+test_name: replace-cvr-by-node-failure
+
+app_namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+label: "{{ lookup('env','APP_LABEL') }}"
+
+platform: "{{ lookup('env','PLATFORM') }}"
+
+host_ip: "{{ lookup('env','ESX_HOST_IP') }}"
+
+esx_pwd: "{{ lookup('env','ESX_PASSWORD') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:


```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Jul  9 2019, 16:51:35) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/replace_cvr_by_node_failure/test.yml

PLAY [localhost] ***************************************************************
2019-11-04T13:29:03.268846 (delta: 0.099656)         elapsed: 0.099656 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:3
2019-11-04T13:29:03.291830 (delta: 0.022924)         elapsed: 0.12264 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:14
2019-11-04T13:29:12.528771 (delta: 9.236896)         elapsed: 9.359581 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-04T13:29:12.705249 (delta: 0.176357)         elapsed: 9.536059 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-04T13:29:12.783385 (delta: 0.07808)         elapsed: 9.614195 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:16
2019-11-04T13:29:12.850074 (delta: 0.066613)         elapsed: 9.680884 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-04T13:29:13.030218 (delta: 0.180091)         elapsed: 9.861028 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "91aa76ba97781f06e98176d0dec05e22f31a62a7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1e984fc32b581f0874c538614a6c1748", "mode": "0644", "owner": "root", "size": 452, "src": "/root/.ansible/tmp/ansible-tmp-1572874153.1-52618801750312/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-04T13:29:13.946809 (delta: 0.916498)         elapsed: 10.777619 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.887257", "end": "2019-11-04 13:29:15.211474", "rc": 0, "start": "2019-11-04 13:29:14.324217", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: replace-cvr-by-node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: replace-cvr-node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: replace-cvr-by-node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: replace-cvr-node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-04T13:29:15.282474 (delta: 1.33561)         elapsed: 12.113284 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-04T13:29:16Z", "generation": 1, "name": "replace-cvr-by-node-failure", "namespace": "", "resourceVersion": "113777", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/replace-cvr-by-node-failure", "uid": "1941197c-ff07-11e9-ab94-005056985d69"}, "spec": {"testMetadata": {"app": null, "chaostype": "replace-cvr-node-failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-04T13:29:16.614689 (delta: 1.332158)         elapsed: 13.445499 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-04T13:29:16.684624 (delta: 0.069881)         elapsed: 13.515434 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-04T13:29:16.747992 (delta: 0.063306)         elapsed: 13.578802 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:22
2019-11-04T13:29:16.812302 (delta: 0.064259)         elapsed: 13.643112 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "c3d158e37e6690e06d2df05aaab730ac04f28e26", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "bf958392dd91677ad0cb84dfd8db23cf", "mode": "0644", "owner": "root", "size": 59, "src": "/root/.ansible/tmp/ansible-tmp-1572874156.87-138948128188720/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:27
2019-11-04T13:29:17.282414 (delta: 0.47006)         elapsed: 14.113224 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "chaoslib/vmware_chaos/vm_power_operations.yml"}, "ansible_included_var_files": ["/experiments/chaos/replace_cvr_by_node_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:30
2019-11-04T13:29:17.373840 (delta: 0.091345)         elapsed: 14.20465 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/vmware_chaos/vm_power_operations.yml"}, "changed": false}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:34
2019-11-04T13:29:17.462647 (delta: 0.088752)         elapsed: 14.293457 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1572874157.51-507841422138/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:39
2019-11-04T13:29:17.924084 (delta: 0.461381)         elapsed: 14.754894 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/replace_cvr_by_node_failure/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:42
2019-11-04T13:29:18.028805 (delta: 0.104635)         elapsed: 14.859615 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [Verify if the application is running.] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:48
2019-11-04T13:29:18.167972 (delta: 0.139102)         elapsed: 14.998782 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-11-04T13:29:18.298557 (delta: 0.130524)         elapsed: 15.129367 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.250513", "end": "2019-11-04 13:29:19.769748", "rc": 0, "start": "2019-11-04 13:29:18.519235", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-11-04T13:27:43Z]]", "stdout_lines": ["map[running:map[startedAt:2019-11-04T13:27:43Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-11-04T13:29:19.865989 (delta: 1.56733)         elapsed: 16.696799 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.156071", "end": "2019-11-04 13:29:21.260053", "rc": 0, "start": "2019-11-04 13:29:20.103982", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:58
2019-11-04T13:29:21.376775 (delta: 1.510723)         elapsed: 18.207585 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.165389", "end": "2019-11-04 13:29:22.828996", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:21.663607", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-lqdbw", "stdout_lines": ["app-busybox-546d66979-lqdbw"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:67
2019-11-04T13:29:22.983015 (delta: 1.606135)         elapsed: 19.813825 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-11-04T13:29:23.200503 (delta: 0.217366)         elapsed: 20.031313 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-lqdbw -n app-busybox-ns -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:02.845725", "end": "2019-11-04 13:29:26.399327", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-11-04 13:29:23.553602", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.038307 seconds, 104.4MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.038307 seconds, 104.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-lqdbw -n app-busybox-ns -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:01.608091", "end": "2019-11-04 13:29:28.200024", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-11-04 13:29:26.591933", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-11-04T13:29:28.280497 (delta: 5.079936)         elapsed: 25.111307 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-11-04T13:29:28.358340 (delta: 0.077792)         elapsed: 25.18915 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-11-04T13:29:28.438248 (delta: 0.079842)         elapsed: 25.269058 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-11-04T13:29:28.501725 (delta: 0.063421)         elapsed: 25.332535 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-11-04T13:29:28.573342 (delta: 0.071563)         elapsed: 25.404152 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-11-04T13:29:28.655362 (delta: 0.081957)         elapsed: 25.486172 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-11-04T13:29:28.736758 (delta: 0.081328)         elapsed: 25.567568 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-11-04T13:29:28.834953 (delta: 0.098134)         elapsed: 25.665763 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-11-04T13:29:28.917953 (delta: 0.082919)         elapsed: 25.748763 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-11-04T13:29:28.988625 (delta: 0.070616)         elapsed: 25.819435 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get Application pod Node to perform chaos] *******************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:76
2019-11-04T13:29:29.061433 (delta: 0.072758)         elapsed: 25.892243 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod app-busybox-546d66979-lqdbw -n app-busybox-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.509368", "end": "2019-11-04 13:29:30.855339", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:29.345971", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node2.mayalabs.io", "stdout_lines": ["gitlab-node2.mayalabs.io"]}

TASK [Obtain the Persistent Volume name] ***************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:85
2019-11-04T13:29:30.973356 (delta: 1.911853)         elapsed: 27.804166 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.073021", "end": "2019-11-04 13:29:32.288240", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:31.215219", "stderr": "", "stderr_lines": [], "stdout": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69", "stdout_lines": ["pvc-bd647d2b-ff06-11e9-ab94-005056985d69"]}

TASK [Obtain the StorageClass name from PVC] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:92
2019-11-04T13:29:32.380089 (delta: 1.406624)         elapsed: 29.210899 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:01.234858", "end": "2019-11-04 13:29:33.906471", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:32.671613", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Get the cStorVolume name] ************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:99
2019-11-04T13:29:34.013373 (delta: 1.633223)         elapsed: 30.844183 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:02.357972", "end": "2019-11-04 13:29:36.723539", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:34.365567", "stderr": "", "stderr_lines": [], "stdout": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69", "stdout_lines": ["pvc-bd647d2b-ff06-11e9-ab94-005056985d69"]}

TASK [Check if the CVRs in healthy state] **************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:108
2019-11-04T13:29:36.826497 (delta: 2.813038)         elapsed: 33.657307 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:02.209779", "end": "2019-11-04 13:29:39.286941", "rc": 0, "start": "2019-11-04 13:29:37.077162", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Obtain the total number of cvr] ******************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:119
2019-11-04T13:29:39.437120 (delta: 2.610569)         elapsed: 36.26793 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs --no-headers -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 | wc -l", "delta": "0:00:01.301462", "end": "2019-11-04 13:29:41.128723", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:39.827261", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the ReplicationFactor from cstorvolume and check if it is equal to the cvr count] ***
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:126
2019-11-04T13:29:41.278275 (delta: 1.841065)         elapsed: 38.109085 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o jsonpath='{.spec.replicationFactor}{\"\\n\"}'", "delta": "0:00:01.187724", "end": "2019-11-04 13:29:42.802176", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:41.614452", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the consistencyFactor from cstorvolume] ***************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:134
2019-11-04T13:29:42.876748 (delta: 1.598352)         elapsed: 39.707558 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o jsonpath='{.spec.consistencyFactor}{\"\\n\"}'", "delta": "0:00:01.176337", "end": "2019-11-04 13:29:44.255996", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:43.079659", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the desiredReplicationFactor from cstorvolume] ********************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:142
2019-11-04T13:29:44.339149 (delta: 1.46235)         elapsed: 41.169959 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o jsonpath='{.spec.desiredReplicationFactor}{\"\\n\"}'", "delta": "0:00:02.246532", "end": "2019-11-04 13:29:46.783775", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:44.537243", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the node name for the cvr] *******************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:150
2019-11-04T13:29:46.866543 (delta: 2.52734)         elapsed: 43.697353 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}'", "delta": "0:00:01.264458", "end": "2019-11-04 13:29:48.352625", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:47.088167", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node3.mayalabs.io", "gitlab-node1.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Obtain the List of CVR's that not scheduled in application node] *********
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:159
2019-11-04T13:29:48.426928 (delta: 1.560308)         elapsed: 45.257738 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o jsonpath='{range .items[?(@.metadata.annotations.cstorpool\\.openebs\\.io/hostname!=\"gitlab-node2.mayalabs.io\")]}{.metadata.name}{\"\\n\"}'", "delta": "0:00:01.306558", "end": "2019-11-04 13:29:49.945833", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:48.639275", "stderr": "", "stderr_lines": [], "stdout": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3\npvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-urb3\npvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-xy6m", "stdout_lines": ["pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3", "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-urb3", "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-xy6m"]}

TASK [Select random cvr from the list of cvr as target cvr to migrate] *********
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:168
2019-11-04T13:29:50.098386 (delta: 1.671403)         elapsed: 46.929196 ******* 
ok: [127.0.0.1] => (item=pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3) => {"ansible_facts": {"target_cvr": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3"}, "changed": false, "item": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3"}

TASK [Obtain the node name for the target cvr to perform the chaos] ************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:173
2019-11-04T13:29:50.323239 (delta: 0.224749)         elapsed: 47.154049 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3 -o=jsonpath='{.items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}'", "delta": "0:00:01.299804", "end": "2019-11-04 13:29:51.904711", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:50.604907", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node3.mayalabs.io", "stdout_lines": ["gitlab-node3.mayalabs.io"]}

TASK [Obtain the replica id from the selected replica] *************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:182
2019-11-04T13:29:52.058205 (delta: 1.734911)         elapsed: 48.889015 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3 --no-headers -o custom-columns=:.spec.replicaid", "delta": "0:00:01.339077", "end": "2019-11-04 13:29:53.693998", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:52.354921", "stderr": "", "stderr_lines": [], "stdout": "3FD14D263BCF83EF4F1FD13DF50A65B1", "stdout_lines": ["3FD14D263BCF83EF4F1FD13DF50A65B1"]}

TASK [Obtain the knownreplica id value from the cstor volume] ******************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:189
2019-11-04T13:29:53.821315 (delta: 1.763014)         elapsed: 50.652125 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o custom-columns=:.status.replicaDetails.knownReplicas.3FD14D263BCF83EF4F1FD13DF50A65B1 --no-headers", "delta": "0:00:01.214652", "end": "2019-11-04 13:29:55.511559", "rc": 0, "start": "2019-11-04 13:29:54.296907", "stderr": "", "stderr_lines": [], "stdout": "10965578580558807408", "stdout_lines": ["10965578580558807408"]}

TASK [Obtain the csp name from targeted cvr] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:200
2019-11-04T13:29:55.629650 (delta: 1.808201)         elapsed: 52.46046 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3 -o jsonpath='{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}'", "delta": "0:00:01.132222", "end": "2019-11-04 13:29:57.173427", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:56.041205", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-qav3", "stdout_lines": ["cstor-block-disk-pool-qav3"]}

TASK [Obtain the SPC name from csp] ********************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:208
2019-11-04T13:29:57.245216 (delta: 1.615486)         elapsed: 54.076026 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-qav3 -o jsonpath='{.metadata.labels.openebs\\.io\\/storage-pool-claim}{\"\\n\"}'", "delta": "0:00:01.294376", "end": "2019-11-04 13:29:58.792670", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:57.498294", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool", "stdout_lines": ["cstor-block-disk-pool"]}

TASK [Getting the list of csp node name correspond to provided spc] ************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:216
2019-11-04T13:29:58.920811 (delta: 1.67554)         elapsed: 55.751621 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:01.263078", "end": "2019-11-04 13:30:00.567824", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:59.304746", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node4.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node4.mayalabs.io", "gitlab-node2.mayalabs.io", "gitlab-node3.mayalabs.io", "gitlab-node1.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Create a file to store CSP name] *****************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:223
2019-11-04T13:30:00.641054 (delta: 1.720153)         elapsed: 57.471864 ******* 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u'kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o=jsonpath=\'{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{"\\n"}{end}\'', u'end': u'2019-11-04 13:30:00.567824', u'stdout': u'gitlab-node4.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io', u'changed': True, 'failed': False, u'delta': u'0:00:01.263078', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'gitlab-node4.mayalabs.io', u'gitlab-node2.mayalabs.io', u'gitlab-node3.mayalabs.io', u'gitlab-node1.mayalabs.io', u'gitlab-node5.mayalabs.io'], 'failed_when_result': False, u'start': u'2019-11-04 13:29:59.304746'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool -o=jsonpath='{range .items[*]}{.metadata.labels.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:01.263078", "end": "2019-11-04 13:30:00.567824", "failed": false, "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:29:59.304746", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node4.mayalabs.io\ngitlab-node2.mayalabs.io\ngitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node4.mayalabs.io", "gitlab-node2.mayalabs.io", "gitlab-node3.mayalabs.io", "gitlab-node1.mayalabs.io", "gitlab-node5.mayalabs.io"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the list of nodes cvr is created] ********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:233
2019-11-04T13:30:01.259062 (delta: 0.617954)         elapsed: 58.089872 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:01.330521", "end": "2019-11-04 13:30:02.845870", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:01.515349", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node3.mayalabs.io", "gitlab-node1.mayalabs.io", "gitlab-node5.mayalabs.io"]}

TASK [Create a file to store CSP name] *****************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:240
2019-11-04T13:30:02.927640 (delta: 1.668496)         elapsed: 59.75845 ******** 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u'kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o=jsonpath=\'{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{"\\n"}{end}\'', u'end': u'2019-11-04 13:30:02.845870', u'stdout': u'gitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io', u'changed': True, 'failed': False, u'delta': u'0:00:01.330521', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'gitlab-node3.mayalabs.io', u'gitlab-node1.mayalabs.io', u'gitlab-node5.mayalabs.io'], 'failed_when_result': False, u'start': u'2019-11-04 13:30:01.515349'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpool\\.openebs\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:01.330521", "end": "2019-11-04 13:30:02.845870", "failed": false, "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:01.515349", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node3.mayalabs.io\ngitlab-node1.mayalabs.io\ngitlab-node5.mayalabs.io", "stdout_lines": ["gitlab-node3.mayalabs.io", "gitlab-node1.mayalabs.io", "gitlab-node5.mayalabs.io"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the node name of the csp where no cvr is created] ****************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:250
2019-11-04T13:30:03.243338 (delta: 0.315642)         elapsed: 60.074148 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat csp_all.tmp | tr \" \" \"\\n\" > csp_all\n cat csp_cvr.tmp | tr \" \" \"\\n\" > csp_cvr\n comm -3 <(sort csp_all) <(sort csp_cvr)", "delta": "0:00:01.187636", "end": "2019-11-04 13:30:04.714904", "rc": 0, "start": "2019-11-04 13:30:03.527268", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node2.mayalabs.io\ngitlab-node4.mayalabs.io", "stdout_lines": ["gitlab-node2.mayalabs.io", "gitlab-node4.mayalabs.io"]}

TASK [Select random node from the list of nodes as target node] ****************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:259
2019-11-04T13:30:04.786158 (delta: 1.542755)         elapsed: 61.616968 ******* 
ok: [127.0.0.1] => (item=gitlab-node4.mayalabs.io) => {"ansible_facts": {"target_node": "gitlab-node4.mayalabs.io"}, "changed": false, "item": "gitlab-node4.mayalabs.io"}

TASK [Obtain the CSP from the targeted node] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:265
2019-11-04T13:30:04.958170 (delta: 0.171939)         elapsed: 61.78898 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l kubernetes.io/hostname=gitlab-node4.mayalabs.io,openebs.io/storage-pool-claim=cstor-block-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.278134", "end": "2019-11-04 13:30:06.491010", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:05.212876", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-9cbn", "stdout_lines": ["cstor-block-disk-pool-9cbn"]}

TASK [Get the csp id] **********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:274
2019-11-04T13:30:06.619152 (delta: 1.660922)         elapsed: 63.449962 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-9cbn --no-headers -o custom-columns=:.metadata.uid", "delta": "0:00:02.303273", "end": "2019-11-04 13:30:09.229763", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:06.926490", "stderr": "", "stderr_lines": [], "stdout": "5ed40387-ff06-11e9-ab94-005056985d69", "stdout_lines": ["5ed40387-ff06-11e9-ab94-005056985d69"]}

TASK [Obtain the Initial capacity of the target] *******************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:281
2019-11-04T13:30:09.312709 (delta: 2.693465)         elapsed: 66.143519 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3 -o jsonpath='{.spec.capacity}{\"\\n\"}'", "delta": "0:00:01.343228", "end": "2019-11-04 13:30:11.041519", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:09.698291", "stderr": "", "stderr_lines": [], "stdout": "5G", "stdout_lines": ["5G"]}

TASK [Get the target ip] *******************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:288
2019-11-04T13:30:11.150650 (delta: 1.837879)         elapsed: 67.98146 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3 -o jsonpath='{.spec.targetIP}{\"\\n\"}'", "delta": "0:00:01.251940", "end": "2019-11-04 13:30:12.648185", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:11.396245", "stderr": "", "stderr_lines": [], "stdout": "172.24.162.63", "stdout_lines": ["172.24.162.63"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:297
2019-11-04T13:30:12.764837 (delta: 1.614116)         elapsed: 69.595647 ******* 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2019-11-04T13:30:13.056418 (delta: 0.291494)         elapsed: 69.887228 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p c10udbyt3@1658 ssh -o StrictHostKeyChecking=no root@10.23.1.1 vim-cmd vmsvc/getallvms | grep gitlab-node3.mayalabs.io | awk '{print $1}'", "delta": "0:00:02.410506", "end": "2019-11-04 13:30:15.770913", "rc": 0, "start": "2019-11-04 13:30:13.360407", "stderr": "Warning: Permanently added '10.23.1.1' (RSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '10.23.1.1' (RSA) to the list of known hosts."], "stdout": "5", "stdout_lines": ["5"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2019-11-04T13:30:15.917824 (delta: 2.861323)         elapsed: 72.748634 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p c10udbyt3@1658 ssh -o StrictHostKeyChecking=no root@10.23.1.1 vim-cmd vmsvc/power.off 5", "delta": "0:00:03.568193", "end": "2019-11-04 13:30:19.977332", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:30:16.409139", "stderr": "", "stderr_lines": [], "stdout": "Powering off VM:", "stdout_lines": ["Powering off VM:"]}

TASK [Check the node status] ***************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:304
2019-11-04T13:30:20.164487 (delta: 4.246576)         elapsed: 76.995297 ******* 
FAILED - RETRYING: Check the node status (15 retries left).
FAILED - RETRYING: Check the node status (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get nodes gitlab-node3.mayalabs.io --no-headers", "delta": "0:00:01.183727", "end": "2019-11-04 13:31:25.703164", "rc": 0, "start": "2019-11-04 13:31:24.519437", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node3.mayalabs.io   NotReady   compute   244d   v1.10.0+b81c8f8", "stdout_lines": ["gitlab-node3.mayalabs.io   NotReady   compute   244d   v1.10.0+b81c8f8"]}

TASK [Replace the node-name annotation in cvr yaml] ****************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:313
2019-11-04T13:31:25.806260 (delta: 65.641714)         elapsed: 142.63707 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the target ip annotations in cvr yaml] ***************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:319
2019-11-04T13:31:26.417473 (delta: 0.611128)         elapsed: 143.248283 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the replica id in CVR spec configuration] ************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:325
2019-11-04T13:31:26.685665 (delta: 0.26814)         elapsed: 143.516475 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the initial capacity annotaion in cvr yaml] **********************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:331
2019-11-04T13:31:27.038325 (delta: 0.352607)         elapsed: 143.869135 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the cvr name in cvr spec configuration] **************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:337
2019-11-04T13:31:27.341433 (delta: 0.30302)         elapsed: 144.172243 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the csp name in cvr yaml] ****************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:343
2019-11-04T13:31:27.678839 (delta: 0.337343)         elapsed: 144.509649 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the csp uid in cvr yaml] *****************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:349
2019-11-04T13:31:28.005818 (delta: 0.326884)         elapsed: 144.836628 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the cstor volume name in cvr yaml] *******************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:355
2019-11-04T13:31:28.335204 (delta: 0.329306)         elapsed: 145.166014 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the persistent volume name in cvr yaml] **************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:361
2019-11-04T13:31:28.645993 (delta: 0.310706)         elapsed: 145.476803 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the storage class name in cvr yaml] ******************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:367
2019-11-04T13:31:29.078760 (delta: 0.4327)         elapsed: 145.90957 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Apply the cvr yaml to migrate the cvr to new pool] ***********************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:373
2019-11-04T13:31:29.374826 (delta: 0.295983)         elapsed: 146.205636 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cvr.yaml", "delta": "0:00:01.491655", "end": "2019-11-04 13:31:31.133123", "rc": 0, "start": "2019-11-04 13:31:29.641468", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io/pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-9cbn created", "stdout_lines": ["cstorvolumereplica.openebs.io/pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-9cbn created"]}

TASK [Check if the migrated new CVR is in healthy state] ***********************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:378
2019-11-04T13:31:31.208108 (delta: 1.833223)         elapsed: 148.038918 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o jsonpath='{.items[?(@.metadata.annotations.cstorpool\\.openebs\\.io/hostname==\"gitlab-node4.mayalabs.io\")].status.phase}{\"\\n\"}'", "delta": "0:00:01.108952", "end": "2019-11-04 13:31:32.536602", "rc": 0, "start": "2019-11-04 13:31:31.427650", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:390
2019-11-04T13:31:32.639652 (delta: 1.431482)         elapsed: 149.470462 ****** 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2019-11-04T13:31:32.930276 (delta: 0.290559)         elapsed: 149.761086 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p c10udbyt3@1658 ssh -o StrictHostKeyChecking=no root@10.23.1.1 vim-cmd vmsvc/getallvms | grep gitlab-node3.mayalabs.io | awk '{print $1}'", "delta": "0:00:02.269106", "end": "2019-11-04 13:31:35.422505", "rc": 0, "start": "2019-11-04 13:31:33.153399", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2019-11-04T13:31:35.527902 (delta: 2.597562)         elapsed: 152.358712 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p c10udbyt3@1658 ssh -o StrictHostKeyChecking=no root@10.23.1.1 vim-cmd vmsvc/power.on 5", "delta": "0:00:03.197911", "end": "2019-11-04 13:31:39.132343", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:31:35.934432", "stderr": "", "stderr_lines": [], "stdout": "Powering on VM:", "stdout_lines": ["Powering on VM:"]}

TASK [Check the node status] ***************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:397
2019-11-04T13:31:39.278810 (delta: 3.75084)         elapsed: 156.10962 ******** 
FAILED - RETRYING: Check the node status (15 retries left).
FAILED - RETRYING: Check the node status (14 retries left).


changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get nodes gitlab-node3.mayalabs.io --no-headers", "delta": "0:00:01.255933", "end": "2019-11-04 13:32:43.687109", "rc": 0, "start": "2019-11-04 13:32:42.431176", "stderr": "", "stderr_lines": [], "stdout": "gitlab-node3.mayalabs.io   Ready   compute   244d   v1.10.0+b81c8f8", "stdout_lines": ["gitlab-node3.mayalabs.io   Ready   compute   244d   v1.10.0+b81c8f8"]}

TASK [Check if the old cvr is in OFFLINE state] ********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:406
2019-11-04T13:32:43.765052 (delta: 64.486146)         elapsed: 220.595862 ***** 
FAILED - RETRYING: Check if the old cvr is in OFFLINE state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o jsonpath='{.items[?(@.metadata.annotations.cstorpool\\.openebs\\.io/hostname==\"gitlab-node3.mayalabs.io\")].status.phase}{\"\\n\"}'", "delta": "0:00:01.059407", "end": "2019-11-04 13:32:56.587057", "rc": 0, "start": "2019-11-04 13:32:55.527650", "stderr": "", "stderr_lines": [], "stdout": "Offline", "stdout_lines": ["Offline"]}

TASK [Remove the old cvr to migrate] *******************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:417
2019-11-04T13:32:56.697367 (delta: 12.932264)         elapsed: 233.528177 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete cvr -n openebs pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3", "delta": "0:00:29.400718", "end": "2019-11-04 13:33:26.431629", "rc": 0, "start": "2019-11-04 13:32:57.030911", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io \"pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3\" deleted", "stdout_lines": ["cstorvolumereplica.openebs.io \"pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-qav3\" deleted"]}

TASK [Check if the cvr got removed] ********************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:422
2019-11-04T13:33:26.510642 (delta: 29.813184)         elapsed: 263.341452 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:02.082982", "end": "2019-11-04 13:33:28.808299", "rc": 0, "start": "2019-11-04 13:33:26.725317", "stderr": "", "stderr_lines": [], "stdout": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-9cbn\npvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-urb3\npvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-xy6m", "stdout_lines": ["pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-9cbn", "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-urb3", "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-cstor-block-disk-pool-xy6m"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:433
2019-11-04T13:33:28.878423 (delta: 2.367726)         elapsed: 265.709233 ****** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-11-04T13:33:29.054772 (delta: 0.176297)         elapsed: 265.885582 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-11-04T13:33:29.138961 (delta: 0.084126)         elapsed: 265.969771 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-546d66979-lqdbw -n app-busybox-ns", "delta": "0:00:41.767262", "end": "2019-11-04 13:34:11.146760", "rc": 0, "start": "2019-11-04 13:33:29.379498", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-546d66979-lqdbw\" deleted", "stdout_lines": ["pod \"app-busybox-546d66979-lqdbw\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-11-04T13:34:11.237253 (delta: 42.09824)         elapsed: 308.068063 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns", "delta": "0:00:01.291305", "end": "2019-11-04 13:34:12.814563", "rc": 0, "start": "2019-11-04 13:34:11.523258", "stderr": "", "stderr_lines": [], "stdout": "NAME                          READY   STATUS              RESTARTS   AGE\napp-busybox-546d66979-64vsl   0/1     ContainerCreating   0          42s", "stdout_lines": ["NAME                          READY   STATUS              RESTARTS   AGE", "app-busybox-546d66979-64vsl   0/1     ContainerCreating   0          42s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-11-04T13:34:12.973147 (delta: 1.735816)         elapsed: 309.803957 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.313612", "end": "2019-11-04 13:34:14.600188", "rc": 0, "start": "2019-11-04 13:34:13.286576", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-64vsl", "stdout_lines": ["app-busybox-546d66979-64vsl"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-11-04T13:34:14.668048 (delta: 1.694835)         elapsed: 311.498858 ****** 
FAILED - RETRYING: Checking application pod is in running state (150 retries left).
FAILED - RETRYING: Checking application pod is in running state (149 retries left).
FAILED - RETRYING: Checking application pod is in running state (148 retries left).
FAILED - RETRYING: Checking application pod is in running state (147 retries left).
FAILED - RETRYING: Checking application pod is in running state (146 retries left).
FAILED - RETRYING: Checking application pod is in running state (145 retries left).
FAILED - RETRYING: Checking application pod is in running state (144 retries left).
FAILED - RETRYING: Checking application pod is in running state (143 retries left).
FAILED - RETRYING: Checking application pod is in running state (142 retries left).
FAILED - RETRYING: Checking application pod is in running state (141 retries left).
changed: [127.0.0.1] => {"attempts": 11, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-64vsl\")].status.phase}'", "delta": "0:00:01.460308", "end": "2019-11-04 13:34:51.222076", "rc": 0, "start": "2019-11-04 13:34:49.761768", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-11-04T13:34:51.305105 (delta: 36.637001)         elapsed: 348.135915 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-64vsl\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.248475", "end": "2019-11-04 13:34:52.861741", "rc": 0, "start": "2019-11-04 13:34:51.613266", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-11-04T13:34:47Z]]", "stdout_lines": ["map[running:map[startedAt:2019-11-04T13:34:47Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-11-04T13:34:52.958940 (delta: 1.65377)         elapsed: 349.78975 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-64vsl -n app-busybox-ns -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.322837", "end": "2019-11-04 13:34:54.599465", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:34:53.276628", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-11-04T13:34:54.709629 (delta: 1.750623)         elapsed: 351.540439 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-64vsl -n app-busybox-ns -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-chaos-md5\"", "delta": "0:00:01.373586", "end": "2019-11-04 13:34:56.480241", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:34:55.106655", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-11-04T13:34:56.619453 (delta: 1.909715)         elapsed: 353.450263 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-11-04T13:34:56.778246 (delta: 0.158704)         elapsed: 353.609056 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-11-04T13:34:56.937258 (delta: 0.158921)         elapsed: 353.768068 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the new replica id value from cstorvolume] ************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:441
2019-11-04T13:34:57.079508 (delta: 0.142124)         elapsed: 353.910318 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o custom-columns=:.status.replicaDetails.knownReplicas.3FD14D263BCF83EF4F1FD13DF50A65B1 --no-headers", "delta": "0:00:01.004040", "end": "2019-11-04 13:34:58.314775", "rc": 0, "start": "2019-11-04 13:34:57.310735", "stderr": "", "stderr_lines": [], "stdout": "8593144812886376707", "stdout_lines": ["8593144812886376707"]}

TASK [Obtain the ReplicationFactor after cvr migration and compare with replication factor obtained before migrate cvr] ***
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:452
2019-11-04T13:34:58.395174 (delta: 1.315559)         elapsed: 355.225984 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o jsonpath='{.spec.replicationFactor}{\"\\n\"}'", "delta": "0:00:01.299473", "end": "2019-11-04 13:34:59.952752", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:34:58.653279", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the consistencyFactor after cvr migration and compare with consistency factor obtained before migrate cvr] ***
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:460
2019-11-04T13:35:00.041564 (delta: 1.646336)         elapsed: 356.872374 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o jsonpath='{.spec.consistencyFactor}{\"\\n\"}'", "delta": "0:00:01.194254", "end": "2019-11-04 13:35:01.529016", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:35:00.334762", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the desiredReplicationFactor after cvr migration and compare with desiredReplication factor obtained before migrate cvr] ***
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:468
2019-11-04T13:35:01.659972 (delta: 1.618308)         elapsed: 358.490782 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o jsonpath='{.spec.desiredReplicationFactor}{\"\\n\"}'", "delta": "0:00:01.327448", "end": "2019-11-04 13:35:03.320563", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:35:01.993115", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get istgt target pod details] ********************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:476
2019-11-04T13:35:03.490014 (delta: 1.829966)         elapsed: 360.320824 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 -n openebs -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.117012", "end": "2019-11-04 13:35:05.048674", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:35:03.931662", "stderr": "", "stderr_lines": [], "stdout": "pvc-bd647d2b-ff06-11e9-ab94-005056985d69-target-69d84f9999wvmp7", "stdout_lines": ["pvc-bd647d2b-ff06-11e9-ab94-005056985d69-target-69d84f9999wvmp7"]}

TASK [Create an empty list of replica pods.] ***********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:483
2019-11-04T13:35:05.156573 (delta: 1.666432)         elapsed: 361.987383 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_replicas_pod": []}, "changed": false}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:487
2019-11-04T13:35:05.294562 (delta: 0.137887)         elapsed: 362.125372 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bd647d2b-ff06-11e9-ab94-005056985d69 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.319966", "end": "2019-11-04 13:35:06.829693", "failed_when_result": false, "rc": 0, "start": "2019-11-04 13:35:05.509727", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-9cbn\ncstor-block-disk-pool-urb3\ncstor-block-disk-pool-xy6m", "stdout_lines": ["cstor-block-disk-pool-9cbn", "cstor-block-disk-pool-urb3", "cstor-block-disk-pool-xy6m"]}

TASK [Obtaining the pool pods] *************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:497
2019-11-04T13:35:06.952840 (delta: 1.658176)         elapsed: 363.78365 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-9cbn) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-9cbn -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.227927", "end": "2019-11-04 13:35:08.543004", "failed_when_result": false, "item": "cstor-block-disk-pool-9cbn", "rc": 0, "start": "2019-11-04 13:35:07.315077", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b", "stdout_lines": ["cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-urb3) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-urb3 -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.250048", "end": "2019-11-04 13:35:10.077909", "failed_when_result": false, "item": "cstor-block-disk-pool-urb3", "rc": 0, "start": "2019-11-04 13:35:08.827861", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-urb3-659948d5d9-kcvh5", "stdout_lines": ["cstor-block-disk-pool-urb3-659948d5d9-kcvh5"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-xy6m) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-xy6m -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.160585", "end": "2019-11-04 13:35:11.532397", "failed_when_result": false, "item": "cstor-block-disk-pool-xy6m", "rc": 0, "start": "2019-11-04 13:35:10.371812", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks", "stdout_lines": ["cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks"]}

TASK [Build a list of replica pods] ********************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:506
2019-11-04T13:35:11.641328 (delta: 4.688401)         elapsed: 368.472138 ****** 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b', '_ansible_item_result': True, u'delta': u'0:00:01.227927', 'stdout_lines': [u'cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b'], 'failed_when_result': False, '_ansible_item_label': u'cstor-block-disk-pool-9cbn', u'end': u'2019-11-04 13:35:08.543004', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-9cbn -n openebs --no-headers -o custom-columns=:.metadata.name', 'item': u'cstor-block-disk-pool-9cbn', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-9cbn -n openebs --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-04 13:35:07.315077', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-9cbn -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.227927", "end": "2019-11-04 13:35:08.543004", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-9cbn -n openebs --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-9cbn", "rc": 0, "start": "2019-11-04 13:35:07.315077", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b", "stdout_lines": ["cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-urb3-659948d5d9-kcvh5', '_ansible_item_result': True, u'delta': u'0:00:01.250048', 'stdout_lines': [u'cstor-block-disk-pool-urb3-659948d5d9-kcvh5'], 'failed_when_result': False, '_ansible_item_label': u'cstor-block-disk-pool-urb3', u'end': u'2019-11-04 13:35:10.077909', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-urb3 -n openebs --no-headers -o custom-columns=:.metadata.name', 'item': u'cstor-block-disk-pool-urb3', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-urb3 -n openebs --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-04 13:35:08.827861', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b", "cstor-block-disk-pool-urb3-659948d5d9-kcvh5"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-urb3 -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.250048", "end": "2019-11-04 13:35:10.077909", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-urb3 -n openebs --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-urb3", "rc": 0, "start": "2019-11-04 13:35:08.827861", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-urb3-659948d5d9-kcvh5", "stdout_lines": ["cstor-block-disk-pool-urb3-659948d5d9-kcvh5"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks', '_ansible_item_result': True, u'delta': u'0:00:01.160585', 'stdout_lines': [u'cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks'], 'failed_when_result': False, '_ansible_item_label': u'cstor-block-disk-pool-xy6m', u'end': u'2019-11-04 13:35:11.532397', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-xy6m -n openebs --no-headers -o custom-columns=:.metadata.name', 'item': u'cstor-block-disk-pool-xy6m', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-xy6m -n openebs --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-04 13:35:10.371812', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b", "cstor-block-disk-pool-urb3-659948d5d9-kcvh5", "cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-xy6m -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.160585", "end": "2019-11-04 13:35:11.532397", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-xy6m -n openebs --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-xy6m", "rc": 0, "start": "2019-11-04 13:35:10.371812", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks", "stdout_lines": ["cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks"]}}

TASK [Generate snapshot name] **************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:511
2019-11-04T13:35:11.833660 (delta: 0.192267)         elapsed: 368.66447 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1", "delta": "0:00:01.032680", "end": "2019-11-04 13:35:13.214381", "rc": 0, "start": "2019-11-04 13:35:12.181701", "stderr": "", "stderr_lines": [], "stdout": "Wk8GheIahYnQ3Ibmmff7M838C17TUDIy", "stdout_lines": ["Wk8GheIahYnQ3Ibmmff7M838C17TUDIy"]}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:515
2019-11-04T13:35:13.283131 (delta: 1.449403)         elapsed: 370.113941 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"snap_name": "Wk8GheIahYnQ3Ibmmff7M838C17TUDIy"}, "changed": false}

TASK [Take snapshot for data verification] *************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:518
2019-11-04T13:35:13.449301 (delta: 0.166114)         elapsed: 370.280111 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bd647d2b-ff06-11e9-ab94-005056985d69-target-69d84f9999wvmp7 -n openebs --container cstor-istgt -- istgtcontrol snapcreate pvc-bd647d2b-ff06-11e9-ab94-005056985d69 Wk8GheIahYnQ3Ibmmff7M838C17TUDIy 30 30", "delta": "0:00:02.378397", "end": "2019-11-04 13:35:16.091548", "rc": 0, "start": "2019-11-04 13:35:13.713151", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPCREATE command", "stdout_lines": ["DONE SNAPCREATE command"]}

TASK [Install netcat on current host] ******************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:524
2019-11-04T13:35:16.248514 (delta: 2.799127)         elapsed: 373.079324 ****** 
 [WARNING]: Consider using the apt module rather than running apt-get.  If you
need to use command because apt is insufficient you can add warn=False to this
command task or set command_warnings=False in ansible.cfg to get rid of this
message.
changed: [127.0.0.1] => {"changed": true, "cmd": "apt-get update && apt-get -y install netcat iproute2", "delta": "0:00:12.330138", "end": "2019-11-04 13:35:28.996119", "rc": 0, "start": "2019-11-04 13:35:16.665981", "stderr": "", "stderr_lines": [], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease\nGet:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]\nGet:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]\nGet:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]\nGet:5 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [9022 B]\nGet:6 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [700 kB]\nGet:7 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1303 kB]\nGet:8 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [23.2 kB]\nGet:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [995 kB]\nGet:10 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [12.6 kB]\nGet:11 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [782 kB]\nGet:12 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [4234 B]\nGet:13 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [5944 B]\nFetched 4087 kB in 7s (556 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\niproute2 is already the newest version (4.15.0-2ubuntu1).\nnetcat is already the newest version (1.10-41.1).\n0 upgraded, 0 newly installed, 0 to remove and 42 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease", "Get:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]", "Get:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]", "Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]", "Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [9022 B]", "Get:6 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [700 kB]", "Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1303 kB]", "Get:8 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [23.2 kB]", "Get:9 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [995 kB]", "Get:10 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [12.6 kB]", "Get:11 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [782 kB]", "Get:12 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [4234 B]", "Get:13 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [5944 B]", "Fetched 4087 kB in 7s (556 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "iproute2 is already the newest version (4.15.0-2ubuntu1).", "netcat is already the newest version (1.10-41.1).", "0 upgraded, 0 newly installed, 0 to remove and 42 not upgraded."]}

TASK [include] *****************************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:528
2019-11-04T13:35:29.070611 (delta: 12.821965)         elapsed: 385.901421 ***** 
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1

TASK [Get replica id] **********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:1
2019-11-04T13:35:29.352181 (delta: 0.281488)         elapsed: 386.182991 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.223253", "end": "2019-11-04 13:35:30.803011", "rc": 0, "start": "2019-11-04 13:35:29.579758", "stderr": "", "stderr_lines": [], "stdout": "5ed40387-ff06-11e9-ab94-005056985d69", "stdout_lines": ["5ed40387-ff06-11e9-ab94-005056985d69"]}

TASK [Check for dataset name] **************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:5
2019-11-04T13:35:30.953772 (delta: 1.601531)         elapsed: 387.784582 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- zfs list cstor-5ed40387-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69", "delta": "0:00:01.421031", "end": "2019-11-04 13:35:32.676016", "rc": 0, "start": "2019-11-04 13:35:31.254985", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-5ed40387-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69  4.14M  24.1G  4.12M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-5ed40387-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69  4.14M  24.1G  4.12M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:13
2019-11-04T13:35:32.837911 (delta: 1.884041)         elapsed: 389.668721 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- bash -c \"zfs send cstor-5ed40387-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy > /snap.data\"", "delta": "0:00:01.556677", "end": "2019-11-04 13:35:34.712060", "rc": 0, "start": "2019-11-04 13:35:33.155383", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:17
2019-11-04T13:35:34.797301 (delta: 1.959292)         elapsed: 391.628111 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.504484", "end": "2019-11-04 13:35:36.673956", "rc": 0, "start": "2019-11-04 13:35:35.169472", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:21
2019-11-04T13:35:36.840812 (delta: 2.043456)         elapsed: 393.671622 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:01.616908", "end": "2019-11-04 13:35:38.859188", "rc": 0, "start": "2019-11-04 13:35:37.242280", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5dc02913\n\ttype = 3\n\tflags = 0x4\n\ttoguid = d7f263a0d42857aa\n\tfromguid = 0\n\ttoname = cstor-5ed40387-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy\nEND checksum = 8507675f1044f/9dee870ee700258e/a6a664e364727a48/815e2c8aae75e20b\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 2610\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 40\n\tTotal DRR_SPILL records = 0\n\tTotal records = 2659\n\tTotal write size = 10686976 (0xa31200)\n\tTotal stream length = 11516584 (0xafbaa8)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5dc02913", "\ttype = 3", "\tflags = 0x4", "\ttoguid = d7f263a0d42857aa", "\tfromguid = 0", "\ttoname = cstor-5ed40387-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy", "END checksum = 8507675f1044f/9dee870ee700258e/a6a664e364727a48/815e2c8aae75e20b", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 2610", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 40", "\tTotal DRR_SPILL records = 0", "\tTotal records = 2659", "\tTotal write size = 10686976 (0xa31200)", "\tTotal stream length = 11516584 (0xafbaa8)"]}

TASK [Install netcat on replica pod] *******************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:25
2019-11-04T13:35:39.012550 (delta: 2.171642)         elapsed: 395.84336 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:08.432538", "end": "2019-11-04 13:35:47.876223", "rc": 0, "start": "2019-11-04 13:35:39.443685", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead.", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (This frontend requires a controlling tty.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:2 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:1 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (182 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  netcat-traditional\nThe following NEW packages will be installed:\n  netcat netcat-traditional\n0 upgraded, 2 newly installed, 0 to remove and 24 not upgraded.\nNeed to get 64.1 kB of archives.\nAfter this operation, 191 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]\nFetched 64.1 kB in 0s (73.4 kB/s)\nSelecting previously unselected package netcat-traditional.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 9575 files and directories currently installed.)\r\nPreparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...\r\nUnpacking netcat-traditional (1.10-41) ...\r\nSelecting previously unselected package netcat.\r\nPreparing to unpack .../netcat_1.10-41_all.deb ...\r\nUnpacking netcat (1.10-41) ...\r\nSetting up netcat-traditional (1.10-41) ...\r\nupdate-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode\r\nSetting up netcat (1.10-41) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:1 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (182 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  netcat-traditional", "The following NEW packages will be installed:", "  netcat netcat-traditional", "0 upgraded, 2 newly installed, 0 to remove and 24 not upgraded.", "Need to get 64.1 kB of archives.", "After this operation, 191 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]", "Fetched 64.1 kB in 0s (73.4 kB/s)", "Selecting previously unselected package netcat-traditional.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 9575 files and directories currently installed.)", "Preparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...", "Unpacking netcat-traditional (1.10-41) ...", "Selecting previously unselected package netcat.", "Preparing to unpack .../netcat_1.10-41_all.deb ...", "Unpacking netcat (1.10-41) ...", "Setting up netcat-traditional (1.10-41) ...", "update-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode", "Setting up netcat (1.10-41) ..."]}

TASK [Start receiver to receive data object from replica pod] ******************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:29
2019-11-04T13:35:48.018521 (delta: 9.005845)         elapsed: 404.849331 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "741846906346.3398", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/741846906346.3398", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:35
2019-11-04T13:35:49.249780 (delta: 1.231137)         elapsed: 406.08059 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.042745", "end": "2019-11-04 13:35:55.495732", "rc": 0, "start": "2019-11-04 13:35:49.452987", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:39
2019-11-04T13:35:55.650184 (delta: 6.400356)         elapsed: 412.480994 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.7 9090 < /1.dump\"", "delta": "0:00:07.616087", "end": "2019-11-04 13:36:03.612143", "rc": 0, "start": "2019-11-04 13:35:55.996056", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:43
2019-11-04T13:36:03.679769 (delta: 8.029499)         elapsed: 420.510579 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.154043", "end": "2019-11-04 13:36:05.101492", "rc": 0, "start": "2019-11-04 13:36:03.947449", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:47
2019-11-04T13:36:05.172299 (delta: 1.49248)         elapsed: 422.003109 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.925282", "end": "2019-11-04 13:36:11.297819", "rc": 0, "start": "2019-11-04 13:36:05.372537", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:51
2019-11-04T13:36:11.437749 (delta: 6.265395)         elapsed: 428.268559 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "78764540176.3543", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/78764540176.3543", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:57
2019-11-04T13:36:12.687405 (delta: 1.24956)         elapsed: 429.518215 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.7 9090 < /3.dump\"", "delta": "0:00:07.656754", "end": "2019-11-04 13:36:20.567889", "rc": 0, "start": "2019-11-04 13:36:12.911135", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:61
2019-11-04T13:36:20.647866 (delta: 7.960404)         elapsed: 437.478676 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.910010", "end": "2019-11-04 13:36:21.890418", "rc": 0, "start": "2019-11-04 13:36:20.980408", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:1
2019-11-04T13:36:21.982934 (delta: 1.33501)         elapsed: 438.813744 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.283163", "end": "2019-11-04 13:36:23.600472", "rc": 0, "start": "2019-11-04 13:36:22.317309", "stderr": "", "stderr_lines": [], "stdout": "5f3eecac-ff06-11e9-ab94-005056985d69", "stdout_lines": ["5f3eecac-ff06-11e9-ab94-005056985d69"]}

TASK [Check for dataset name] **************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:5
2019-11-04T13:36:23.721858 (delta: 1.738857)         elapsed: 440.552668 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- zfs list cstor-5f3eecac-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69", "delta": "0:00:01.528966", "end": "2019-11-04 13:36:25.568765", "rc": 0, "start": "2019-11-04 13:36:24.039799", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-5f3eecac-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69  4.16M  24.1G  4.12M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-5f3eecac-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69  4.16M  24.1G  4.12M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:13
2019-11-04T13:36:25.709159 (delta: 1.987211)         elapsed: 442.539969 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-5f3eecac-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy > /snap.data\"", "delta": "0:00:01.600455", "end": "2019-11-04 13:36:27.723157", "rc": 0, "start": "2019-11-04 13:36:26.122702", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:17
2019-11-04T13:36:27.798351 (delta: 2.0891)         elapsed: 444.629161 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.484691", "end": "2019-11-04 13:36:29.509421", "rc": 0, "start": "2019-11-04 13:36:28.024730", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:21
2019-11-04T13:36:29.605223 (delta: 1.806817)         elapsed: 446.436033 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:01.302748", "end": "2019-11-04 13:36:31.114544", "rc": 0, "start": "2019-11-04 13:36:29.811796", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5dc02913\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 69dc5b2777fb9bbe\n\tfromguid = 0\n\ttoname = cstor-5f3eecac-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy\nEND checksum = 847e7b0c7a0ea/dd71f132953cf2db/67542942f978796b/127dbfaa62a3cd4c\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 2610\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 40\n\tTotal DRR_SPILL records = 0\n\tTotal records = 2659\n\tTotal write size = 10686976 (0xa31200)\n\tTotal stream length = 11516584 (0xafbaa8)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5dc02913", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 69dc5b2777fb9bbe", "\tfromguid = 0", "\ttoname = cstor-5f3eecac-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy", "END checksum = 847e7b0c7a0ea/dd71f132953cf2db/67542942f978796b/127dbfaa62a3cd4c", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 2610", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 40", "\tTotal DRR_SPILL records = 0", "\tTotal records = 2659", "\tTotal write size = 10686976 (0xa31200)", "\tTotal stream length = 11516584 (0xafbaa8)"]}

TASK [Install netcat on replica pod] *******************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:25
2019-11-04T13:36:31.220524 (delta: 1.615241)         elapsed: 448.051334 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:08.478305", "end": "2019-11-04 13:36:39.945351", "rc": 0, "start": "2019-11-04 13:36:31.467046", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead.", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (This frontend requires a controlling tty.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:2 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:1 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (164 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  netcat-traditional\nThe following NEW packages will be installed:\n  netcat netcat-traditional\n0 upgraded, 2 newly installed, 0 to remove and 24 not upgraded.\nNeed to get 64.1 kB of archives.\nAfter this operation, 191 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]\nFetched 64.1 kB in 0s (74.3 kB/s)\nSelecting previously unselected package netcat-traditional.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 9575 files and directories currently installed.)\r\nPreparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...\r\nUnpacking netcat-traditional (1.10-41) ...\r\nSelecting previously unselected package netcat.\r\nPreparing to unpack .../netcat_1.10-41_all.deb ...\r\nUnpacking netcat (1.10-41) ...\r\nSetting up netcat-traditional (1.10-41) ...\r\nupdate-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode\r\nSetting up netcat (1.10-41) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:1 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (164 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  netcat-traditional", "The following NEW packages will be installed:", "  netcat netcat-traditional", "0 upgraded, 2 newly installed, 0 to remove and 24 not upgraded.", "Need to get 64.1 kB of archives.", "After this operation, 191 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]", "Fetched 64.1 kB in 0s (74.3 kB/s)", "Selecting previously unselected package netcat-traditional.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 9575 files and directories currently installed.)", "Preparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...", "Unpacking netcat-traditional (1.10-41) ...", "Selecting previously unselected package netcat.", "Preparing to unpack .../netcat_1.10-41_all.deb ...", "Unpacking netcat (1.10-41) ...", "Setting up netcat-traditional (1.10-41) ...", "update-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode", "Setting up netcat (1.10-41) ..."]}

TASK [Start receiver to receive data object from replica pod] ******************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:29
2019-11-04T13:36:40.108490 (delta: 8.887874)         elapsed: 456.9393 ******** 
changed: [127.0.0.1] => {"ansible_job_id": "667601407391.3842", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/667601407391.3842", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:35
2019-11-04T13:36:41.425523 (delta: 1.316897)         elapsed: 458.256333 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.196514", "end": "2019-11-04 13:36:47.839393", "rc": 0, "start": "2019-11-04 13:36:41.642879", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:39
2019-11-04T13:36:48.006668 (delta: 6.581055)         elapsed: 464.837478 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.7 9090 < /1.dump\"", "delta": "0:00:07.485560", "end": "2019-11-04 13:36:55.823540", "rc": 0, "start": "2019-11-04 13:36:48.337980", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:43
2019-11-04T13:36:55.893149 (delta: 7.886385)         elapsed: 472.723959 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.196412", "end": "2019-11-04 13:36:57.311775", "rc": 0, "start": "2019-11-04 13:36:56.115363", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:47
2019-11-04T13:36:57.376683 (delta: 1.483479)         elapsed: 474.207493 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.155453", "end": "2019-11-04 13:37:03.794557", "rc": 0, "start": "2019-11-04 13:36:57.639104", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:51
2019-11-04T13:37:03.928834 (delta: 6.5521)         elapsed: 480.759644 ******** 
changed: [127.0.0.1] => {"ansible_job_id": "886787113557.3986", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/886787113557.3986", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:57
2019-11-04T13:37:05.131289 (delta: 1.202364)         elapsed: 481.962099 ****** 


changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-urb3-659948d5d9-kcvh5 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.7 9090 < /3.dump\"", "delta": "0:00:07.656138", "end": "2019-11-04 13:37:13.003041", "rc": 0, "start": "2019-11-04 13:37:05.346903", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:61
2019-11-04T13:37:13.133807 (delta: 8.00246)         elapsed: 489.964617 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.188594", "end": "2019-11-04 13:37:14.582965", "rc": 0, "start": "2019-11-04 13:37:13.394371", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:1
2019-11-04T13:37:14.655360 (delta: 1.521455)         elapsed: 491.48617 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.288996", "end": "2019-11-04 13:37:16.206357", "rc": 0, "start": "2019-11-04 13:37:14.917361", "stderr": "", "stderr_lines": [], "stdout": "5e8bfe6b-ff06-11e9-ab94-005056985d69", "stdout_lines": ["5e8bfe6b-ff06-11e9-ab94-005056985d69"]}

TASK [Check for dataset name] **************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:5
2019-11-04T13:37:16.288451 (delta: 1.633033)         elapsed: 493.119261 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- zfs list cstor-5e8bfe6b-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69", "delta": "0:00:01.573205", "end": "2019-11-04 13:37:18.171463", "rc": 0, "start": "2019-11-04 13:37:16.598258", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-5e8bfe6b-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69  4.16M  24.1G  4.12M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-5e8bfe6b-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69  4.16M  24.1G  4.12M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:13
2019-11-04T13:37:18.245619 (delta: 1.957104)         elapsed: 495.076429 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- bash -c \"zfs send cstor-5e8bfe6b-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy > /snap.data\"", "delta": "0:00:01.781451", "end": "2019-11-04 13:37:20.247637", "rc": 0, "start": "2019-11-04 13:37:18.466186", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:17
2019-11-04T13:37:20.319378 (delta: 2.073703)         elapsed: 497.150188 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.652357", "end": "2019-11-04 13:37:22.293719", "rc": 0, "start": "2019-11-04 13:37:20.641362", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:21
2019-11-04T13:37:22.359455 (delta: 2.040009)         elapsed: 499.190265 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:01.585725", "end": "2019-11-04 13:37:24.209516", "rc": 0, "start": "2019-11-04 13:37:22.623791", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5dc02913\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 1e34c24514d34fde\n\tfromguid = 0\n\ttoname = cstor-5e8bfe6b-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy\nEND checksum = 840f23a6513ad/43dd5fa1ced25e0e/2e4436c07de65db8/2e77e7316157edf3\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 2610\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 40\n\tTotal DRR_SPILL records = 0\n\tTotal records = 2659\n\tTotal write size = 10686976 (0xa31200)\n\tTotal stream length = 11516584 (0xafbaa8)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5dc02913", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 1e34c24514d34fde", "\tfromguid = 0", "\ttoname = cstor-5e8bfe6b-ff06-11e9-ab94-005056985d69/pvc-bd647d2b-ff06-11e9-ab94-005056985d69@Wk8GheIahYnQ3Ibmmff7M838C17TUDIy", "END checksum = 840f23a6513ad/43dd5fa1ced25e0e/2e4436c07de65db8/2e77e7316157edf3", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 2610", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 40", "\tTotal DRR_SPILL records = 0", "\tTotal records = 2659", "\tTotal write size = 10686976 (0xa31200)", "\tTotal stream length = 11516584 (0xafbaa8)"]}

TASK [Install netcat on replica pod] *******************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:25
2019-11-04T13:37:24.334536 (delta: 1.975025)         elapsed: 501.165346 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:08.564223", "end": "2019-11-04 13:37:33.167744", "rc": 0, "start": "2019-11-04 13:37:24.603521", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead.", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (This frontend requires a controlling tty.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:2 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (182 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  netcat-traditional\nThe following NEW packages will be installed:\n  netcat netcat-traditional\n0 upgraded, 2 newly installed, 0 to remove and 24 not upgraded.\nNeed to get 64.1 kB of archives.\nAfter this operation, 191 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]\nFetched 64.1 kB in 0s (76.1 kB/s)\nSelecting previously unselected package netcat-traditional.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 9575 files and directories currently installed.)\r\nPreparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...\r\nUnpacking netcat-traditional (1.10-41) ...\r\nSelecting previously unselected package netcat.\r\nPreparing to unpack .../netcat_1.10-41_all.deb ...\r\nUnpacking netcat (1.10-41) ...\r\nSetting up netcat-traditional (1.10-41) ...\r\nupdate-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode\r\nSetting up netcat (1.10-41) ...", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:2 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (182 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  netcat-traditional", "The following NEW packages will be installed:", "  netcat netcat-traditional", "0 upgraded, 2 newly installed, 0 to remove and 24 not upgraded.", "Need to get 64.1 kB of archives.", "After this operation, 191 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat-traditional amd64 1.10-41 [60.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 netcat all 1.10-41 [3438 B]", "Fetched 64.1 kB in 0s (76.1 kB/s)", "Selecting previously unselected package netcat-traditional.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 9575 files and directories currently installed.)", "Preparing to unpack .../netcat-traditional_1.10-41_amd64.deb ...", "Unpacking netcat-traditional (1.10-41) ...", "Selecting previously unselected package netcat.", "Preparing to unpack .../netcat_1.10-41_all.deb ...", "Unpacking netcat (1.10-41) ...", "Setting up netcat-traditional (1.10-41) ...", "update-alternatives: using /bin/nc.traditional to provide /bin/nc (nc) in auto mode", "Setting up netcat (1.10-41) ..."]}

TASK [Start receiver to receive data object from replica pod] ******************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:29
2019-11-04T13:37:33.371403 (delta: 9.036787)         elapsed: 510.202213 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "64918674139.4288", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/64918674139.4288", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:35
2019-11-04T13:37:34.731810 (delta: 1.36026)         elapsed: 511.56262 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.093099", "end": "2019-11-04 13:37:41.064764", "rc": 0, "start": "2019-11-04 13:37:34.971665", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:39
2019-11-04T13:37:41.197177 (delta: 6.465296)         elapsed: 518.027987 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.7 9090 < /1.dump\"", "delta": "0:00:07.637494", "end": "2019-11-04 13:37:49.041391", "rc": 0, "start": "2019-11-04 13:37:41.403897", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:43
2019-11-04T13:37:49.121723 (delta: 7.924489)         elapsed: 525.952533 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.171120", "end": "2019-11-04 13:37:50.534333", "rc": 0, "start": "2019-11-04 13:37:49.363213", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:47
2019-11-04T13:37:50.613022 (delta: 1.491246)         elapsed: 527.443832 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.052906", "end": "2019-11-04 13:37:56.891990", "rc": 0, "start": "2019-11-04 13:37:50.839084", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:51
2019-11-04T13:37:57.041642 (delta: 6.42854)         elapsed: 533.872452 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "72254593577.4433", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/72254593577.4433", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:57
2019-11-04T13:37:58.275125 (delta: 1.233382)         elapsed: 535.105935 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.7 9090 < /3.dump\"", "delta": "0:00:07.723457", "end": "2019-11-04 13:38:06.230294", "rc": 0, "start": "2019-11-04 13:37:58.506837", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:61
2019-11-04T13:38:06.338368 (delta: 8.063167)         elapsed: 543.169178 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.074548", "end": "2019-11-04 13:38:07.665191", "rc": 0, "start": "2019-11-04 13:38:06.590643", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:533
2019-11-04T13:38:07.740501 (delta: 1.402078)         elapsed: 544.571311 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"base_replica": "cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b"}, "changed": false}

TASK [compare data object] *****************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:536
2019-11-04T13:38:07.856532 (delta: 0.115961)         elapsed: 544.687342 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b) => {"changed": true, "cmd": "diff cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.1.dump cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.1.dump", "delta": "0:00:01.010003", "end": "2019-11-04 13:38:09.246245", "rc": 0, "rpod": "cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b", "start": "2019-11-04 13:38:08.236242", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-urb3-659948d5d9-kcvh5) => {"changed": true, "cmd": "diff cstor-block-disk-pool-urb3-659948d5d9-kcvh5.1.dump cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.1.dump", "delta": "0:00:00.919077", "end": "2019-11-04 13:38:10.366843", "rc": 0, "rpod": "cstor-block-disk-pool-urb3-659948d5d9-kcvh5", "start": "2019-11-04 13:38:09.447766", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks) => {"changed": true, "cmd": "diff cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks.1.dump cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.1.dump", "delta": "0:00:01.131762", "end": "2019-11-04 13:38:11.763094", "rc": 0, "rpod": "cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks", "start": "2019-11-04 13:38:10.631332", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [compare meta data object] ************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:542
2019-11-04T13:38:11.837076 (delta: 3.980449)         elapsed: 548.667886 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b) => {"changed": true, "cmd": "diff cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.3.dump cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.3.dump", "delta": "0:00:00.893950", "end": "2019-11-04 13:38:12.989649", "rc": 0, "rpod": "cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b", "start": "2019-11-04 13:38:12.095699", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-urb3-659948d5d9-kcvh5) => {"changed": true, "cmd": "diff cstor-block-disk-pool-urb3-659948d5d9-kcvh5.3.dump cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.3.dump", "delta": "0:00:01.155613", "end": "2019-11-04 13:38:14.412492", "rc": 0, "rpod": "cstor-block-disk-pool-urb3-659948d5d9-kcvh5", "start": "2019-11-04 13:38:13.256879", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks) => {"changed": true, "cmd": "diff cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks.3.dump cstor-block-disk-pool-9cbn-55bdd8d878-2mk2b.3.dump", "delta": "0:00:01.088265", "end": "2019-11-04 13:38:15.685800", "rc": 0, "rpod": "cstor-block-disk-pool-xy6m-698dd4d5f9-jbdks", "start": "2019-11-04 13:38:14.597535", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Destroy snapshot created for data verification] **************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:548
2019-11-04T13:38:15.753841 (delta: 3.916712)         elapsed: 552.584651 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bd647d2b-ff06-11e9-ab94-005056985d69-target-69d84f9999wvmp7 -n openebs --container cstor-istgt -- istgtcontrol snapdestroy pvc-bd647d2b-ff06-11e9-ab94-005056985d69 Wk8GheIahYnQ3Ibmmff7M838C17TUDIy 30 30", "delta": "0:00:01.430563", "end": "2019-11-04 13:38:17.517723", "rc": 0, "start": "2019-11-04 13:38:16.087160", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPDESTROY command", "stdout_lines": ["DONE SNAPDESTROY command"]}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:554
2019-11-04T13:38:17.664879 (delta: 1.910982)         elapsed: 554.495689 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/replace_cvr_by_node_failure/test.yml:572
2019-11-04T13:38:17.854441 (delta: 0.189467)         elapsed: 554.685251 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-04T13:38:18.120653 (delta: 0.266117)         elapsed: 554.951463 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-04T13:38:18.198179 (delta: 0.077466)         elapsed: 555.028989 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-04T13:38:18.263344 (delta: 0.065084)         elapsed: 555.094154 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-04T13:38:18.338270 (delta: 0.074871)         elapsed: 555.16908 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "e7c64aa052445b19d8384b3c32b1ed4242caab4e", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c8b3bc0104fdddccdce7922d555423df", "mode": "0644", "owner": "root", "size": 426, "src": "/root/.ansible/tmp/ansible-tmp-1572874698.41-276301874377612/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-04T13:38:20.850547 (delta: 2.512193)         elapsed: 557.681357 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.045604", "end": "2019-11-04 13:38:22.170567", "rc": 0, "start": "2019-11-04 13:38:21.124963", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: replace-cvr-by-node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: replace-cvr-by-node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-04T13:38:22.253930 (delta: 1.403296)         elapsed: 559.08474 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-04T13:29:16Z", "generation": 1, "name": "replace-cvr-by-node-failure", "namespace": "", "resourceVersion": "116108", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/replace-cvr-by-node-failure", "uid": "1941197c-ff07-11e9-ab94-005056985d69"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=143  changed=120  unreachable=0    failed=0   

2019-11-04T13:38:23.339875 (delta: 1.085881)         elapsed: 560.170685 ****** 
=============================================================================== 
```