### PR TITLE
feat[experiment]: litmusbook for velero based backup and restore on cstor volume

### DIFF
--- a/apps/percona/functional/backup_and_restore/backup-restore.yml
+++ b/apps/percona/functional/backup_and_restore/backup-restore.yml
@@ -1,0 +1,43 @@
+---
+- block:
+
+   - name: Creating Backup
+     shell: >
+       velero backup create {{ backup_name }} --include-namespaces={{ app_ns }} --snapshot-volumes --volume-snapshot-locations=minio
+     args:
+       executable: /bin/bash
+
+   - name: Getting the state of Backup
+     shell: kubectl get backup {{ backup_name }} -n velero -o jsonpath='{.status.phase}'
+     register: backup_state
+     until: "'Completed' in backup_state.stdout"
+     delay: 5
+     retries: 30
+
+  when: action == "BACKUP"
+
+- block:
+
+   - name: Creating application namespace
+     shell: kubectl create ns {{ app_ns }}
+     register: volume_snapshot_location
+     failed_when: "'created' not in volume_snapshot_location.stdout"
+
+   - name: Restoring application 
+     shell: >
+       velero restore create --from-backup {{ backup-name }} --restore-volumes=true
+     args:
+       executable: /bin/bash
+
+   - name: Getting restore name
+     shell: velero get restore | grep {{ backup_name }} | awk '{print $1}'
+     register: restore_name
+
+   - name: Checking the restore status
+     shell: kubectl get restore {{ restore_name.stdout }} -n velero -o jsonpath='{.status.phase}'
+     register: restore_state
+     until: "'Completed' in restore_state.stdout"
+     delay: 5
+     retries: 45
+
+  when: action == "RESTORE"

--- a/apps/percona/functional/backup_and_restore/credentials-velero
+++ b/apps/percona/functional/backup_and_restore/credentials-velero
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = minio
+aws_secret_access_key = minio123

--- a/apps/percona/functional/backup_and_restore/run_litmus_test.yml
+++ b/apps/percona/functional/backup_and_restore/run_litmus_test.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-velero-backup-restore
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: velero-backup-restore
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+            # Application pvc
+          - name: APP_PVC
+            value: percona-mysql-claim
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-percona-ns 
+
+          - name: DB_USER_NAME
+            value: root
+
+          - name: DB_PASSWORD
+            value: k8sDem0
+
+          - name: DEPLOY_TYPE
+            value: deployment
+
+          - name: BACKUP_NAME
+            value: percona-backup
+
+          - name: VELERO_PLUGIN_NAME
+            value: "openebs/velero-plugin:ci"
+
+          - name: VELERO_VERSION
+            value: "v1.1.0"
+            
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./apps/percona/functional/backup_and_restore/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/apps/percona/functional/backup_and_restore/setup_dependency.yml
+++ b/apps/percona/functional/backup_and_restore/setup_dependency.yml
@@ -1,0 +1,60 @@
+- name: Downloading velero binary
+  get_url:
+    url: "{{ velero_binary_url }}"
+    dest: "./"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Installing velero inside litmus container
+  shell: |
+    tar -xvf velero-v1.1.0-linux-amd64.tar.gz
+    mv velero-v1.1.0-linux-amd64/velero /usr/local/bin/
+
+- name: Checking the velero version
+  shell: velero version
+  register: velero_version
+  failed_when: "velero_version not in velero_version.stdout"
+
+- name: Installing minio s3-bucket
+  shell: kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml
+
+- name: Checking for minio pod status
+  shell: kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'
+  register: minio_status
+  until: "'Running' in minio_status.stdout"
+  delay: 5
+  retries: 15
+
+- name: Installing velero server inside cluster
+  shell: >
+    velero install \
+      --provider aws \
+      --bucket velero \
+      --secret-file ./credentials-velero \
+      --use-volume-snapshots=false \
+      --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+
+- name: Checking for velero server status
+  shell: kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'
+  register: velero_status
+  until: "'Running' in velero_status.stdout"
+  delay: 5
+  retries: 20
+
+- name: Installing development image of OpenEBS velero-plugin
+  shell: velero plugin add {{ velero_plugin_name }}
+
+- name: Checking for velero server status
+  shell: kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'
+  register: velero_status_post_update
+  until: "'Running' in velero_status_post_update.stdout"
+  delay: 5
+  retries: 20
+
+- name: Creating volume snapshot location
+  shell: kubectl apply -f volume-snapshot-location.yml
+  register: volume_snapshot_location
+  failed_when: "'created' not in volume_snapshot_location.stdout"

