### PR TITLE
refactor[litmusbook]: backup and restore script to wait until target pod is in running state

### DIFF
--- a/apps/percona/functional/backup_and_restore/backup-restore.yml
+++ b/apps/percona/functional/backup_and_restore/backup-restore.yml
@@ -25,7 +25,7 @@
 
    - name: Restoring application 
      shell: >
-       velero restore create --from-backup {{ backup-name }} --restore-volumes=true
+       velero restore create --from-backup {{ backup_name }} --restore-volumes=true
      args:
        executable: /bin/bash
 

--- a/apps/percona/functional/backup_and_restore/setup_dependency.yml
+++ b/apps/percona/functional/backup_and_restore/setup_dependency.yml
@@ -15,8 +15,8 @@
 
 - name: Checking the velero version
   shell: velero version
-  register: velero_version
-  failed_when: "velero_version not in velero_version.stdout"
+  register: velero
+  failed_when: "velero_version not in velero.stdout"
 
 - name: Installing minio s3-bucket
   shell: kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml

--- a/apps/percona/functional/backup_and_restore/test.yml
+++ b/apps/percona/functional/backup_and_restore/test.yml
@@ -67,8 +67,11 @@
           register: volume_name
 
         - name: Getting the target IP
-          shell: kubectl get pod -n openebs -o wide | grep {{ volume_name.stdout }} | awk '{print $6}'
+          shell: kubectl get pod -n openebs -l openebs.io/persistent-volume={{ volume_name.stdout }} -o jsonpath='{.items[0].status.podIP}'
           register: target_ip
+          until: 'target_ip.stdout != ""'
+          delay: 5
+          retries: 10
 
         - name: Getting storage class name
           shell: kubectl get pv {{ volume_name.stdout }} -o jsonpath='{.spec.storageClassName}'


### PR DESCRIPTION

Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>


**What this PR does / why we need it**:
- waits for target pod to be in running state
- Fix typo in getting restore status task.
**Following is the log of ansible-test container**
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./apps/percona/functional/backup_and_restore/test.yml

PLAY [localhost] ***************************************************************
2019-11-11T07:09:08.308225 (delta: 0.067182)         elapsed: 0.067182 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:1
2019-11-11T07:09:08.322540 (delta: 0.01425)         elapsed: 0.081497 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:12
2019-11-11T07:09:17.995553 (delta: 9.672981)         elapsed: 9.75451 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-11T07:09:18.107405 (delta: 0.111789)         elapsed: 9.866362 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-11T07:09:18.200398 (delta: 0.092865)         elapsed: 9.959355 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:15
2019-11-11T07:09:18.331483 (delta: 0.130852)         elapsed: 10.09044 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-11T07:09:18.547808 (delta: 0.216197)         elapsed: 10.306765 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cb23761ee0ecfea3a093f94c0443739c777b3007", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0da5664e16958d4f3c263662ebe36b5c", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1573456158.65-42965686374771/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-11T07:09:19.520704 (delta: 0.972795)         elapsed: 11.279661 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.250825", "end": "2019-11-11 07:09:21.234411", "rc": 0, "start": "2019-11-11 07:09:19.983586", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-11T07:09:21.297347 (delta: 1.776584)         elapsed: 13.056304 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-11T06:06:36Z", "generation": 1, "name": "velero-backup-restore", "namespace": "", "resourceVersion": "38772", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "6af315d5-0449-11ea-92eb-00505698550d"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-11T07:09:22.798706 (delta: 1.501301)         elapsed: 14.557663 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-11T07:09:22.875953 (delta: 0.077168)         elapsed: 14.63491 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-11T07:09:22.972364 (delta: 0.096326)         elapsed: 14.731321 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:19
2019-11-11T07:09:23.074363 (delta: 0.101888)         elapsed: 14.83332 ******** 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2019-11-11T07:09:23.258849 (delta: 0.184349)         elapsed: 15.017806 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:02.263844", "end": "2019-11-11 07:09:25.872369", "rc": 0, "start": "2019-11-11 07:09:23.608525", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2019-11-11T07:09:25.936062 (delta: 2.677142)         elapsed: 17.695019 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2019-11-11T07:09:26.002929 (delta: 0.066811)         elapsed: 17.761886 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:22
2019-11-11T07:09:26.059570 (delta: 0.056578)         elapsed: 17.818527 ******* 
included: /apps/percona/functional/backup_and_restore/setup_dependency.yml for 127.0.0.1

