### PR TITLE
refactor[yaml]: Modified the busybox deployment yaml spec

### DIFF
--- a/apps/busybox/deployers/busybox_deployment.yml
+++ b/apps/busybox/deployers/busybox_deployment.yml
@@ -1,4 +1,15 @@
-apiVersion: apps/v1beta1
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    lkey: lvalue
+  name: busybox
+spec:
+  clusterIP: None
+  selector:
+    lkey: lvalue
+---
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-busybox
@@ -6,6 +17,11 @@ metadata:
     lkey: lvalue
     affinity_label: lvalue
 spec:
+  serviceName: busybox
+  selector:
+    matchLabels:
+      lkey: lvalue
+      affinity_label: lvalue
   template:
     metadata:
       labels:
@@ -40,3 +56,4 @@ spec:
   resources:
     requests:
       storage: teststorage
+


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the deployment spec yaml. Used service to create the deployment it's fixing the below error while using k8s module. 
```
fatal: [127.0.0.1]: FAILED! => {"changed": false, "error": 422, "msg": "Failed to create object: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Deployment.apps \\\"app-busybox\\\" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{\\\"app\\\":\\\"bb-app-kill-jiva\\\", \\\"openebs.io/target-affinity\\\":\\\"lvalue\\\"}: `selector` does not match template `labels`]\",\"reason\":\"Invalid\",\"details\":{\"name\":\"app-busybox\",\"group\":\"apps\",\"kind\":\"Deployment\",\"causes\":[{\"reason\":\"FieldValueRequired\",\"message\":\"Required value\",\"field\":\"spec.selector\"},{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: map[string]string{\\\"app\\\":\\\"bb-app-kill-jiva\\\", \\\"openebs.io/target-affinity\\\":\\\"lvalue\\\"}: `selector` does not match template `labels`\",\"field\":\"spec.template.metadata.labels\"}]},\"code\":422}\n", "reason": "Unprocessable Entity", "status": 422}
```
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2019-10-31T12:25:56.376786 (delta: 0.066093)         elapsed: 0.066093 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-10-31T12:25:56.390474 (delta: 0.013635)         elapsed: 0.079781 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:05.197812 (delta: 8.807298)         elapsed: 8.887119 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-10-31T12:26:05.294728 (delta: 0.096876)         elapsed: 8.984035 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-10-31T12:26:05.383152 (delta: 0.088358)         elapsed: 9.072459 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:05.479587 (delta: 0.096374)         elapsed: 9.168894 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-31T12:26:05.653662 (delta: 0.174003)         elapsed: 9.342969 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "9ea3edca7526192c365bd31ccb59eb0c0e598399", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "eb5bdeb749f75ff9216d380c1fb41bb8", "mode": "0644", "owner": "root", "size": 425, "src": "/root/.ansible/tmp/ansible-tmp-1572524765.74-129231968487375/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-31T12:26:06.495845 (delta: 0.842138)         elapsed: 10.185152 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.874432", "end": "2019-10-31 12:26:07.712746", "rc": 0, "start": "2019-10-31 12:26:06.838314", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-provision-sathya \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-provision-sathya ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-31T12:26:07.771408 (delta: 1.275512)         elapsed: 11.460715 ******* 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-10-31T12:01:03Z", "generation": 1, "name": "busybox-provision-sathya", "namespace": "", "resourceVersion": "284192", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/busybox-provision-sathya", "uid": "1caff61b-fbd6-11e9-897d-005056985c20"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-31T12:26:09.449418 (delta: 1.677957)         elapsed: 13.138725 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-31T12:26:09.525401 (delta: 0.075925)         elapsed: 13.214708 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-31T12:26:09.615696 (delta: 0.09021)         elapsed: 13.305003 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:09.723283 (delta: 0.107497)         elapsed: 13.41259 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the affinity label annotation in statefulset yml] ****************
2019-10-31T12:26:09.855763 (delta: 0.132387)         elapsed: 13.54507 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the volume capcity placeholder with provider] ********************
2019-10-31T12:26:09.986284 (delta: 0.130429)         elapsed: 13.675591 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:10.116524 (delta: 0.130143)         elapsed: 13.805831 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning the Application] ******************************************
2019-10-31T12:26:10.246534 (delta: 0.129913)         elapsed: 13.935841 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:10.380842 (delta: 0.134214)         elapsed: 14.070149 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-10-31T12:26:10.647978 (delta: 0.267043)         elapsed: 14.337285 ******* 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "resources": [{"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass", "metadata": {"annotations": {"cas.openebs.io/config": "- name: StoragePoolClaim\n  value: cstor-block-disk-pool\n- name: ReplicaCount\n  value: \"3\"\n", "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"storage.k8s.io/v1\",\"kind\":\"StorageClass\",\"metadata\":{\"annotations\":{\"cas.openebs.io/config\":\"- name: StoragePoolClaim\\n  value: cstor-block-disk-pool\\n- name: ReplicaCount\\n  value: \\\"3\\\"\\n\",\"openebs.io/cas-type\":\"cstor\"},\"name\":\"openebs-cstor-disk\"},\"provisioner\":\"openebs.io/provisioner-iscsi\"}\n", "openebs.io/cas-type": "cstor"}, "creationTimestamp": "2019-10-31T08:09:00Z", "name": "openebs-cstor-disk", "resourceVersion": "223115", "selfLink": "/apis/storage.k8s.io/v1/storageclasses/openebs-cstor-disk", "uid": "b23c9d08-fbb5-11e9-897d-005056985c20"}, "provisioner": "openebs.io/provisioner-iscsi", "reclaimPolicy": "Delete", "volumeBindingMode": "Immediate"}]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-10-31T12:26:12.316470 (delta: 1.668427)         elapsed: 16.005777 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-10-31T12:26:12.912709 (delta: 0.596112)         elapsed: 16.602016 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:13.307374 (delta: 0.394603)         elapsed: 16.996681 ******* 
included: /utils/scm/openebs/fetch_replica_values.yml for 127.0.0.1