--- a/apps/percona/functional/backup_and_restore/test.yml
+++ b/apps/percona/functional/backup_and_restore/test.yml
@@ -1,0 +1,128 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+    
+         # GENERATING THE TEST NAME
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ##  RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Verify that the AUT is running
+          include_tasks: /utils/k8s/check_deployment_status.yml
+
+        - include_tasks: "./setup_dependency.yml"
+
+        - name: Get Application  pod details
+          shell: kubectl get pods -n {{ app_ns }}  -l {{ app_label }}  --no-headers -o custom-columns=:metadata.name
+          register: app_pod
+
+        - name: Create new database in the mysql
+          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ app_ns }}"
+            pod_name: "{{ app_pod.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: "backup"
+
+        - name: Creating Backup for the provided application
+          include_tasks: "./backup-restore.yml"
+          vars:
+            action: 'BACKUP'
+
+        - name: Deleting Application
+          shell: |
+            kubectl delete pvc,deploy,svc --all -n {{ app_ns }}
+            kubectl delete ns {{ app_ns }}
+
+        - name: Checking whether namespace is deleted
+          shell: >
+            kubectl get ns 
+            --no-headers 
+            -o custom-columns=:metadata.name
+          args: 
+            executable: /bin/bash
+          register: ns_list
+          until: "app_ns not in ns_list.stdout_lines"
+          delay: 5
+          retries: 15
+
+        - name: Restoring Application
+          include_tasks: "./backup-restore.yml"
+          vars:
+            action: 'RESTORE'
+
+        - name: Getting the volume name
+          shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
+          register: volume_name
+
+        - name: Getting the target IP
+          shell: kubectl get pod -n openebs -o wide | grep {{ volume_name.stdout }} | awk '{print $6}'
+          register: target_ip
+
+        - name: Getting storage class name
+          shell: kubectl get pv {{ volume_name.stdout }} -o jsonpath='{.spec.storageClassName}'
+          register: storage_class
+
+        - name: Getting the spc name
+          shell: kubectl get sc {{ storage_class.stdout }} -o jsonpath='{.metadata.annotations.cas\.openebs\.io/config}' | grep -A 1 StoragePoolClaim | awk 'FNR == 2 {print}' | cut -d' ' -f4
+          register: spc_name
+
+        - name: Getting the pool pod corresponding to spc
+          shell: kubectl get po -n openebs --no-headers -l openebs.io/storage-pool-claim={{ spc_name.stdout }} | awk '{print $1}'
+          register: pool_pod
+
+        - name: Getting the volume name inside cstor pool
+          shell: |
+            echo $(kubectl exec -it {{item}} -n openebs -c cstor-pool -- zfs list | grep {{ volume_name.stdout }} | awk '{print $1}') >> cstor-vol
+          with_items: "{{ pool_pod.stdout_lines }}"
+  
+        - name: Assingning the cstor-pool volume name to variable
+          shell: cat ./cstor-vol
+          register: pool_volume_name
+        
+        - name: Setting target IP for volume inside cstor pool
+          shell: kubectl exec -it {{item.0}} -n openebs -- zfs set io.openebs:targetip={{ target_ip.stdout }} {{item.1}}
+          with_together:
+            - "{{ pool_pod.stdout_lines }}"  
+            - "{{ pool_volume_name.stdout_lines }}" 
+
+        - name: Waiting for application to be in ruuning state
+          shell: kubectl get pod {{ app_pod.stdout }} -n {{ app_ns }} -o jsonpath='{.status.phase}'
+          register: app_pod_status
+          until: "'Running' in app_pod_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Verifying Data persistense
+          include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ app_ns }}"
+            pod_name: "{{ app_pod.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: "backup"
+            label: "{{ app_label }}"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always: 
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'        

--- a/apps/percona/functional/backup_and_restore/test_vars.yml
+++ b/apps/percona/functional/backup_and_restore/test_vars.yml
@@ -1,0 +1,8 @@
+test_name: "velero-backup-restore"
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+app_label: "{{ lookup('env','APP_LABEL') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+backup_name: "{{ lookup('env','BACKUP_NAME') }}"
+velero_plugin_name: "{{ lookup('env','VELERO_PLUGIN_NAME') }}"
+velero_version: "{{ lookup('env','VELERO_VERSION') }}"
+velero_binary_url: "https://github.com/vmware-tanzu/velero/releases/download/{{ lookup('env','VELERO_VERSION') }}/velero-{{ lookup('env','VELERO_VERSION') }}-linux-amd64.tar.gz"

--- a/apps/percona/functional/backup_and_restore/volume-snapshot-location.yml
+++ b/apps/percona/functional/backup_and_restore/volume-snapshot-location.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  name: minio
+  namespace: velero
+spec:
+  provider: openebs.io/cstor-blockstore
+  config:
+      bucket: velero
+      provider: aws
+      region: minio
+      s3ForcePathStyle: "true"
+      s3Url: http://minio.velero.svc:9000


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

**What this PR does / why we need it**:
- Adds litmusbook for performing velero based backup and restore on cstor volume.
- Includes setup-dependency.yml to install velero client inside litmus container,

**Following is the log of ansible test container:**
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./apps/percona/functional/backup_and_restore/test.yml