TASK [Downloading velero binary] ***********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:1
2019-11-11T07:09:26.180806 (delta: 0.12117)         elapsed: 17.939763 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "24c98ca1c9cfe5c754c76c07ba6cbc517bc68f92", "dest": "./velero-v1.1.0-linux-amd64.tar.gz", "gid": 0, "group": "root", "md5sum": "2f8fb6505764a6f937b8b5645d4b8fb8", "mode": "0644", "msg": "OK (26731554 bytes)", "owner": "root", "size": 26731554, "src": "/root/.ansible/tmp/ansible-tmp-1573456166.26-161522908126323/tmpRMCscP", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/vmware-tanzu/velero/releases/download/v1.1.0/velero-v1.1.0-linux-amd64.tar.gz"}

TASK [Installing velero inside litmus container] *******************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:11
2019-11-11T07:09:38.727012 (delta: 12.546143)         elapsed: 30.485969 ****** 
 [WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "tar -xvf velero-v1.1.0-linux-amd64.tar.gz\n mv velero-v1.1.0-linux-amd64/velero /usr/local/bin/", "delta": "0:00:01.969711", "end": "2019-11-11 07:09:40.966279", "rc": 0, "start": "2019-11-11 07:09:38.996568", "stderr": "", "stderr_lines": [], "stdout": "velero-v1.1.0-linux-amd64/LICENSE\nvelero-v1.1.0-linux-amd64/examples/README.md\nvelero-v1.1.0-linux-amd64/examples/minio\nvelero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app\nvelero-v1.1.0-linux-amd64/examples/nginx-app/README.md\nvelero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml\nvelero-v1.1.0-linux-amd64/velero", "stdout_lines": ["velero-v1.1.0-linux-amd64/LICENSE", "velero-v1.1.0-linux-amd64/examples/README.md", "velero-v1.1.0-linux-amd64/examples/minio", "velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app", "velero-v1.1.0-linux-amd64/examples/nginx-app/README.md", "velero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml", "velero-v1.1.0-linux-amd64/velero"]}

TASK [Checking the velero version] *********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:16
2019-11-11T07:09:41.025246 (delta: 2.298166)         elapsed: 32.784203 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero version", "delta": "0:00:01.268891", "end": "2019-11-11 07:09:42.527724", "failed_when_result": false, "rc": 0, "start": "2019-11-11 07:09:41.258833", "stderr": "", "stderr_lines": [], "stdout": "Client:\n\tVersion: v1.1.0\n\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608\n<error getting server version: namespaces \"velero\" not found>", "stdout_lines": ["Client:", "\tVersion: v1.1.0", "\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608", "<error getting server version: namespaces \"velero\" not found>"]}

TASK [Installing minio s3-bucket] **********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:21
2019-11-11T07:09:42.658895 (delta: 1.633587)         elapsed: 34.417852 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "delta": "0:00:01.727977", "end": "2019-11-11 07:09:44.709925", "rc": 0, "start": "2019-11-11 07:09:42.981948", "stderr": "", "stderr_lines": [], "stdout": "namespace/velero created\ndeployment.apps/minio created\nservice/minio created\njob.batch/minio-setup created", "stdout_lines": ["namespace/velero created", "deployment.apps/minio created", "service/minio created", "job.batch/minio-setup created"]}