TASK [Get the application replica values from env] *****************************
2019-10-31T12:26:13.468200 (delta: 0.160775)         elapsed: 17.157507 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_rkey": "replicas", "app_rvalue": "2"}, "changed": false}

TASK [Replace the application replica placeholder in statefulset spec.] ********
2019-10-31T12:26:13.635070 (delta: 0.166778)         elapsed: 17.324377 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Get the application label values from env] *******************************
2019-10-31T12:26:14.060238 (delta: 0.425099)         elapsed: 17.749545 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-sts"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-10-31T12:26:14.241420 (delta: 0.181131)         elapsed: 17.930727 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-10-31T12:26:14.600647 (delta: 0.359102)         elapsed: 18.289954 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:14.731708 (delta: 0.130968)         elapsed: 18.421015 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-10-31T12:26:14.970165 (delta: 0.238374)         elapsed: 18.659472 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.379213", "end": "2019-10-31 12:26:16.653306", "rc": 0, "start": "2019-10-31 12:26:15.274093", "stderr": "", "stderr_lines": [], "stdout": "a\napp\napp-busybox-ns\napp-cass\ndefault\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nns\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["a", "app", "app-busybox-ns", "app-cass", "default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "ns", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
2019-10-31T12:26:16.767484 (delta: 1.797185)         elapsed: 20.456791 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns sathya", "delta": "0:00:01.151530", "end": "2019-10-31 12:26:18.377162", "rc": 0, "start": "2019-10-31 12:26:17.225632", "stderr": "", "stderr_lines": [], "stdout": "namespace/sathya created", "stdout_lines": ["namespace/sathya created"]}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:18.489104 (delta: 1.721491)         elapsed: 22.178411 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-10-31T12:26:18.718300 (delta: 0.229103)         elapsed: 22.407607 ******* 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"annotations": {"openshift.io/sa.scc.mcs": "s0:c15,c5", "openshift.io/sa.scc.supplemental-groups": "1000220000/10000", "openshift.io/sa.scc.uid-range": "1000220000/10000"}, "creationTimestamp": "2019-10-31T12:26:18Z", "name": "sathya", "resourceVersion": "285269", "selfLink": "/api/v1/namespaces/sathya", "uid": "a3a78f58-fbd9-11e9-897d-005056985c20"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [Replace the affinity label annotation in deployment yml] *****************
2019-10-31T12:26:20.097380 (delta: 1.378977)         elapsed: 23.786687 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "4 replacements made"}