PLAY [localhost] ***************************************************************
2019-11-06T00:11:02.861217 (delta: 0.04744)         elapsed: 0.04744 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:1
2019-11-06T00:11:02.869387 (delta: 0.008145)         elapsed: 0.05561 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:12
2019-11-06T00:11:07.652674 (delta: 4.783259)         elapsed: 4.838897 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-06T00:11:07.702737 (delta: 0.050028)         elapsed: 4.88896 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-06T00:11:07.744947 (delta: 0.042164)         elapsed: 4.93117 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:15
2019-11-06T00:11:07.783861 (delta: 0.038774)         elapsed: 4.970084 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-06T00:11:07.847938 (delta: 0.064033)         elapsed: 5.034161 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "cb23761ee0ecfea3a093f94c0443739c777b3007", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0da5664e16958d4f3c263662ebe36b5c", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1572999067.89-18355546407617/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-06T00:11:08.380629 (delta: 0.532649)         elapsed: 5.566852 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.528147", "end": "2019-11-06 00:11:09.147837", "rc": 0, "start": "2019-11-06 00:11:08.619690", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-06T00:11:09.183876 (delta: 0.803209)         elapsed: 6.370099 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-05T20:43:24Z", "generation": 31, "name": "velero-backup-restore", "resourceVersion": "73309", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "e93f55f9-000c-11ea-8939-42010a800092"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-06T00:11:09.976547 (delta: 0.792634)         elapsed: 7.16277 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-06T00:11:10.011129 (delta: 0.034541)         elapsed: 7.197352 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-06T00:11:10.047135 (delta: 0.035964)         elapsed: 7.233358 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:19
2019-11-06T00:11:10.081579 (delta: 0.034402)         elapsed: 7.267802 ******** 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2019-11-06T00:11:10.138188 (delta: 0.056572)         elapsed: 7.324411 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.035839", "end": "2019-11-06 00:11:11.312674", "rc": 0, "start": "2019-11-06 00:11:10.276835", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2019-11-06T00:11:11.361330 (delta: 1.223105)         elapsed: 8.547553 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2019-11-06T00:11:11.400357 (delta: 0.038984)         elapsed: 8.58658 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:22
2019-11-06T00:11:11.440558 (delta: 0.040157)         elapsed: 8.626781 ******** 
included: /apps/percona/functional/backup_and_restore/setup_dependency.yml for 127.0.0.1

TASK [Downloading velero binary] ***********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:1
2019-11-06T00:11:11.508113 (delta: 0.06751)         elapsed: 8.694336 ********* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "24c98ca1c9cfe5c754c76c07ba6cbc517bc68f92", "dest": "./velero-v1.1.0-linux-amd64.tar.gz", "gid": 0, "group": "root", "md5sum": "2f8fb6505764a6f937b8b5645d4b8fb8", "mode": "0644", "msg": "OK (26731554 bytes)", "owner": "root", "size": 26731554, "src": "/root/.ansible/tmp/ansible-tmp-1572999071.54-269012508766149/tmp6HCBch", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/vmware-tanzu/velero/releases/download/v1.1.0/velero-v1.1.0-linux-amd64.tar.gz"}

TASK [Installing velero inside litmus container] *******************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:11
2019-11-06T00:11:13.158114 (delta: 1.649965)         elapsed: 10.344337 ******* 
 [WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "tar -xvf velero-v1.1.0-linux-amd64.tar.gz\n mv velero-v1.1.0-linux-amd64/velero /usr/local/bin/", "delta": "0:00:01.126564", "end": "2019-11-06 00:11:14.411282", "rc": 0, "start": "2019-11-06 00:11:13.284718", "stderr": "", "stderr_lines": [], "stdout": "velero-v1.1.0-linux-amd64/LICENSE\nvelero-v1.1.0-linux-amd64/examples/README.md\nvelero-v1.1.0-linux-amd64/examples/minio\nvelero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app\nvelero-v1.1.0-linux-amd64/examples/nginx-app/README.md\nvelero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml\nvelero-v1.1.0-linux-amd64/velero", "stdout_lines": ["velero-v1.1.0-linux-amd64/LICENSE", "velero-v1.1.0-linux-amd64/examples/README.md", "velero-v1.1.0-linux-amd64/examples/minio", "velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app", "velero-v1.1.0-linux-amd64/examples/nginx-app/README.md", "velero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml", "velero-v1.1.0-linux-amd64/velero"]}

TASK [Checking the velero version] *********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:16
2019-11-06T00:11:14.448340 (delta: 1.290172)         elapsed: 11.634563 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero version", "delta": "0:00:00.615197", "end": "2019-11-06 00:11:15.192522", "failed_when_result": false, "rc": 0, "start": "2019-11-06 00:11:14.577325", "stderr": "", "stderr_lines": [], "stdout": "Client:\n\tVersion: v1.1.0\n\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608\n<error getting server version: namespaces \"velero\" not found>", "stdout_lines": ["Client:", "\tVersion: v1.1.0", "\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608", "<error getting server version: namespaces \"velero\" not found>"]}

TASK [Installing minio s3-bucket] **********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:21
2019-11-06T00:11:15.236322 (delta: 0.787938)         elapsed: 12.422545 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "delta": "0:00:01.138503", "end": "2019-11-06 00:11:16.506954", "rc": 0, "start": "2019-11-06 00:11:15.368451", "stderr": "", "stderr_lines": [], "stdout": "namespace/velero created\ndeployment.apps/minio created\nservice/minio created\njob.batch/minio-setup created", "stdout_lines": ["namespace/velero created", "deployment.apps/minio created", "service/minio created", "job.batch/minio-setup created"]}