TASK [Checking for minio pod status] *******************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:24
2019-11-11T07:09:44.830072 (delta: 2.171075)         elapsed: 36.589029 ******* 
FAILED - RETRYING: Checking for minio pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.227011", "end": "2019-11-11 07:09:53.078268", "rc": 0, "start": "2019-11-11 07:09:51.851257", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing velero server inside cluster] *********************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:31
2019-11-11T07:09:53.163386 (delta: 8.333199)         elapsed: 44.922343 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero install --provider aws --bucket velero --secret-file ./credentials-velero --use-volume-snapshots=false --backup-location-config region=minio,s3ForcePathStyle=\"true\",s3Url=http://minio.velero.svc:9000", "delta": "0:00:03.058916", "end": "2019-11-11 07:09:56.575053", "rc": 0, "start": "2019-11-11 07:09:53.516137", "stderr": "", "stderr_lines": [], "stdout": "CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumerestores.velero.io: created\nCustomResourceDefinition/resticrepositories.velero.io: attempting to create resource\nCustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding\nCustomResourceDefinition/resticrepositories.velero.io: created\nCustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource\nCustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding\nCustomResourceDefinition/volumesnapshotlocations.velero.io: created\nCustomResourceDefinition/restores.velero.io: attempting to create resource\nCustomResourceDefinition/restores.velero.io: already exists, proceeding\nCustomResourceDefinition/restores.velero.io: created\nCustomResourceDefinition/schedules.velero.io: attempting to create resource\nCustomResourceDefinition/schedules.velero.io: already exists, proceeding\nCustomResourceDefinition/schedules.velero.io: created\nCustomResourceDefinition/downloadrequests.velero.io: attempting to create resource\nCustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/downloadrequests.velero.io: created\nCustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource\nCustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding\nCustomResourceDefinition/deletebackuprequests.velero.io: created\nCustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumebackups.velero.io: created\nCustomResourceDefinition/backups.velero.io: attempting to create resource\nCustomResourceDefinition/backups.velero.io: already exists, proceeding\nCustomResourceDefinition/backups.velero.io: created\nCustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource\nCustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding\nCustomResourceDefinition/backupstoragelocations.velero.io: created\nCustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource\nCustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/serverstatusrequests.velero.io: created\nWaiting for resources to be ready in cluster...\nNamespace/velero: attempting to create resource\nNamespace/velero: already exists, proceeding\nNamespace/velero: created\nClusterRoleBinding/velero: attempting to create resource\nClusterRoleBinding/velero: already exists, proceeding\nClusterRoleBinding/velero: created\nServiceAccount/velero: attempting to create resource\nServiceAccount/velero: created\nSecret/cloud-credentials: attempting to create resource\nSecret/cloud-credentials: created\nBackupStorageLocation/default: attempting to create resource\nBackupStorageLocation/default: created\nDeployment/velero: attempting to create resource\nDeployment/velero: created\nVelero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status.", "stdout_lines": ["CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumerestores.velero.io: created", "CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource", "CustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding", "CustomResourceDefinition/resticrepositories.velero.io: created", "CustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource", "CustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding", "CustomResourceDefinition/volumesnapshotlocations.velero.io: created", "CustomResourceDefinition/restores.velero.io: attempting to create resource", "CustomResourceDefinition/restores.velero.io: already exists, proceeding", "CustomResourceDefinition/restores.velero.io: created", "CustomResourceDefinition/schedules.velero.io: attempting to create resource", "CustomResourceDefinition/schedules.velero.io: already exists, proceeding", "CustomResourceDefinition/schedules.velero.io: created", "CustomResourceDefinition/downloadrequests.velero.io: attempting to create resource", "CustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/downloadrequests.velero.io: created", "CustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource", "CustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding", "CustomResourceDefinition/deletebackuprequests.velero.io: created", "CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumebackups.velero.io: created", "CustomResourceDefinition/backups.velero.io: attempting to create resource", "CustomResourceDefinition/backups.velero.io: already exists, proceeding", "CustomResourceDefinition/backups.velero.io: created", "CustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource", "CustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding", "CustomResourceDefinition/backupstoragelocations.velero.io: created", "CustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource", "CustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/serverstatusrequests.velero.io: created", "Waiting for resources to be ready in cluster...", "Namespace/velero: attempting to create resource", "Namespace/velero: already exists, proceeding", "Namespace/velero: created", "ClusterRoleBinding/velero: attempting to create resource", "ClusterRoleBinding/velero: already exists, proceeding", "ClusterRoleBinding/velero: created", "ServiceAccount/velero: attempting to create resource", "ServiceAccount/velero: created", "Secret/cloud-credentials: attempting to create resource", "Secret/cloud-credentials: created", "BackupStorageLocation/default: attempting to create resource", "BackupStorageLocation/default: created", "Deployment/velero: attempting to create resource", "Deployment/velero: created", "Velero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status."]}