TASK [Replace the volume capcity placeholder with provider] ********************
2019-10-31T12:26:20.448136 (delta: 0.350658)         elapsed: 24.137443 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:20.818046 (delta: 0.369835)         elapsed: 24.507353 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying busybox] *******************************************************
2019-10-31T12:26:21.001417 (delta: 0.183317)         elapsed: 24.690724 ******* 
changed: [127.0.0.1] => {"changed": true, "result": {"results": [{"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "Service", "metadata": {"creationTimestamp": "2019-10-31T12:26:22Z", "labels": {"app": "busybox-sts"}, "name": "busybox", "namespace": "sathya", "resourceVersion": "285310", "selfLink": "/api/v1/namespaces/sathya/services/busybox", "uid": "a6044356-fbd9-11e9-897d-005056985c20"}, "spec": {"clusterIP": "None", "selector": {"app": "busybox-sts"}, "sessionAffinity": "None", "type": "ClusterIP"}, "status": {"loadBalancer": {}}}}, {"changed": true, "method": "create", "result": {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"creationTimestamp": "2019-10-31T12:26:22Z", "generation": 1, "labels": {"app": "busybox-sts", "openebs.io/target-affinity": "lvalue"}, "name": "app-busybox", "namespace": "sathya", "resourceVersion": "285312", "selfLink": "/apis/apps/v1/namespaces/sathya/deployments/app-busybox", "uid": "a6089785-fbd9-11e9-897d-005056985c20"}, "spec": {"progressDeadlineSeconds": 600, "replicas": 1, "revisionHistoryLimit": 10, "selector": {"matchLabels": {"app": "busybox-sts", "openebs.io/target-affinity": "lvalue"}}, "strategy": {"rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"}, "type": "RollingUpdate"}, "template": {"metadata": {"creationTimestamp": null, "labels": {"app": "busybox-sts", "openebs.io/target-affinity": "lvalue"}}, "spec": {"containers": [{"args": ["-c", "while true; do sleep 10;done"], "command": ["/bin/sh"], "image": "busybox", "imagePullPolicy": "IfNotPresent", "name": "app-busybox", "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/busybox", "name": "data-vol"}]}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "terminationGracePeriodSeconds": 30, "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "openebs-busybox"}}]}}}, "status": {}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"creationTimestamp": "2019-10-31T12:26:22Z", "finalizers": ["kubernetes.io/pvc-protection"], "labels": {"openebs.io/target-affinity": "lvalue"}, "name": "openebs-busybox", "namespace": "sathya", "resourceVersion": "285313", "selfLink": "/api/v1/namespaces/sathya/persistentvolumeclaims/openebs-busybox", "uid": "a612a53b-fbd9-11e9-897d-005056985c20"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "5G"}}, "storageClassName": "openebs-cstor-disk"}, "status": {"phase": "Pending"}}}]}}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:22.650004 (delta: 1.648533)         elapsed: 26.339311 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2019-10-31T12:26:22.905304 (delta: 0.2552)         elapsed: 26.594611 ********* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
changed: [127.0.0.1] => {"attempts": 8, "changed": true, "cmd": "kubectl get pod -n sathya -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.207306", "end": "2019-10-31 12:26:49.241359", "rc": 0, "start": "2019-10-31 12:26:48.034053", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-10-31T12:26:48Z]]", "stdout_lines": ["map[running:map[startedAt:2019-10-31T12:26:48Z]]"]}

TASK [Checking busybox pod is in running state] ********************************
2019-10-31T12:26:49.374879 (delta: 26.469477)         elapsed: 53.064186 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sathya -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.116297", "end": "2019-10-31 12:26:50.793253", "rc": 0, "start": "2019-10-31 12:26:49.676956", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:50.900894 (delta: 1.525923)         elapsed: 54.590201 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning the Application] ******************************************
2019-10-31T12:26:51.048842 (delta: 0.14786)         elapsed: 54.738149 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-10-31T12:26:51.220198 (delta: 0.171262)         elapsed: 54.909505 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-10-31T12:26:51.389278 (delta: 0.168981)         elapsed: 55.078585 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-10-31T12:26:51.580736 (delta: 0.191363)         elapsed: 55.270043 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-10-31T12:26:51.691732 (delta: 0.110904)         elapsed: 55.381039 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-10-31T12:26:51.797869 (delta: 0.106011)         elapsed: 55.487176 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-10-31T12:26:51.906417 (delta: 0.108458)         elapsed: 55.595724 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "0ee28bd980aa8487153377067f71aa28fc46cc56", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "dcd2487cde5a5944b4856d89e5220939", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1572524812.12-79943770375652/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-10-31T12:26:54.717644 (delta: 2.811104)         elapsed: 58.406951 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.131347", "end": "2019-10-31 12:26:56.191523", "rc": 0, "start": "2019-10-31 12:26:55.060176", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-provision-sathya \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-provision-sathya ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-10-31T12:26:56.246871 (delta: 1.529163)         elapsed: 59.936178 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-10-31T12:01:03Z", "generation": 1, "name": "busybox-provision-sathya", "namespace": "", "resourceVersion": "285576", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/busybox-provision-sathya", "uid": "1caff61b-fbd6-11e9-897d-005056985c20"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=32   changed=15   unreachable=0    failed=0   

2019-10-31T12:26:57.470433 (delta: 1.223503)         elapsed: 61.15974 ******** 
=============================================================================== 
```