TASK [Checking for minio pod status] *******************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:24
2019-11-06T00:11:16.546175 (delta: 1.309813)         elapsed: 13.732398 ******* 
FAILED - RETRYING: Checking for minio pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:00.609588", "end": "2019-11-06 00:11:23.110122", "rc": 0, "start": "2019-11-06 00:11:22.500534", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing velero server inside cluster] *********************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:31
2019-11-06T00:11:23.150583 (delta: 6.60437)         elapsed: 20.336806 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero install --provider aws --bucket velero --secret-file ./credentials-velero --use-volume-snapshots=false --backup-location-config region=minio,s3ForcePathStyle=\"true\",s3Url=http://minio.velero.svc:9000", "delta": "0:00:02.402524", "end": "2019-11-06 00:11:25.685090", "rc": 0, "start": "2019-11-06 00:11:23.282566", "stderr": "", "stderr_lines": [], "stdout": "CustomResourceDefinition/schedules.velero.io: attempting to create resource\nCustomResourceDefinition/schedules.velero.io: already exists, proceeding\nCustomResourceDefinition/schedules.velero.io: created\nCustomResourceDefinition/downloadrequests.velero.io: attempting to create resource\nCustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/downloadrequests.velero.io: created\nCustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource\nCustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding\nCustomResourceDefinition/deletebackuprequests.velero.io: created\nCustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumebackups.velero.io: created\nCustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource\nCustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/serverstatusrequests.velero.io: created\nCustomResourceDefinition/backups.velero.io: attempting to create resource\nCustomResourceDefinition/backups.velero.io: already exists, proceeding\nCustomResourceDefinition/backups.velero.io: created\nCustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumerestores.velero.io: created\nCustomResourceDefinition/resticrepositories.velero.io: attempting to create resource\nCustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding\nCustomResourceDefinition/resticrepositories.velero.io: created\nCustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource\nCustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding\nCustomResourceDefinition/backupstoragelocations.velero.io: created\nCustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource\nCustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding\nCustomResourceDefinition/volumesnapshotlocations.velero.io: created\nCustomResourceDefinition/restores.velero.io: attempting to create resource\nCustomResourceDefinition/restores.velero.io: already exists, proceeding\nCustomResourceDefinition/restores.velero.io: created\nWaiting for resources to be ready in cluster...\nNamespace/velero: attempting to create resource\nNamespace/velero: already exists, proceeding\nNamespace/velero: created\nClusterRoleBinding/velero: attempting to create resource\nClusterRoleBinding/velero: already exists, proceeding\nClusterRoleBinding/velero: created\nServiceAccount/velero: attempting to create resource\nServiceAccount/velero: created\nSecret/cloud-credentials: attempting to create resource\nSecret/cloud-credentials: created\nBackupStorageLocation/default: attempting to create resource\nBackupStorageLocation/default: created\nDeployment/velero: attempting to create resource\nDeployment/velero: created\nVelero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status.", "stdout_lines": ["CustomResourceDefinition/schedules.velero.io: attempting to create resource", "CustomResourceDefinition/schedules.velero.io: already exists, proceeding", "CustomResourceDefinition/schedules.velero.io: created", "CustomResourceDefinition/downloadrequests.velero.io: attempting to create resource", "CustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/downloadrequests.velero.io: created", "CustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource", "CustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding", "CustomResourceDefinition/deletebackuprequests.velero.io: created", "CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumebackups.velero.io: created", "CustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource", "CustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/serverstatusrequests.velero.io: created", "CustomResourceDefinition/backups.velero.io: attempting to create resource", "CustomResourceDefinition/backups.velero.io: already exists, proceeding", "CustomResourceDefinition/backups.velero.io: created", "CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumerestores.velero.io: created", "CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource", "CustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding", "CustomResourceDefinition/resticrepositories.velero.io: created", "CustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource", "CustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding", "CustomResourceDefinition/backupstoragelocations.velero.io: created", "CustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource", "CustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding", "CustomResourceDefinition/volumesnapshotlocations.velero.io: created", "CustomResourceDefinition/restores.velero.io: attempting to create resource", "CustomResourceDefinition/restores.velero.io: already exists, proceeding", "CustomResourceDefinition/restores.velero.io: created", "Waiting for resources to be ready in cluster...", "Namespace/velero: attempting to create resource", "Namespace/velero: already exists, proceeding", "Namespace/velero: created", "ClusterRoleBinding/velero: attempting to create resource", "ClusterRoleBinding/velero: already exists, proceeding", "ClusterRoleBinding/velero: created", "ServiceAccount/velero: attempting to create resource", "ServiceAccount/velero: created", "Secret/cloud-credentials: attempting to create resource", "Secret/cloud-credentials: created", "BackupStorageLocation/default: attempting to create resource", "BackupStorageLocation/default: created", "Deployment/velero: attempting to create resource", "Deployment/velero: created", "Velero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status."]}

TASK [Checking for velero server status] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:40
2019-11-06T00:11:25.724561 (delta: 2.573936)         elapsed: 22.910784 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:00.624234", "end": "2019-11-06 00:11:32.223319", "rc": 0, "start": "2019-11-06 00:11:31.599085", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing development image of OpenEBS velero-plugin] *******************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:47
2019-11-06T00:11:32.265018 (delta: 6.540418)         elapsed: 29.451241 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero plugin add openebs/velero-plugin:ci", "delta": "0:00:00.587677", "end": "2019-11-06 00:11:32.988908", "rc": 0, "start": "2019-11-06 00:11:32.401231", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Checking for velero server status] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:50
2019-11-06T00:11:33.026974 (delta: 0.761919)         elapsed: 30.213197 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:00.651710", "end": "2019-11-06 00:11:33.816361", "rc": 0, "start": "2019-11-06 00:11:33.164651", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get Application  pod details] ********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:24
2019-11-06T00:11:33.866825 (delta: 0.83981)         elapsed: 31.053048 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.686118", "end": "2019-11-06 00:11:34.724606", "rc": 0, "start": "2019-11-06 00:11:34.038488", "stderr": "", "stderr_lines": [], "stdout": "percona-598c987dc8-bcdlh", "stdout_lines": ["percona-598c987dc8-bcdlh"]}