TASK [Checking for velero server status] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:40
2019-11-11T07:09:56.719536 (delta: 3.555972)         elapsed: 48.478493 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.313556", "end": "2019-11-11 07:10:04.742722", "rc": 0, "start": "2019-11-11 07:10:03.429166", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing development image of OpenEBS velero-plugin] *******************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:47
2019-11-11T07:10:04.810798 (delta: 8.091121)         elapsed: 56.569755 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero plugin add openebs/velero-plugin:ci", "delta": "0:00:00.980743", "end": "2019-11-11 07:10:06.057718", "rc": 0, "start": "2019-11-11 07:10:05.076975", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Checking for velero server status] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:50
2019-11-11T07:10:06.115756 (delta: 1.304898)         elapsed: 57.874713 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.244777", "end": "2019-11-11 07:10:14.143271", "rc": 0, "start": "2019-11-11 07:10:12.898494", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Creating volume snapshot location] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:57
2019-11-11T07:10:14.246543 (delta: 8.13073)         elapsed: 66.0055 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f volume-snapshot-location.yml", "delta": "0:00:01.801398", "end": "2019-11-11 07:10:16.347452", "failed_when_result": false, "rc": 0, "start": "2019-11-11 07:10:14.546054", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotlocation.velero.io/minio created", "stdout_lines": ["volumesnapshotlocation.velero.io/minio created"]}

TASK [Get Application  pod details] ********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:24
2019-11-11T07:10:16.491122 (delta: 2.244454)         elapsed: 68.250079 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.227758", "end": "2019-11-11 07:10:17.968587", "rc": 0, "start": "2019-11-11 07:10:16.740829", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-v7ssz", "stdout_lines": ["percona-cb697f8b4-v7ssz"]}

TASK [Create new database in the mysql] ****************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:28
2019-11-11T07:10:18.069082 (delta: 1.577898)         elapsed: 69.828039 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-11-11T07:10:18.303131 (delta: 0.233949)         elapsed: 70.062088 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;') => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-v7ssz -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database backup;'", "delta": "0:00:02.484704", "end": "2019-11-11 07:10:21.098083", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "rc": 0, "start": "2019-11-11 07:10:18.613379", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-v7ssz -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "delta": "0:00:01.971847", "end": "2019-11-11 07:10:23.471148", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "rc": 0, "start": "2019-11-11 07:10:21.499301", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-v7ssz -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "delta": "0:00:01.881063", "end": "2019-11-11 07:10:25.565973", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "rc": 0, "start": "2019-11-11 07:10:23.684910", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-11-11T07:10:25.705327 (delta: 7.402114)         elapsed: 77.464284 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-11-11T07:10:25.845184 (delta: 0.139715)         elapsed: 77.604141 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-11-11T07:10:25.968103 (delta: 0.122811)         elapsed: 77.72706 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-11-11T07:10:26.028395 (delta: 0.060184)         elapsed: 77.787352 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-11-11T07:10:26.089670 (delta: 0.061193)         elapsed: 77.848627 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-11-11T07:10:26.149674 (delta: 0.059937)         elapsed: 77.908631 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-11-11T07:10:26.212168 (delta: 0.062434)         elapsed: 77.971125 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-11-11T07:10:26.268443 (delta: 0.056184)         elapsed: 78.0274 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-11-11T07:10:26.329177 (delta: 0.060666)         elapsed: 78.088134 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup for the provided application] ****************************
task path: /apps/percona/functional/backup_and_restore/test.yml:38
2019-11-11T07:10:26.398591 (delta: 0.069353)         elapsed: 78.157548 ******* 
included: /apps/percona/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:4
2019-11-11T07:10:26.572948 (delta: 0.174251)         elapsed: 78.331905 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero backup create percona-backup --include-namespaces=app-percona-ns --snapshot-volumes --volume-snapshot-locations=minio", "delta": "0:00:01.004923", "end": "2019-11-11 07:10:27.884467", "rc": 0, "start": "2019-11-11 07:10:26.879544", "stderr": "", "stderr_lines": [], "stdout": "Backup request \"percona-backup\" submitted successfully.\nRun `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details.", "stdout_lines": ["Backup request \"percona-backup\" submitted successfully.", "Run `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details."]}