TASK [Create new database in the mysql] ****************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:28
2019-11-06T00:11:34.765134 (delta: 0.898256)         elapsed: 31.951357 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-11-06T00:11:34.862590 (delta: 0.097413)         elapsed: 32.048813 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;') => {"changed": true, "cmd": "kubectl exec percona-598c987dc8-bcdlh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database backup;'", "delta": "0:00:00.883342", "end": "2019-11-06 00:11:36.024293", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "rc": 0, "start": "2019-11-06 00:11:35.140951", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup) => {"changed": true, "cmd": "kubectl exec percona-598c987dc8-bcdlh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "delta": "0:00:01.057545", "end": "2019-11-06 00:11:37.238112", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "rc": 0, "start": "2019-11-06 00:11:36.180567", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup) => {"changed": true, "cmd": "kubectl exec percona-598c987dc8-bcdlh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "delta": "0:00:00.918216", "end": "2019-11-06 00:11:38.309935", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "rc": 0, "start": "2019-11-06 00:11:37.391719", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-11-06T00:11:38.362973 (delta: 3.500325)         elapsed: 35.549196 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-11-06T00:11:38.402552 (delta: 0.039533)         elapsed: 35.588775 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-11-06T00:11:38.443628 (delta: 0.041031)         elapsed: 35.629851 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-11-06T00:11:38.484131 (delta: 0.040459)         elapsed: 35.670354 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-11-06T00:11:38.525056 (delta: 0.040886)         elapsed: 35.711279 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-11-06T00:11:38.565708 (delta: 0.040592)         elapsed: 35.751931 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-11-06T00:11:38.604068 (delta: 0.03832)         elapsed: 35.790291 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-11-06T00:11:38.648512 (delta: 0.044351)         elapsed: 35.834735 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-11-06T00:11:38.690532 (delta: 0.041975)         elapsed: 35.876755 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup for the provided application] ****************************
task path: /apps/percona/functional/backup_and_restore/test.yml:38
2019-11-06T00:11:38.732058 (delta: 0.041484)         elapsed: 35.918281 ******* 
included: /apps/percona/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating volume snapshot location] ***************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:4
2019-11-06T00:11:38.800508 (delta: 0.068409)         elapsed: 35.986731 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f volume-snapshot-location.yml", "delta": "0:00:00.753940", "end": "2019-11-06 00:11:39.694739", "failed_when_result": false, "rc": 0, "start": "2019-11-06 00:11:38.940799", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotlocation.velero.io/minio created", "stdout_lines": ["volumesnapshotlocation.velero.io/minio created"]}

TASK [Creating Backup] *********************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:9
2019-11-06T00:11:39.740737 (delta: 0.940193)         elapsed: 36.92696 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero backup create percona-backup --include-namespaces=app-percona-ns --snapshot-volumes --volume-snapshot-locations=minio", "delta": "0:00:00.589979", "end": "2019-11-06 00:11:40.521882", "rc": 0, "start": "2019-11-06 00:11:39.931903", "stderr": "", "stderr_lines": [], "stdout": "Backup request \"percona-backup\" submitted successfully.\nRun `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details.", "stdout_lines": ["Backup request \"percona-backup\" submitted successfully.", "Run `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details."]}

TASK [Getting the state of Backup] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:15
2019-11-06T00:11:40.563269 (delta: 0.822475)         elapsed: 37.749492 ******* 
FAILED - RETRYING: Getting the state of Backup (15 retries left).
FAILED - RETRYING: Getting the state of Backup (14 retries left).
FAILED - RETRYING: Getting the state of Backup (13 retries left).
FAILED - RETRYING: Getting the state of Backup (12 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get backup percona-backup -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:00.617623", "end": "2019-11-06 00:12:04.452392", "rc": 0, "start": "2019-11-06 00:12:03.834769", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Creating application namespace] ******************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:26
2019-11-06T00:12:04.493807 (delta: 23.930487)         elapsed: 61.68003 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoreing application] **************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:31
2019-11-06T00:12:04.535512 (delta: 0.041644)         elapsed: 61.721735 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:37
2019-11-06T00:12:04.575234 (delta: 0.03968)         elapsed: 61.761457 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:41
2019-11-06T00:12:04.619454 (delta: 0.044178)         elapsed: 61.805677 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting Application] ****************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:43
2019-11-06T00:12:04.661543 (delta: 0.042043)         elapsed: 61.847766 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc,deploy,svc --all -n app-percona-ns\n kubectl delete ns app-percona-ns", "delta": "0:00:12.511941", "end": "2019-11-06 00:12:17.378238", "rc": 0, "start": "2019-11-06 00:12:04.866297", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"percona-mysql-claim\" deleted\ndeployment.extensions \"percona\" deleted\nservice \"percona-mysql\" deleted\nnamespace \"app-percona-ns\" deleted", "stdout_lines": ["persistentvolumeclaim \"percona-mysql-claim\" deleted", "deployment.extensions \"percona\" deleted", "service \"percona-mysql\" deleted", "namespace \"app-percona-ns\" deleted"]}

TASK [Checking whether namespace is deleted] ***********************************
task path: /apps/percona/functional/backup_and_restore/test.yml:48
2019-11-06T00:12:17.418613 (delta: 12.757026)         elapsed: 74.604836 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.640847", "end": "2019-11-06 00:12:18.208537", "rc": 0, "start": "2019-11-06 00:12:17.567690", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-system\nlitmus\nopenebs\nvelero", "stdout_lines": ["default", "kube-public", "kube-system", "litmus", "openebs", "velero"]}

TASK [Restoreing Application] **************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:60
2019-11-06T00:12:18.265575 (delta: 0.846925)         elapsed: 75.451798 ******* 
included: /apps/percona/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating volume snapshot location] ***************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:4
2019-11-06T00:12:18.337247 (delta: 0.07162)         elapsed: 75.52347 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:9
2019-11-06T00:12:18.384375 (delta: 0.047083)         elapsed: 75.570598 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:15
2019-11-06T00:12:18.426401 (delta: 0.041979)         elapsed: 75.612624 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:26
2019-11-06T00:12:18.466154 (delta: 0.039703)         elapsed: 75.652377 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-percona-ns", "delta": "0:00:00.624497", "end": "2019-11-06 00:12:19.240697", "failed_when_result": false, "rc": 0, "start": "2019-11-06 00:12:18.616200", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-percona-ns created", "stdout_lines": ["namespace/app-percona-ns created"]}

TASK [Restoreing application] **************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:31
2019-11-06T00:12:19.285567 (delta: 0.819364)         elapsed: 76.47179 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero restore create --from-backup percona-backup --restore-volumes=true", "delta": "0:00:00.596568", "end": "2019-11-06 00:12:20.031563", "rc": 0, "start": "2019-11-06 00:12:19.434995", "stderr": "", "stderr_lines": [], "stdout": "Restore request \"percona-backup-20191106001220\" submitted successfully.\nRun `velero restore describe percona-backup-20191106001220` or `velero restore logs percona-backup-20191106001220` for more details.", "stdout_lines": ["Restore request \"percona-backup-20191106001220\" submitted successfully.", "Run `velero restore describe percona-backup-20191106001220` or `velero restore logs percona-backup-20191106001220` for more details."]}