TASK [Getting the state of Backup] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:10
2019-11-11T07:10:27.961863 (delta: 1.388806)         elapsed: 79.72082 ******** 
FAILED - RETRYING: Getting the state of Backup (30 retries left).
FAILED - RETRYING: Getting the state of Backup (29 retries left).
FAILED - RETRYING: Getting the state of Backup (28 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get backup percona-backup -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.271044", "end": "2019-11-11 07:10:49.370792", "rc": 0, "start": "2019-11-11 07:10:48.099748", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Creating application namespace] ******************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:21
2019-11-11T07:10:49.463228 (delta: 21.501297)         elapsed: 101.222185 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:26
2019-11-11T07:10:49.586119 (delta: 0.122816)         elapsed: 101.345076 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:32
2019-11-11T07:10:49.709316 (delta: 0.123078)         elapsed: 101.468273 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:36
2019-11-11T07:10:49.825800 (delta: 0.116342)         elapsed: 101.584757 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting Application] ****************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:43
2019-11-11T07:10:49.973361 (delta: 0.147453)         elapsed: 101.732318 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc,deploy,svc --all -n app-percona-ns\n kubectl delete ns app-percona-ns", "delta": "0:00:11.923508", "end": "2019-11-11 07:11:02.133264", "rc": 0, "start": "2019-11-11 07:10:50.209756", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"percona-mysql-claim\" deleted\ndeployment.extensions \"percona\" deleted\nservice \"percona-mysql\" deleted\nnamespace \"app-percona-ns\" deleted", "stdout_lines": ["persistentvolumeclaim \"percona-mysql-claim\" deleted", "deployment.extensions \"percona\" deleted", "service \"percona-mysql\" deleted", "namespace \"app-percona-ns\" deleted"]}

TASK [Checking whether namespace is deleted] ***********************************
task path: /apps/percona/functional/backup_and_restore/test.yml:48
2019-11-11T07:11:02.246015 (delta: 12.272455)         elapsed: 114.004972 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:02.114830", "end": "2019-11-11 07:11:04.703560", "rc": 0, "start": "2019-11-11 07:11:02.588730", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\nvelero", "stdout_lines": ["default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "velero"]}

TASK [Restoring Application] ***************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:60
2019-11-11T07:11:04.909453 (delta: 2.663293)         elapsed: 116.66841 ******* 
included: /apps/percona/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:4
2019-11-11T07:11:05.125815 (delta: 0.21625)         elapsed: 116.884772 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:10
2019-11-11T07:11:05.177846 (delta: 0.051969)         elapsed: 116.936803 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:21
2019-11-11T07:11:05.229554 (delta: 0.051645)         elapsed: 116.988511 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-percona-ns", "delta": "0:00:01.231930", "end": "2019-11-11 07:11:06.692579", "failed_when_result": false, "rc": 0, "start": "2019-11-11 07:11:05.460649", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-percona-ns created", "stdout_lines": ["namespace/app-percona-ns created"]}

TASK [Restoring application] ***************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:26
2019-11-11T07:11:06.788570 (delta: 1.558953)         elapsed: 118.547527 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero restore create --from-backup percona-backup --restore-volumes=true", "delta": "0:00:01.039440", "end": "2019-11-11 07:11:08.278713", "rc": 0, "start": "2019-11-11 07:11:07.239273", "stderr": "", "stderr_lines": [], "stdout": "Restore request \"percona-backup-20191111071108\" submitted successfully.\nRun `velero restore describe percona-backup-20191111071108` or `velero restore logs percona-backup-20191111071108` for more details.", "stdout_lines": ["Restore request \"percona-backup-20191111071108\" submitted successfully.", "Run `velero restore describe percona-backup-20191111071108` or `velero restore logs percona-backup-20191111071108` for more details."]}