TASK [Getting restore name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:37
2019-11-06T00:12:20.076678 (delta: 0.791067)         elapsed: 77.262901 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero get restore | grep percona-backup | awk '{print $1}'", "delta": "0:00:00.664466", "end": "2019-11-06 00:12:20.915971", "rc": 0, "start": "2019-11-06 00:12:20.251505", "stderr": "", "stderr_lines": [], "stdout": "percona-backup-20191106001220", "stdout_lines": ["percona-backup-20191106001220"]}

TASK [Checking the restore status] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:41
2019-11-06T00:12:20.967854 (delta: 0.891134)         elapsed: 78.154077 ******* 
FAILED - RETRYING: Checking the restore status (45 retries left).
FAILED - RETRYING: Checking the restore status (44 retries left).
FAILED - RETRYING: Checking the restore status (43 retries left).
FAILED - RETRYING: Checking the restore status (42 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get restore percona-backup-20191106001220 -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:00.631879", "end": "2019-11-06 00:12:44.886257", "rc": 0, "start": "2019-11-06 00:12:44.254378", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Getting the volume name] *************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:65
2019-11-06T00:12:44.927313 (delta: 23.959412)         elapsed: 102.113536 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns -o jsonpath='{.spec.volumeName}'", "delta": "0:00:00.621125", "end": "2019-11-06 00:12:45.692171", "rc": 0, "start": "2019-11-06 00:12:45.071046", "stderr": "", "stderr_lines": [], "stdout": "pvc-19815c37-002a-11ea-8939-42010a800092", "stdout_lines": ["pvc-19815c37-002a-11ea-8939-42010a800092"]}

TASK [Getting the target IP] ***************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:69
2019-11-06T00:12:45.732139 (delta: 0.804783)         elapsed: 102.918362 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -o wide | grep pvc-19815c37-002a-11ea-8939-42010a800092 | awk '{print $6}'", "delta": "0:00:00.613068", "end": "2019-11-06 00:12:46.493008", "rc": 0, "start": "2019-11-06 00:12:45.879940", "stderr": "", "stderr_lines": [], "stdout": "10.80.2.51", "stdout_lines": ["10.80.2.51"]}

TASK [Getting storage class name] **********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:73
2019-11-06T00:12:46.531310 (delta: 0.799128)         elapsed: 103.717533 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-19815c37-002a-11ea-8939-42010a800092 -o jsonpath='{.spec.storageClassName}'", "delta": "0:00:00.633622", "end": "2019-11-06 00:12:47.303118", "rc": 0, "start": "2019-11-06 00:12:46.669496", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Getting the spc name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:77
2019-11-06T00:12:47.349609 (delta: 0.818253)         elapsed: 104.535832 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse -o jsonpath='{.metadata.annotations.cas\\.openebs\\.io/config}' | grep -A 1 StoragePoolClaim | awk 'FNR == 2 {print}' | cut -d' ' -f4", "delta": "0:00:00.617250", "end": "2019-11-06 00:12:48.107127", "rc": 0, "start": "2019-11-06 00:12:47.489877", "stderr": "", "stderr_lines": [], "stdout": "\"cstor-sparse-pool\"", "stdout_lines": ["\"cstor-sparse-pool\""]}

TASK [Getting the pool pod corresponding to spc] *******************************
task path: /apps/percona/functional/backup_and_restore/test.yml:81
2019-11-06T00:12:48.146009 (delta: 0.796354)         elapsed: 105.332232 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs --no-headers -l openebs.io/storage-pool-claim=\"cstor-sparse-pool\" | awk '{print $1}'", "delta": "0:00:00.619399", "end": "2019-11-06 00:12:48.905900", "rc": 0, "start": "2019-11-06 00:12:48.286501", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6\ncstor-sparse-pool-jjx2-d454b8fb5-fq8hb\ncstor-sparse-pool-ws9e-7889cfc9dc-42z47", "stdout_lines": ["cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6", "cstor-sparse-pool-jjx2-d454b8fb5-fq8hb", "cstor-sparse-pool-ws9e-7889cfc9dc-42z47"]}

TASK [Getting the volume name inside cstor pool] *******************************
task path: /apps/percona/functional/backup_and_restore/test.yml:85
2019-11-06T00:12:48.945850 (delta: 0.799793)         elapsed: 106.132073 ****** 
changed: [127.0.0.1] => (item=cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6 -n openebs -c cstor-pool -- zfs list | grep pvc-19815c37-002a-11ea-8939-42010a800092 | awk '{print $1}') >> cstor-vol", "delta": "0:00:00.833700", "end": "2019-11-06 00:12:49.925252", "item": "cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6", "rc": 0, "start": "2019-11-06 00:12:49.091552", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-sparse-pool-jjx2-d454b8fb5-fq8hb) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-sparse-pool-jjx2-d454b8fb5-fq8hb -n openebs -c cstor-pool -- zfs list | grep pvc-19815c37-002a-11ea-8939-42010a800092 | awk '{print $1}') >> cstor-vol", "delta": "0:00:00.801045", "end": "2019-11-06 00:12:50.855434", "item": "cstor-sparse-pool-jjx2-d454b8fb5-fq8hb", "rc": 0, "start": "2019-11-06 00:12:50.054389", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-sparse-pool-ws9e-7889cfc9dc-42z47) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-sparse-pool-ws9e-7889cfc9dc-42z47 -n openebs -c cstor-pool -- zfs list | grep pvc-19815c37-002a-11ea-8939-42010a800092 | awk '{print $1}') >> cstor-vol", "delta": "0:00:00.792728", "end": "2019-11-06 00:12:51.793817", "item": "cstor-sparse-pool-ws9e-7889cfc9dc-42z47", "rc": 0, "start": "2019-11-06 00:12:51.001089", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Assingning the cstor-pool volume name to variable] ***********************
task path: /apps/percona/functional/backup_and_restore/test.yml:90
2019-11-06T00:12:51.834582 (delta: 2.888689)         elapsed: 109.020805 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat ./cstor-vol", "delta": "0:00:00.522737", "end": "2019-11-06 00:12:52.504470", "rc": 0, "start": "2019-11-06 00:12:51.981733", "stderr": "", "stderr_lines": [], "stdout": "cstor-f1e93ee1-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092\ncstor-f1511d22-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092\ncstor-f28112a4-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092", "stdout_lines": ["cstor-f1e93ee1-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092", "cstor-f1511d22-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092", "cstor-f28112a4-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092"]}