TASK [Getting restore name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:32
2019-11-11T07:11:08.373681 (delta: 1.585022)         elapsed: 120.132638 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero get restore | grep percona-backup | awk '{print $1}'", "delta": "0:00:01.196865", "end": "2019-11-11 07:11:09.938180", "rc": 0, "start": "2019-11-11 07:11:08.741315", "stderr": "", "stderr_lines": [], "stdout": "percona-backup-20191111071108", "stdout_lines": ["percona-backup-20191111071108"]}

TASK [Checking the restore status] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:36
2019-11-11T07:11:10.036560 (delta: 1.662772)         elapsed: 121.795517 ****** 
FAILED - RETRYING: Checking the restore status (45 retries left).
FAILED - RETRYING: Checking the restore status (44 retries left).
FAILED - RETRYING: Checking the restore status (43 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get restore percona-backup-20191111071108 -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.331004", "end": "2019-11-11 07:11:31.638295", "rc": 0, "start": "2019-11-11 07:11:30.307291", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Getting the volume name] *************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:65
2019-11-11T07:11:31.752028 (delta: 21.715377)         elapsed: 143.510985 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.094824", "end": "2019-11-11 07:11:33.232985", "rc": 0, "start": "2019-11-11 07:11:32.138161", "stderr": "", "stderr_lines": [], "stdout": "pvc-6f3157ad-0452-11ea-92eb-00505698550d", "stdout_lines": ["pvc-6f3157ad-0452-11ea-92eb-00505698550d"]}

TASK [Getting the target IP] ***************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:69
2019-11-11T07:11:33.310049 (delta: 1.557927)         elapsed: 145.069006 ****** 
FAILED - RETRYING: Getting the target IP (10 retries left).
FAILED - RETRYING: Getting the target IP (9 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=pvc-6f3157ad-0452-11ea-92eb-00505698550d -o jsonpath='{.items[0].status.podIP}'", "delta": "0:00:01.386838", "end": "2019-11-11 07:11:48.115955", "rc": 0, "start": "2019-11-11 07:11:46.729117", "stderr": "", "stderr_lines": [], "stdout": "172.23.2.17", "stdout_lines": ["172.23.2.17"]}

TASK [Getting storage class name] **********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:76
2019-11-11T07:11:48.261933 (delta: 14.951799)         elapsed: 160.02089 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-6f3157ad-0452-11ea-92eb-00505698550d -o jsonpath='{.spec.storageClassName}'", "delta": "0:00:01.341067", "end": "2019-11-11 07:11:50.012971", "rc": 0, "start": "2019-11-11 07:11:48.671904", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Getting the spc name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:80
2019-11-11T07:11:50.088600 (delta: 1.826505)         elapsed: 161.847557 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse -o jsonpath='{.metadata.annotations.cas\\.openebs\\.io/config}' | grep -A 1 StoragePoolClaim | awk 'FNR == 2 {print}' | cut -d' ' -f4", "delta": "0:00:01.288284", "end": "2019-11-11 07:11:51.662227", "rc": 0, "start": "2019-11-11 07:11:50.373943", "stderr": "", "stderr_lines": [], "stdout": "\"cstor-sparse-pool\"", "stdout_lines": ["\"cstor-sparse-pool\""]}

TASK [Getting the pool pod corresponding to spc] *******************************
task path: /apps/percona/functional/backup_and_restore/test.yml:84
2019-11-11T07:11:51.771282 (delta: 1.682607)         elapsed: 163.530239 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs --no-headers -l openebs.io/storage-pool-claim=\"cstor-sparse-pool\" | awk '{print $1}'", "delta": "0:00:01.320009", "end": "2019-11-11 07:11:53.452332", "rc": 0, "start": "2019-11-11 07:11:52.132323", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-d0zj-dcf59f74c-wnpqp\ncstor-sparse-pool-i5gk-566c9f5f6-8pxbc\ncstor-sparse-pool-vw84-bc9b846cf-nckpq", "stdout_lines": ["cstor-sparse-pool-d0zj-dcf59f74c-wnpqp", "cstor-sparse-pool-i5gk-566c9f5f6-8pxbc", "cstor-sparse-pool-vw84-bc9b846cf-nckpq"]}

TASK [Getting the volume name inside cstor pool] *******************************
task path: /apps/percona/functional/backup_and_restore/test.yml:88
2019-11-11T07:11:53.543397 (delta: 1.772009)         elapsed: 165.302354 ****** 
changed: [127.0.0.1] => (item=cstor-sparse-pool-d0zj-dcf59f74c-wnpqp) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-sparse-pool-d0zj-dcf59f74c-wnpqp -n openebs -c cstor-pool -- zfs list | grep pvc-6f3157ad-0452-11ea-92eb-00505698550d | awk '{print $1}') >> cstor-vol", "delta": "0:00:01.326491", "end": "2019-11-11 07:11:55.180626", "item": "cstor-sparse-pool-d0zj-dcf59f74c-wnpqp", "rc": 0, "start": "2019-11-11 07:11:53.854135", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-sparse-pool-i5gk-566c9f5f6-8pxbc) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-sparse-pool-i5gk-566c9f5f6-8pxbc -n openebs -c cstor-pool -- zfs list | grep pvc-6f3157ad-0452-11ea-92eb-00505698550d | awk '{print $1}') >> cstor-vol", "delta": "0:00:01.322879", "end": "2019-11-11 07:11:56.824206", "item": "cstor-sparse-pool-i5gk-566c9f5f6-8pxbc", "rc": 0, "start": "2019-11-11 07:11:55.501327", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-sparse-pool-vw84-bc9b846cf-nckpq) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-sparse-pool-vw84-bc9b846cf-nckpq -n openebs -c cstor-pool -- zfs list | grep pvc-6f3157ad-0452-11ea-92eb-00505698550d | awk '{print $1}') >> cstor-vol", "delta": "0:00:01.484404", "end": "2019-11-11 07:11:58.587635", "item": "cstor-sparse-pool-vw84-bc9b846cf-nckpq", "rc": 0, "start": "2019-11-11 07:11:57.103231", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Assingning the cstor-pool volume name to variable] ***********************
task path: /apps/percona/functional/backup_and_restore/test.yml:93
2019-11-11T07:11:58.651796 (delta: 5.108302)         elapsed: 170.410753 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat ./cstor-vol", "delta": "0:00:01.194794", "end": "2019-11-11 07:12:00.103430", "rc": 0, "start": "2019-11-11 07:11:58.908636", "stderr": "", "stderr_lines": [], "stdout": "cstor-7a00bc26-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d\ncstor-7a987619-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d\ncstor-79662b75-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d", "stdout_lines": ["cstor-7a00bc26-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d", "cstor-7a987619-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d", "cstor-79662b75-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d"]}

TASK [Setting target IP for volume inside cstor pool] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:97
2019-11-11T07:12:00.161677 (delta: 1.509819)         elapsed: 171.920634 ****** 
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-d0zj-dcf59f74c-wnpqp', u'cstor-7a00bc26-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d']) => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-d0zj-dcf59f74c-wnpqp -n openebs -- zfs set io.openebs:targetip=172.23.2.17 cstor-7a00bc26-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d", "delta": "0:00:01.489066", "end": "2019-11-11 07:12:01.904067", "item": ["cstor-sparse-pool-d0zj-dcf59f74c-wnpqp", "cstor-7a00bc26-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d"], "rc": 0, "start": "2019-11-11 07:12:00.415001", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-d0zj-dcf59f74c-wnpqp -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-d0zj-dcf59f74c-wnpqp -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-i5gk-566c9f5f6-8pxbc', u'cstor-7a987619-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d']) => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-i5gk-566c9f5f6-8pxbc -n openebs -- zfs set io.openebs:targetip=172.23.2.17 cstor-7a987619-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d", "delta": "0:00:01.466891", "end": "2019-11-11 07:12:03.671397", "item": ["cstor-sparse-pool-i5gk-566c9f5f6-8pxbc", "cstor-7a987619-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d"], "rc": 0, "start": "2019-11-11 07:12:02.204506", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-i5gk-566c9f5f6-8pxbc -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-i5gk-566c9f5f6-8pxbc -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-vw84-bc9b846cf-nckpq', u'cstor-79662b75-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d']) => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-vw84-bc9b846cf-nckpq -n openebs -- zfs set io.openebs:targetip=172.23.2.17 cstor-79662b75-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d", "delta": "0:00:01.561802", "end": "2019-11-11 07:12:05.590961", "item": ["cstor-sparse-pool-vw84-bc9b846cf-nckpq", "cstor-79662b75-0443-11ea-92eb-00505698550d/pvc-6f3157ad-0452-11ea-92eb-00505698550d"], "rc": 0, "start": "2019-11-11 07:12:04.029159", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-vw84-bc9b846cf-nckpq -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-vw84-bc9b846cf-nckpq -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Waiting for application to be in ruuning state] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:103
2019-11-11T07:12:05.728757 (delta: 5.567023)         elapsed: 177.487714 ****** 
FAILED - RETRYING: Waiting for application to be in ruuning state (30 retries left).
FAILED - RETRYING: Waiting for application to be in ruuning state (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod percona-cb697f8b4-v7ssz -n app-percona-ns -o jsonpath='{.status.phase}'", "delta": "0:00:01.373876", "end": "2019-11-11 07:12:20.779668", "rc": 0, "start": "2019-11-11 07:12:19.405792", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying Data persistense] **********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:110
2019-11-11T07:12:20.866160 (delta: 15.137293)         elapsed: 192.625117 ***** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-11-11T07:12:21.105584 (delta: 0.239331)         elapsed: 192.864541 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-11-11T07:12:21.207691 (delta: 0.10201)         elapsed: 192.966648 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-cb697f8b4-v7ssz -n app-percona-ns", "delta": "0:00:40.725316", "end": "2019-11-11 07:13:02.295364", "rc": 0, "start": "2019-11-11 07:12:21.570048", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-cb697f8b4-v7ssz\" deleted", "stdout_lines": ["pod \"percona-cb697f8b4-v7ssz\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-11-11T07:13:02.357599 (delta: 41.149843)         elapsed: 234.116556 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:01.281262", "end": "2019-11-11 07:13:03.856170", "rc": 0, "start": "2019-11-11 07:13:02.574908", "stderr": "", "stderr_lines": [], "stdout": "NAME                      READY   STATUS    RESTARTS   AGE\npercona-cb697f8b4-46kqb   1/1     Running   0          40s", "stdout_lines": ["NAME                      READY   STATUS    RESTARTS   AGE", "percona-cb697f8b4-46kqb   1/1     Running   0          40s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-11-11T07:13:04.003233 (delta: 1.645574)         elapsed: 235.76219 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.413678", "end": "2019-11-11 07:13:05.707154", "rc": 0, "start": "2019-11-11 07:13:04.293476", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-46kqb", "stdout_lines": ["percona-cb697f8b4-46kqb"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-11-11T07:13:05.839490 (delta: 1.836152)         elapsed: 237.598447 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-46kqb\")].status.phase}'", "delta": "0:00:01.374921", "end": "2019-11-11 07:13:07.524274", "rc": 0, "start": "2019-11-11 07:13:06.149353", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-11-11T07:13:07.636574 (delta: 1.796966)         elapsed: 239.395531 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-46kqb\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.245678", "end": "2019-11-11 07:13:09.163919", "rc": 0, "start": "2019-11-11 07:13:07.918241", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-11-11T07:12:26Z]]", "stdout_lines": ["map[running:map[startedAt:2019-11-11T07:12:26Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-11-11T07:13:09.234475 (delta: 1.597782)         elapsed: 240.993432 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-46kqb -n app-percona-ns -- mysqlcheck -c backup -uroot -pk8sDem0", "delta": "0:00:01.876869", "end": "2019-11-11 07:13:11.413908", "failed_when_result": false, "rc": 0, "start": "2019-11-11 07:13:09.537039", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "backup.ttbl                                        OK", "stdout_lines": ["backup.ttbl                                        OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-11-11T07:13:11.542648 (delta: 2.308111)         elapsed: 243.301605 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-46kqb -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' backup;", "delta": "0:00:01.625341", "end": "2019-11-11 07:13:13.517561", "failed_when_result": false, "rc": 0, "start": "2019-11-11 07:13:11.892220", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-11-11T07:13:13.585881 (delta: 2.043127)         elapsed: 245.344838 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-11-11T07:13:13.650214 (delta: 0.064268)         elapsed: 245.409171 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:121
2019-11-11T07:13:13.707394 (delta: 0.057113)         elapsed: 245.466351 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:129
2019-11-11T07:13:13.806396 (delta: 0.09892)         elapsed: 245.565353 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-11T07:13:13.917584 (delta: 0.111102)         elapsed: 245.676541 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-11T07:13:13.993790 (delta: 0.076143)         elapsed: 245.752747 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-11T07:13:14.064091 (delta: 0.070209)         elapsed: 245.823048 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-11T07:13:14.139636 (delta: 0.075469)         elapsed: 245.898593 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "218cc4cd06f4a20f4ce3c234b033d66800aa02b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9f2161a292cb589ce3599bf99ea6818b", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1573456394.22-6417463149281/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-11T07:13:16.983434 (delta: 2.843723)         elapsed: 248.742391 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.285548", "end": "2019-11-11 07:13:18.614185", "rc": 0, "start": "2019-11-11 07:13:17.328637", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-11T07:13:18.677143 (delta: 1.693638)         elapsed: 250.4361 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-11T06:06:36Z", "generation": 1, "name": "velero-backup-restore", "namespace": "", "resourceVersion": "40167", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "6af315d5-0449-11ea-92eb-00505698550d"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=43   unreachable=0    failed=0
```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