TASK [Setting target IP for volume inside cstor pool] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:94
2019-11-06T00:12:52.544417 (delta: 0.709783)         elapsed: 109.73064 ******* 
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6', u'cstor-f1e93ee1-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092']) => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6 -n openebs -- zfs set io.openebs:targetip=10.80.2.51 cstor-f1e93ee1-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092", "delta": "0:00:00.968984", "end": "2019-11-06 00:12:53.669362", "item": ["cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6", "cstor-f1e93ee1-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092"], "rc": 0, "start": "2019-11-06 00:12:52.700378", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6 -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-eyi7-6b76c8cbdf-dnmv6 -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-jjx2-d454b8fb5-fq8hb', u'cstor-f1511d22-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092']) => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-jjx2-d454b8fb5-fq8hb -n openebs -- zfs set io.openebs:targetip=10.80.2.51 cstor-f1511d22-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092", "delta": "0:00:00.914170", "end": "2019-11-06 00:12:54.726254", "item": ["cstor-sparse-pool-jjx2-d454b8fb5-fq8hb", "cstor-f1511d22-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092"], "rc": 0, "start": "2019-11-06 00:12:53.812084", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-jjx2-d454b8fb5-fq8hb -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-jjx2-d454b8fb5-fq8hb -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-ws9e-7889cfc9dc-42z47', u'cstor-f28112a4-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092']) => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-ws9e-7889cfc9dc-42z47 -n openebs -- zfs set io.openebs:targetip=10.80.2.51 cstor-f28112a4-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092", "delta": "0:00:00.843504", "end": "2019-11-06 00:12:55.693165", "item": ["cstor-sparse-pool-ws9e-7889cfc9dc-42z47", "cstor-f28112a4-000b-11ea-8939-42010a800092/pvc-19815c37-002a-11ea-8939-42010a800092"], "rc": 0, "start": "2019-11-06 00:12:54.849661", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-ws9e-7889cfc9dc-42z47 -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-ws9e-7889cfc9dc-42z47 -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Waiting for application to be in ruuning state] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:100
2019-11-06T00:12:55.733528 (delta: 3.189067)         elapsed: 112.919751 ****** 
FAILED - RETRYING: Waiting for application to be in ruuning state (15 retries left).
FAILED - RETRYING: Waiting for application to be in ruuning state (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod percona-598c987dc8-bcdlh -n app-percona-ns -o jsonpath='{.status.phase}'", "delta": "0:00:00.652018", "end": "2019-11-06 00:13:08.078254", "rc": 0, "start": "2019-11-06 00:13:07.426236", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying Data persistense] **********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:107
2019-11-06T00:13:08.127925 (delta: 12.394355)         elapsed: 125.314148 ***** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-11-06T00:13:08.216561 (delta: 0.088592)         elapsed: 125.402784 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-11-06T00:13:08.282228 (delta: 0.065625)         elapsed: 125.468451 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-598c987dc8-bcdlh -n app-percona-ns", "delta": "0:00:14.520048", "end": "2019-11-06 00:13:22.964628", "rc": 0, "start": "2019-11-06 00:13:08.444580", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-598c987dc8-bcdlh\" deleted", "stdout_lines": ["pod \"percona-598c987dc8-bcdlh\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-11-06T00:13:23.003730 (delta: 14.721455)         elapsed: 140.189953 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:00.640322", "end": "2019-11-06 00:13:23.798706", "rc": 0, "start": "2019-11-06 00:13:23.158384", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS    RESTARTS   AGE\npercona-598c987dc8-gc659   1/1     Running   0          14s", "stdout_lines": ["NAME                       READY   STATUS    RESTARTS   AGE", "percona-598c987dc8-gc659   1/1     Running   0          14s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-11-06T00:13:23.848768 (delta: 0.844987)         elapsed: 141.034991 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:00.636998", "end": "2019-11-06 00:13:24.633578", "rc": 0, "start": "2019-11-06 00:13:23.996580", "stderr": "", "stderr_lines": [], "stdout": "percona-598c987dc8-gc659", "stdout_lines": ["percona-598c987dc8-gc659"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-11-06T00:13:24.672936 (delta: 0.824123)         elapsed: 141.859159 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-598c987dc8-gc659\")].status.phase}'", "delta": "0:00:00.623025", "end": "2019-11-06 00:13:25.439559", "rc": 0, "start": "2019-11-06 00:13:24.816534", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-11-06T00:13:25.485042 (delta: 0.812058)         elapsed: 142.671265 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-598c987dc8-gc659\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.621609", "end": "2019-11-06 00:13:26.253389", "rc": 0, "start": "2019-11-06 00:13:25.631780", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-11-06T00:13:12Z]]", "stdout_lines": ["map[running:map[startedAt:2019-11-06T00:13:12Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-11-06T00:13:26.295884 (delta: 0.810796)         elapsed: 143.482107 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-598c987dc8-gc659 -n app-percona-ns -- mysqlcheck -c backup -uroot -pk8sDem0", "delta": "0:00:00.800427", "end": "2019-11-06 00:13:27.246037", "failed_when_result": false, "rc": 0, "start": "2019-11-06 00:13:26.445610", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "backup.ttbl                                        OK", "stdout_lines": ["backup.ttbl                                        OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-11-06T00:13:27.290415 (delta: 0.994484)         elapsed: 144.476638 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-598c987dc8-gc659 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' backup;", "delta": "0:00:00.791530", "end": "2019-11-06 00:13:28.232027", "failed_when_result": false, "rc": 0, "start": "2019-11-06 00:13:27.440497", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-11-06T00:13:28.275349 (delta: 0.984897)         elapsed: 145.461572 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-11-06T00:13:28.315045 (delta: 0.039658)         elapsed: 145.501268 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:118
2019-11-06T00:13:28.357202 (delta: 0.042112)         elapsed: 145.543425 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:126
2019-11-06T00:13:28.414141 (delta: 0.056893)         elapsed: 145.600364 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-06T00:13:28.490304 (delta: 0.076118)         elapsed: 145.676527 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-06T00:13:28.535502 (delta: 0.045147)         elapsed: 145.721725 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-06T00:13:28.576590 (delta: 0.041034)         elapsed: 145.762813 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-06T00:13:28.616382 (delta: 0.039749)         elapsed: 145.802605 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "218cc4cd06f4a20f4ce3c234b033d66800aa02b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9f2161a292cb589ce3599bf99ea6818b", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1572999208.66-237200747116344/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-06T00:13:29.982048 (delta: 1.365619)         elapsed: 147.168271 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.523014", "end": "2019-11-06 00:13:30.661488", "rc": 0, "start": "2019-11-06 00:13:30.138474", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-06T00:13:30.701750 (delta: 0.719655)         elapsed: 147.887973 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-05T20:43:24Z", "generation": 32, "name": "velero-backup-restore", "resourceVersion": "74311", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "e93f55f9-000c-11ea-8939-42010a800092"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=43   unreachable=0    failed=0   

2019-11-06T00:13:31.434788 (delta: 0.733)         elapsed: 148.621011 ********* 
===============================================================================
```
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
