### PR TITLE
refacto[litmusbook]: Adds logic to get pool name from cvr in velero bakup and restore test

### DIFF
--- a/apps/percona/functional/backup_and_restore/test.yml
+++ b/apps/percona/functional/backup_and_restore/test.yml
@@ -73,31 +73,37 @@
           delay: 5
           retries: 10
 
-        - name: Getting storage class name
-          shell: kubectl get pv {{ volume_name.stdout }} -o jsonpath='{.spec.storageClassName}'
-          register: storage_class
+        - name: Getting the volume name
+          shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
+          register: volume_name
+ 
+        - name: Getting the CVR name from the corresponding PV
+          shell:  kubectl get cvr -n openebs -l openebs.io/persistent-volume={{ volume_name.stdout }} -o jsonpath='{range.items[*]}{.metadata.labels.cstorpool\.openebs\.io/name}{"\n"}{end}'
+          register: cvr_name
 
-        - name: Getting the spc name
-          shell: kubectl get sc {{ storage_class.stdout }} -o jsonpath='{.metadata.annotations.cas\.openebs\.io/config}' | grep -A 1 StoragePoolClaim | awk 'FNR == 2 {print}' | cut -d' ' -f4
-          register: spc_name
+        - name: Geting the CSP name corresponding to CVR
+          shell: kubectl get csp {{item}} -n openebs -o jsonpath='{.metadata.name}'
+          register: csp_pod
+          with_items: "{{ cvr_name.stdout_lines }}"     
 
-        - name: Getting the pool pod corresponding to spc
-          shell: kubectl get po -n openebs --no-headers -l openebs.io/storage-pool-claim={{ spc_name.stdout }} | awk '{print $1}'
+        - name: Getting the pool pod name
+          shell: kubectl get pod -n openebs | grep {{item}} | awk '{print $1}'
           register: pool_pod
+          with_items: "{{ cvr_name.stdout_lines }}" 
 
         - name: Getting the volume name inside cstor pool
           shell: |
-            echo $(kubectl exec -it {{item}} -n openebs -c cstor-pool -- zfs list | grep {{ volume_name.stdout }} | awk '{print $1}') >> cstor-vol
-          with_items: "{{ pool_pod.stdout_lines }}"
+            echo $(kubectl exec -it {{item.stdout}} -n openebs -c cstor-pool -- zfs list | grep {{ volume_name.stdout }} | awk '{print $1}') >> cstor-vol
+          with_items: "{{ pool_pod.results }}"
   
         - name: Assingning the cstor-pool volume name to variable
           shell: cat ./cstor-vol
           register: pool_volume_name
         
         - name: Setting target IP for volume inside cstor pool
-          shell: kubectl exec -it {{item.0}} -n openebs -- zfs set io.openebs:targetip={{ target_ip.stdout }} {{item.1}}
+          shell: kubectl exec -it {{item.0.stdout}} -n openebs -- zfs set io.openebs:targetip={{ target_ip.stdout }} {{item.1}}
           with_together:
-            - "{{ pool_pod.stdout_lines }}"  
+            - "{{ pool_pod.results }}"  
             - "{{ pool_volume_name.stdout_lines }}" 
 
         - name: Waiting for application to be in ruuning state


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Adds logic to get pool name from cvr in velero bakup and restore test
**Following is the log of ansible-test container**:
```

PLAYBOOK: test.yml *************************************************************
1 plays in ./apps/percona/functional/backup_and_restore/test.yml

PLAY [localhost] ***************************************************************
2019-11-13T07:30:54.197800 (delta: 0.068377)         elapsed: 0.068377 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:1
2019-11-13T07:30:54.213022 (delta: 0.015158)         elapsed: 0.083599 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:12
2019-11-13T07:31:04.926610 (delta: 10.713567)         elapsed: 10.797187 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-13T07:31:05.029843 (delta: 0.103176)         elapsed: 10.90042 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-13T07:31:05.121986 (delta: 0.092077)         elapsed: 10.992563 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:15
2019-11-13T07:31:05.200922 (delta: 0.078838)         elapsed: 11.071499 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-13T07:31:05.310775 (delta: 0.109789)         elapsed: 11.181352 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cb23761ee0ecfea3a093f94c0443739c777b3007", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0da5664e16958d4f3c263662ebe36b5c", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1573630265.38-184394510008997/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-13T07:31:06.163618 (delta: 0.852784)         elapsed: 12.034195 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.344844", "end": "2019-11-13 07:31:07.915461", "rc": 0, "start": "2019-11-13 07:31:06.570617", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-13T07:31:07.979690 (delta: 1.815997)         elapsed: 13.850267 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-13T03:47:50Z", "generation": 1, "name": "velero-backup-restore", "namespace": "", "resourceVersion": "268111", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "5d1e2160-05c8-11ea-81b5-00505698550d"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-13T07:31:09.365952 (delta: 1.386183)         elapsed: 15.236529 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-13T07:31:09.425030 (delta: 0.05902)         elapsed: 15.295607 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-13T07:31:09.490532 (delta: 0.065443)         elapsed: 15.361109 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:19
2019-11-13T07:31:09.560544 (delta: 0.069944)         elapsed: 15.431121 ******* 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2019-11-13T07:31:09.673397 (delta: 0.112788)         elapsed: 15.543974 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.381929", "end": "2019-11-13 07:31:11.295170", "rc": 0, "start": "2019-11-13 07:31:09.913241", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2019-11-13T07:31:11.368493 (delta: 1.695033)         elapsed: 17.23907 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2019-11-13T07:31:11.456581 (delta: 0.088027)         elapsed: 17.327158 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:22
2019-11-13T07:31:11.529115 (delta: 0.072454)         elapsed: 17.399692 ******* 
included: /apps/percona/functional/backup_and_restore/setup_dependency.yml for 127.0.0.1

TASK [Downloading velero binary] ***********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:1
2019-11-13T07:31:11.646091 (delta: 0.116903)         elapsed: 17.516668 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "24c98ca1c9cfe5c754c76c07ba6cbc517bc68f92", "dest": "./velero-v1.1.0-linux-amd64.tar.gz", "gid": 0, "group": "root", "md5sum": "2f8fb6505764a6f937b8b5645d4b8fb8", "mode": "0644", "msg": "OK (26731554 bytes)", "owner": "root", "size": 26731554, "src": "/root/.ansible/tmp/ansible-tmp-1573630271.72-133528763979250/tmp_N_G0K", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/vmware-tanzu/velero/releases/download/v1.1.0/velero-v1.1.0-linux-amd64.tar.gz"}

TASK [Installing velero inside litmus container] *******************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:11
2019-11-13T07:31:18.938287 (delta: 7.292133)         elapsed: 24.808864 ******* 
 [WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "tar -xvf velero-v1.1.0-linux-amd64.tar.gz\n mv velero-v1.1.0-linux-amd64/velero /usr/local/bin/", "delta": "0:00:02.128321", "end": "2019-11-13 07:31:21.356843", "rc": 0, "start": "2019-11-13 07:31:19.228522", "stderr": "", "stderr_lines": [], "stdout": "velero-v1.1.0-linux-amd64/LICENSE\nvelero-v1.1.0-linux-amd64/examples/README.md\nvelero-v1.1.0-linux-amd64/examples/minio\nvelero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app\nvelero-v1.1.0-linux-amd64/examples/nginx-app/README.md\nvelero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml\nvelero-v1.1.0-linux-amd64/velero", "stdout_lines": ["velero-v1.1.0-linux-amd64/LICENSE", "velero-v1.1.0-linux-amd64/examples/README.md", "velero-v1.1.0-linux-amd64/examples/minio", "velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app", "velero-v1.1.0-linux-amd64/examples/nginx-app/README.md", "velero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml", "velero-v1.1.0-linux-amd64/velero"]}

TASK [Checking the velero version] *********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:16
2019-11-13T07:31:21.421118 (delta: 2.482773)         elapsed: 27.291695 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero version", "delta": "0:00:01.355689", "end": "2019-11-13 07:31:23.048027", "failed_when_result": false, "rc": 0, "start": "2019-11-13 07:31:21.692338", "stderr": "", "stderr_lines": [], "stdout": "Client:\n\tVersion: v1.1.0\n\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608\n<error getting server version: namespaces \"velero\" not found>", "stdout_lines": ["Client:", "\tVersion: v1.1.0", "\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608", "<error getting server version: namespaces \"velero\" not found>"]}

TASK [Installing minio s3-bucket] **********************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:21
2019-11-13T07:31:23.153774 (delta: 1.732593)         elapsed: 29.024351 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "delta": "0:00:02.248701", "end": "2019-11-13 07:31:25.786304", "rc": 0, "start": "2019-11-13 07:31:23.537603", "stderr": "", "stderr_lines": [], "stdout": "namespace/velero created\ndeployment.apps/minio created\nservice/minio created\njob.batch/minio-setup created", "stdout_lines": ["namespace/velero created", "deployment.apps/minio created", "service/minio created", "job.batch/minio-setup created"]}

TASK [Checking for minio pod status] *******************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:24
2019-11-13T07:31:25.851171 (delta: 2.697315)         elapsed: 31.721748 ******* 
FAILED - RETRYING: Checking for minio pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.318905", "end": "2019-11-13 07:31:33.967447", "rc": 0, "start": "2019-11-13 07:31:32.648542", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing velero server inside cluster] *********************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:31
2019-11-13T07:31:34.055634 (delta: 8.204403)         elapsed: 39.926211 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero install --provider aws --bucket velero --secret-file ./credentials-velero --use-volume-snapshots=false --backup-location-config region=minio,s3ForcePathStyle=\"true\",s3Url=http://minio.velero.svc:9000", "delta": "0:00:03.071345", "end": "2019-11-13 07:31:37.464338", "rc": 0, "start": "2019-11-13 07:31:34.392993", "stderr": "", "stderr_lines": [], "stdout": "CustomResourceDefinition/backups.velero.io: attempting to create resource\nCustomResourceDefinition/backups.velero.io: already exists, proceeding\nCustomResourceDefinition/backups.velero.io: created\nCustomResourceDefinition/downloadrequests.velero.io: attempting to create resource\nCustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/downloadrequests.velero.io: created\nCustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource\nCustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding\nCustomResourceDefinition/deletebackuprequests.velero.io: created\nCustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumebackups.velero.io: created\nCustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumerestores.velero.io: created\nCustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource\nCustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding\nCustomResourceDefinition/backupstoragelocations.velero.io: created\nCustomResourceDefinition/restores.velero.io: attempting to create resource\nCustomResourceDefinition/restores.velero.io: already exists, proceeding\nCustomResourceDefinition/restores.velero.io: created\nCustomResourceDefinition/schedules.velero.io: attempting to create resource\nCustomResourceDefinition/schedules.velero.io: already exists, proceeding\nCustomResourceDefinition/schedules.velero.io: created\nCustomResourceDefinition/resticrepositories.velero.io: attempting to create resource\nCustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding\nCustomResourceDefinition/resticrepositories.velero.io: created\nCustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource\nCustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding\nCustomResourceDefinition/volumesnapshotlocations.velero.io: created\nCustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource\nCustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/serverstatusrequests.velero.io: created\nWaiting for resources to be ready in cluster...\nNamespace/velero: attempting to create resource\nNamespace/velero: already exists, proceeding\nNamespace/velero: created\nClusterRoleBinding/velero: attempting to create resource\nClusterRoleBinding/velero: already exists, proceeding\nClusterRoleBinding/velero: created\nServiceAccount/velero: attempting to create resource\nServiceAccount/velero: created\nSecret/cloud-credentials: attempting to create resource\nSecret/cloud-credentials: created\nBackupStorageLocation/default: attempting to create resource\nBackupStorageLocation/default: created\nDeployment/velero: attempting to create resource\nDeployment/velero: created\nVelero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status.", "stdout_lines": ["CustomResourceDefinition/backups.velero.io: attempting to create resource", "CustomResourceDefinition/backups.velero.io: already exists, proceeding", "CustomResourceDefinition/backups.velero.io: created", "CustomResourceDefinition/downloadrequests.velero.io: attempting to create resource", "CustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/downloadrequests.velero.io: created", "CustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource", "CustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding", "CustomResourceDefinition/deletebackuprequests.velero.io: created", "CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumebackups.velero.io: created", "CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumerestores.velero.io: created", "CustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource", "CustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding", "CustomResourceDefinition/backupstoragelocations.velero.io: created", "CustomResourceDefinition/restores.velero.io: attempting to create resource", "CustomResourceDefinition/restores.velero.io: already exists, proceeding", "CustomResourceDefinition/restores.velero.io: created", "CustomResourceDefinition/schedules.velero.io: attempting to create resource", "CustomResourceDefinition/schedules.velero.io: already exists, proceeding", "CustomResourceDefinition/schedules.velero.io: created", "CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource", "CustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding", "CustomResourceDefinition/resticrepositories.velero.io: created", "CustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource", "CustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding", "CustomResourceDefinition/volumesnapshotlocations.velero.io: created", "CustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource", "CustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/serverstatusrequests.velero.io: created", "Waiting for resources to be ready in cluster...", "Namespace/velero: attempting to create resource", "Namespace/velero: already exists, proceeding", "Namespace/velero: created", "ClusterRoleBinding/velero: attempting to create resource", "ClusterRoleBinding/velero: already exists, proceeding", "ClusterRoleBinding/velero: created", "ServiceAccount/velero: attempting to create resource", "ServiceAccount/velero: created", "Secret/cloud-credentials: attempting to create resource", "Secret/cloud-credentials: created", "BackupStorageLocation/default: attempting to create resource", "BackupStorageLocation/default: created", "Deployment/velero: attempting to create resource", "Deployment/velero: created", "Velero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status."]}

TASK [Checking for velero server status] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:40
2019-11-13T07:31:37.599532 (delta: 3.543823)         elapsed: 43.470109 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.413646", "end": "2019-11-13 07:31:45.797807", "rc": 0, "start": "2019-11-13 07:31:44.384161", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing development image of OpenEBS velero-plugin] *******************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:47
2019-11-13T07:31:45.897348 (delta: 8.29771)         elapsed: 51.767925 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero plugin add openebs/velero-plugin:ci", "delta": "0:00:01.299374", "end": "2019-11-13 07:31:47.606707", "rc": 0, "start": "2019-11-13 07:31:46.307333", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Checking for velero server status] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:50
2019-11-13T07:31:47.680063 (delta: 1.78261)         elapsed: 53.55064 ********* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.292292", "end": "2019-11-13 07:31:55.744375", "rc": 0, "start": "2019-11-13 07:31:54.452083", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Creating volume snapshot location] ***************************************
task path: /apps/percona/functional/backup_and_restore/setup_dependency.yml:57
2019-11-13T07:31:55.839510 (delta: 8.159381)         elapsed: 61.710087 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f volume-snapshot-location.yml", "delta": "0:00:01.769253", "end": "2019-11-13 07:31:57.951451", "failed_when_result": false, "rc": 0, "start": "2019-11-13 07:31:56.182198", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotlocation.velero.io/minio created", "stdout_lines": ["volumesnapshotlocation.velero.io/minio created"]}

TASK [Get Application  pod details] ********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:24
2019-11-13T07:31:58.124639 (delta: 2.285054)         elapsed: 63.995216 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.254725", "end": "2019-11-13 07:31:59.671320", "rc": 0, "start": "2019-11-13 07:31:58.416595", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-zx5xh", "stdout_lines": ["percona-cb697f8b4-zx5xh"]}

TASK [Create new database in the mysql] ****************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:28
2019-11-13T07:31:59.758051 (delta: 1.633221)         elapsed: 65.628628 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-11-13T07:32:00.036190 (delta: 0.278041)         elapsed: 65.906767 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;') => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-zx5xh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database backup;'", "delta": "0:00:01.656680", "end": "2019-11-13 07:32:01.924238", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "rc": 0, "start": "2019-11-13 07:32:00.267558", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-zx5xh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "delta": "0:00:01.910254", "end": "2019-11-13 07:32:04.203841", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "rc": 0, "start": "2019-11-13 07:32:02.293587", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-zx5xh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "delta": "0:00:02.016616", "end": "2019-11-13 07:32:06.583279", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "rc": 0, "start": "2019-11-13 07:32:04.566663", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-11-13T07:32:06.710435 (delta: 6.674177)         elapsed: 72.581012 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-11-13T07:32:06.849051 (delta: 0.1385)         elapsed: 72.719628 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-11-13T07:32:06.985044 (delta: 0.135881)         elapsed: 72.855621 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-11-13T07:32:07.120022 (delta: 0.134859)         elapsed: 72.990599 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-11-13T07:32:07.244032 (delta: 0.123919)         elapsed: 73.114609 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-11-13T07:32:07.401388 (delta: 0.15725)         elapsed: 73.271965 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-11-13T07:32:07.510566 (delta: 0.109034)         elapsed: 73.381143 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-11-13T07:32:07.565859 (delta: 0.055234)         elapsed: 73.436436 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-11-13T07:32:07.620818 (delta: 0.054904)         elapsed: 73.491395 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup for the provided application] ****************************
task path: /apps/percona/functional/backup_and_restore/test.yml:38
2019-11-13T07:32:07.703524 (delta: 0.082648)         elapsed: 73.574101 ******* 
included: /apps/percona/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:4
2019-11-13T07:32:07.894459 (delta: 0.190857)         elapsed: 73.765036 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero backup create percona-backup --include-namespaces=app-percona-ns --snapshot-volumes --volume-snapshot-locations=minio", "delta": "0:00:01.347187", "end": "2019-11-13 07:32:09.564787", "rc": 0, "start": "2019-11-13 07:32:08.217600", "stderr": "", "stderr_lines": [], "stdout": "Backup request \"percona-backup\" submitted successfully.\nRun `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details.", "stdout_lines": ["Backup request \"percona-backup\" submitted successfully.", "Run `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details."]}

TASK [Getting the state of Backup] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:10
2019-11-13T07:32:09.650445 (delta: 1.755904)         elapsed: 75.521022 ******* 
FAILED - RETRYING: Getting the state of Backup (30 retries left).
FAILED - RETRYING: Getting the state of Backup (29 retries left).
FAILED - RETRYING: Getting the state of Backup (28 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get backup percona-backup -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.320772", "end": "2019-11-13 07:32:31.377575", "rc": 0, "start": "2019-11-13 07:32:30.056803", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Creating application namespace] ******************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:21
2019-11-13T07:32:31.508698 (delta: 21.858167)         elapsed: 97.379275 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:26
2019-11-13T07:32:31.605481 (delta: 0.096687)         elapsed: 97.476058 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:32
2019-11-13T07:32:31.705623 (delta: 0.099983)         elapsed: 97.5762 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:36
2019-11-13T07:32:31.797202 (delta: 0.09149)         elapsed: 97.667779 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting Application] ****************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:43
2019-11-13T07:32:31.899960 (delta: 0.102663)         elapsed: 97.770537 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc,deploy,svc --all -n app-percona-ns\n kubectl delete ns app-percona-ns", "delta": "0:00:13.676253", "end": "2019-11-13 07:32:45.946863", "rc": 0, "start": "2019-11-13 07:32:32.270610", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"percona-mysql-claim\" deleted\ndeployment.extensions \"percona\" deleted\nservice \"percona-mysql\" deleted\nnamespace \"app-percona-ns\" deleted", "stdout_lines": ["persistentvolumeclaim \"percona-mysql-claim\" deleted", "deployment.extensions \"percona\" deleted", "service \"percona-mysql\" deleted", "namespace \"app-percona-ns\" deleted"]}

TASK [Checking whether namespace is deleted] ***********************************
task path: /apps/percona/functional/backup_and_restore/test.yml:48
2019-11-13T07:32:46.010349 (delta: 14.110296)         elapsed: 111.880926 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.229717", "end": "2019-11-13 07:32:47.456583", "rc": 0, "start": "2019-11-13 07:32:46.226866", "stderr": "", "stderr_lines": [], "stdout": "busybox-cstor\nbusybox-cstor-clone\nbusybox-cstor-sts\nbusybox-jiva\nbusybox-jiva-sts\ncvr-scaleup\ndefault\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\npercona-cstor\npercona-jiva\nvelero", "stdout_lines": ["busybox-cstor", "busybox-cstor-clone", "busybox-cstor-sts", "busybox-jiva", "busybox-jiva-sts", "cvr-scaleup", "default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "percona-cstor", "percona-jiva", "velero"]}

TASK [Restoring Application] ***************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:60
2019-11-13T07:32:47.536283 (delta: 1.525873)         elapsed: 113.40686 ******* 
included: /apps/percona/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:4
2019-11-13T07:32:47.651270 (delta: 0.11493)         elapsed: 113.521847 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:10
2019-11-13T07:32:47.708908 (delta: 0.057579)         elapsed: 113.579485 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:21
2019-11-13T07:32:47.768550 (delta: 0.059579)         elapsed: 113.639127 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-percona-ns", "delta": "0:00:01.239598", "end": "2019-11-13 07:32:49.211785", "failed_when_result": false, "rc": 0, "start": "2019-11-13 07:32:47.972187", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-percona-ns created", "stdout_lines": ["namespace/app-percona-ns created"]}

TASK [Restoring application] ***************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:26
2019-11-13T07:32:49.303052 (delta: 1.534443)         elapsed: 115.173629 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero restore create --from-backup percona-backup --restore-volumes=true", "delta": "0:00:01.283270", "end": "2019-11-13 07:32:50.830304", "rc": 0, "start": "2019-11-13 07:32:49.547034", "stderr": "", "stderr_lines": [], "stdout": "Restore request \"percona-backup-20191113073250\" submitted successfully.\nRun `velero restore describe percona-backup-20191113073250` or `velero restore logs percona-backup-20191113073250` for more details.", "stdout_lines": ["Restore request \"percona-backup-20191113073250\" submitted successfully.", "Run `velero restore describe percona-backup-20191113073250` or `velero restore logs percona-backup-20191113073250` for more details."]}

TASK [Getting restore name] ****************************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:32
2019-11-13T07:32:50.934162 (delta: 1.631012)         elapsed: 116.804739 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero get restore | grep percona-backup | awk '{print $1}'", "delta": "0:00:01.157351", "end": "2019-11-13 07:32:52.604531", "rc": 0, "start": "2019-11-13 07:32:51.447180", "stderr": "", "stderr_lines": [], "stdout": "percona-backup-20191113073250", "stdout_lines": ["percona-backup-20191113073250"]}

TASK [Checking the restore status] *********************************************
task path: /apps/percona/functional/backup_and_restore/backup-restore.yml:36
2019-11-13T07:32:52.714681 (delta: 1.780428)         elapsed: 118.585258 ****** 
FAILED - RETRYING: Checking the restore status (45 retries left).
FAILED - RETRYING: Checking the restore status (44 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get restore percona-backup-20191113073250 -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.284489", "end": "2019-11-13 07:33:07.453798", "rc": 0, "start": "2019-11-13 07:33:06.169309", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Getting the volume name] *************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:65
2019-11-13T07:33:07.587311 (delta: 14.872478)         elapsed: 133.457888 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.394763", "end": "2019-11-13 07:33:09.283924", "rc": 0, "start": "2019-11-13 07:33:07.889161", "stderr": "", "stderr_lines": [], "stdout": "pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "stdout_lines": ["pvc-cc7d62a6-05e7-11ea-81b5-00505698550d"]}

TASK [Getting the target IP] ***************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:69
2019-11-13T07:33:09.369203 (delta: 1.781785)         elapsed: 135.23978 ******* 
FAILED - RETRYING: Getting the target IP (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=pvc-cc7d62a6-05e7-11ea-81b5-00505698550d -o jsonpath='{.items[0].status.podIP}'", "delta": "0:00:01.314990", "end": "2019-11-13 07:33:17.826535", "rc": 0, "start": "2019-11-13 07:33:16.511545", "stderr": "", "stderr_lines": [], "stdout": "172.23.6.44", "stdout_lines": ["172.23.6.44"]}

TASK [Getting the volume name] *************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:76
2019-11-13T07:33:17.910380 (delta: 8.541099)         elapsed: 143.780957 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.318713", "end": "2019-11-13 07:33:19.602187", "rc": 0, "start": "2019-11-13 07:33:18.283474", "stderr": "", "stderr_lines": [], "stdout": "pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "stdout_lines": ["pvc-cc7d62a6-05e7-11ea-81b5-00505698550d"]}

TASK [Getting the CVR name from the corresponding PV] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:80
2019-11-13T07:33:19.737288 (delta: 1.826819)         elapsed: 145.607865 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-cc7d62a6-05e7-11ea-81b5-00505698550d -o jsonpath='{range.items[*]}{.metadata.labels.cstorpool\\.openebs\\.io/name}{\"\\n\"}{end}'", "delta": "0:00:01.524227", "end": "2019-11-13 07:33:21.578582", "rc": 0, "start": "2019-11-13 07:33:20.054355", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-dza6\ncstor-block-disk-pool-lnx4\ncstor-block-disk-pool-p3zm", "stdout_lines": ["cstor-block-disk-pool-dza6", "cstor-block-disk-pool-lnx4", "cstor-block-disk-pool-p3zm"]}

TASK [Geting the CSP name corresponding to CVR] ********************************
task path: /apps/percona/functional/backup_and_restore/test.yml:84
2019-11-13T07:33:21.666307 (delta: 1.928858)         elapsed: 147.536884 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-dza6) => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-dza6 -n openebs -o jsonpath='{.metadata.name}'", "delta": "0:00:01.196412", "end": "2019-11-13 07:33:23.090225", "item": "cstor-block-disk-pool-dza6", "rc": 0, "start": "2019-11-13 07:33:21.893813", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-dza6", "stdout_lines": ["cstor-block-disk-pool-dza6"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-lnx4) => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-lnx4 -n openebs -o jsonpath='{.metadata.name}'", "delta": "0:00:01.410386", "end": "2019-11-13 07:33:24.832791", "item": "cstor-block-disk-pool-lnx4", "rc": 0, "start": "2019-11-13 07:33:23.422405", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-lnx4", "stdout_lines": ["cstor-block-disk-pool-lnx4"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-p3zm) => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-p3zm -n openebs -o jsonpath='{.metadata.name}'", "delta": "0:00:01.383686", "end": "2019-11-13 07:33:26.578965", "item": "cstor-block-disk-pool-p3zm", "rc": 0, "start": "2019-11-13 07:33:25.195279", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-p3zm", "stdout_lines": ["cstor-block-disk-pool-p3zm"]}

TASK [Getting the pool pod name] ***********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:89
2019-11-13T07:33:26.690422 (delta: 5.024056)         elapsed: 152.560999 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-dza6) => {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", "delta": "0:00:01.322838", "end": "2019-11-13 07:33:28.281969", "item": "cstor-block-disk-pool-dza6", "rc": 0, "start": "2019-11-13 07:33:26.959131", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-dza6-9bfff448c-ndssc", "stdout_lines": ["cstor-block-disk-pool-dza6-9bfff448c-ndssc"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-lnx4) => {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", "delta": "0:00:01.200784", "end": "2019-11-13 07:33:29.845565", "item": "cstor-block-disk-pool-lnx4", "rc": 0, "start": "2019-11-13 07:33:28.644781", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw", "stdout_lines": ["cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-p3zm) => {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", "delta": "0:00:01.497248", "end": "2019-11-13 07:33:31.661650", "item": "cstor-block-disk-pool-p3zm", "rc": 0, "start": "2019-11-13 07:33:30.164402", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-p3zm-78879bf768-qm7g4", "stdout_lines": ["cstor-block-disk-pool-p3zm-78879bf768-qm7g4"]}

TASK [Getting the volume name inside cstor pool] *******************************
task path: /apps/percona/functional/backup_and_restore/test.yml:94
2019-11-13T07:33:31.809108 (delta: 5.118573)         elapsed: 157.679685 ****** 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-dza6-9bfff448c-ndssc', '_ansible_item_result': True, u'delta': u'0:00:01.322838', 'stdout_lines': [u'cstor-block-disk-pool-dza6-9bfff448c-ndssc'], '_ansible_item_label': u'cstor-block-disk-pool-dza6', u'end': u'2019-11-13 07:33:28.281969', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", 'item': u'cstor-block-disk-pool-dza6', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-13 07:33:26.959131', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-block-disk-pool-dza6-9bfff448c-ndssc -n openebs -c cstor-pool -- zfs list | grep pvc-cc7d62a6-05e7-11ea-81b5-00505698550d | awk '{print $1}') >> cstor-vol", "delta": "0:00:01.464390", "end": "2019-11-13 07:33:33.743445", "item": {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", "delta": "0:00:01.322838", "end": "2019-11-13 07:33:28.281969", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-dza6", "rc": 0, "start": "2019-11-13 07:33:26.959131", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-dza6-9bfff448c-ndssc", "stdout_lines": ["cstor-block-disk-pool-dza6-9bfff448c-ndssc"]}, "rc": 0, "start": "2019-11-13 07:33:32.279055", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw', '_ansible_item_result': True, u'delta': u'0:00:01.200784', 'stdout_lines': [u'cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw'], '_ansible_item_label': u'cstor-block-disk-pool-lnx4', u'end': u'2019-11-13 07:33:29.845565', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", 'item': u'cstor-block-disk-pool-lnx4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-13 07:33:28.644781', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw -n openebs -c cstor-pool -- zfs list | grep pvc-cc7d62a6-05e7-11ea-81b5-00505698550d | awk '{print $1}') >> cstor-vol", "delta": "0:00:01.683254", "end": "2019-11-13 07:33:35.826302", "item": {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", "delta": "0:00:01.200784", "end": "2019-11-13 07:33:29.845565", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-lnx4", "rc": 0, "start": "2019-11-13 07:33:28.644781", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw", "stdout_lines": ["cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw"]}, "rc": 0, "start": "2019-11-13 07:33:34.143048", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-p3zm-78879bf768-qm7g4', '_ansible_item_result': True, u'delta': u'0:00:01.497248', 'stdout_lines': [u'cstor-block-disk-pool-p3zm-78879bf768-qm7g4'], '_ansible_item_label': u'cstor-block-disk-pool-p3zm', u'end': u'2019-11-13 07:33:31.661650', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", 'item': u'cstor-block-disk-pool-p3zm', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-13 07:33:30.164402', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-block-disk-pool-p3zm-78879bf768-qm7g4 -n openebs -c cstor-pool -- zfs list | grep pvc-cc7d62a6-05e7-11ea-81b5-00505698550d | awk '{print $1}') >> cstor-vol", "delta": "0:00:01.661275", "end": "2019-11-13 07:33:37.713304", "item": {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", "delta": "0:00:01.497248", "end": "2019-11-13 07:33:31.661650", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-p3zm", "rc": 0, "start": "2019-11-13 07:33:30.164402", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-p3zm-78879bf768-qm7g4", "stdout_lines": ["cstor-block-disk-pool-p3zm-78879bf768-qm7g4"]}, "rc": 0, "start": "2019-11-13 07:33:36.052029", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Assingning the cstor-pool volume name to variable] ***********************
task path: /apps/percona/functional/backup_and_restore/test.yml:99
2019-11-13T07:33:37.885476 (delta: 6.076258)         elapsed: 163.756053 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat ./cstor-vol", "delta": "0:00:01.094797", "end": "2019-11-13 07:33:39.200809", "rc": 0, "start": "2019-11-13 07:33:38.106012", "stderr": "", "stderr_lines": [], "stdout": "cstor-50ffb576-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d\ncstor-5123d219-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d\ncstor-513f3189-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "stdout_lines": ["cstor-50ffb576-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "cstor-5123d219-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "cstor-513f3189-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d"]}

TASK [Setting target IP for volume inside cstor pool] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:103
2019-11-13T07:33:39.271031 (delta: 1.385491)         elapsed: 165.141608 ****** 
changed: [127.0.0.1] => (item=[{'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-dza6-9bfff448c-ndssc', '_ansible_item_result': True, u'delta': u'0:00:01.322838', 'stdout_lines': [u'cstor-block-disk-pool-dza6-9bfff448c-ndssc'], '_ansible_item_label': u'cstor-block-disk-pool-dza6', u'end': u'2019-11-13 07:33:28.281969', '_ansible_no_log': False, u'start': u'2019-11-13 07:33:26.959131', 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", 'item': u'cstor-block-disk-pool-dza6', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'cstor-50ffb576-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d']) => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-dza6-9bfff448c-ndssc -n openebs -- zfs set io.openebs:targetip=172.23.6.44 cstor-50ffb576-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "delta": "0:00:01.718306", "end": "2019-11-13 07:33:41.248065", "item": [{"_ansible_ignore_errors": null, "_ansible_item_label": "cstor-block-disk-pool-dza6", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", "delta": "0:00:01.322838", "end": "2019-11-13 07:33:28.281969", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-dza6 | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-dza6", "rc": 0, "start": "2019-11-13 07:33:26.959131", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-dza6-9bfff448c-ndssc", "stdout_lines": ["cstor-block-disk-pool-dza6-9bfff448c-ndssc"]}, "cstor-50ffb576-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d"], "rc": 0, "start": "2019-11-13 07:33:39.529759", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-dza6-9bfff448c-ndssc -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-dza6-9bfff448c-ndssc -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[{'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw', '_ansible_item_result': True, u'delta': u'0:00:01.200784', 'stdout_lines': [u'cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw'], '_ansible_item_label': u'cstor-block-disk-pool-lnx4', u'end': u'2019-11-13 07:33:29.845565', '_ansible_no_log': False, u'start': u'2019-11-13 07:33:28.644781', 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", 'item': u'cstor-block-disk-pool-lnx4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'cstor-5123d219-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d']) => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw -n openebs -- zfs set io.openebs:targetip=172.23.6.44 cstor-5123d219-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "delta": "0:00:01.632628", "end": "2019-11-13 07:33:43.139803", "item": [{"_ansible_ignore_errors": null, "_ansible_item_label": "cstor-block-disk-pool-lnx4", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", "delta": "0:00:01.200784", "end": "2019-11-13 07:33:29.845565", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-lnx4 | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-lnx4", "rc": 0, "start": "2019-11-13 07:33:28.644781", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw", "stdout_lines": ["cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw"]}, "cstor-5123d219-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d"], "rc": 0, "start": "2019-11-13 07:33:41.507175", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-lnx4-66d799bf7f-f2vzw -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[{'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-p3zm-78879bf768-qm7g4', '_ansible_item_result': True, u'delta': u'0:00:01.497248', 'stdout_lines': [u'cstor-block-disk-pool-p3zm-78879bf768-qm7g4'], '_ansible_item_label': u'cstor-block-disk-pool-p3zm', u'end': u'2019-11-13 07:33:31.661650', '_ansible_no_log': False, u'start': u'2019-11-13 07:33:30.164402', 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", 'item': u'cstor-block-disk-pool-p3zm', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'cstor-513f3189-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d']) => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-p3zm-78879bf768-qm7g4 -n openebs -- zfs set io.openebs:targetip=172.23.6.44 cstor-513f3189-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d", "delta": "0:00:01.493405", "end": "2019-11-13 07:33:44.884818", "item": [{"_ansible_ignore_errors": null, "_ansible_item_label": "cstor-block-disk-pool-p3zm", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", "delta": "0:00:01.497248", "end": "2019-11-13 07:33:31.661650", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-p3zm | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-p3zm", "rc": 0, "start": "2019-11-13 07:33:30.164402", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-p3zm-78879bf768-qm7g4", "stdout_lines": ["cstor-block-disk-pool-p3zm-78879bf768-qm7g4"]}, "cstor-513f3189-055b-11ea-81b5-00505698550d/pvc-cc7d62a6-05e7-11ea-81b5-00505698550d"], "rc": 0, "start": "2019-11-13 07:33:43.391413", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-p3zm-78879bf768-qm7g4 -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-p3zm-78879bf768-qm7g4 -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Waiting for application to be in ruuning state] **************************
task path: /apps/percona/functional/backup_and_restore/test.yml:109
2019-11-13T07:33:45.046152 (delta: 5.775033)         elapsed: 170.916729 ****** 
FAILED - RETRYING: Waiting for application to be in ruuning state (30 retries left).
FAILED - RETRYING: Waiting for application to be in ruuning state (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod percona-cb697f8b4-zx5xh -n app-percona-ns -o jsonpath='{.status.phase}'", "delta": "0:00:01.409870", "end": "2019-11-13 07:34:00.422344", "rc": 0, "start": "2019-11-13 07:33:59.012474", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying Data persistense] **********************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:116
2019-11-13T07:34:00.538806 (delta: 15.492541)         elapsed: 186.409383 ***** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-11-13T07:34:00.789795 (delta: 0.250884)         elapsed: 186.660372 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-11-13T07:34:00.886327 (delta: 0.096345)         elapsed: 186.756904 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-cb697f8b4-zx5xh -n app-percona-ns", "delta": "0:00:05.940557", "end": "2019-11-13 07:34:07.104615", "rc": 0, "start": "2019-11-13 07:34:01.164058", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-cb697f8b4-zx5xh\" deleted", "stdout_lines": ["pod \"percona-cb697f8b4-zx5xh\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-11-13T07:34:07.243221 (delta: 6.356823)         elapsed: 193.113798 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:02.288344", "end": "2019-11-13 07:34:09.772261", "rc": 0, "start": "2019-11-13 07:34:07.483917", "stderr": "", "stderr_lines": [], "stdout": "NAME                      READY   STATUS    RESTARTS   AGE\npercona-cb697f8b4-c27dq   1/1     Running   0          6s", "stdout_lines": ["NAME                      READY   STATUS    RESTARTS   AGE", "percona-cb697f8b4-c27dq   1/1     Running   0          6s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-11-13T07:34:09.843830 (delta: 2.600464)         elapsed: 195.714407 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.277202", "end": "2019-11-13 07:34:11.345021", "rc": 0, "start": "2019-11-13 07:34:10.067819", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-c27dq", "stdout_lines": ["percona-cb697f8b4-c27dq"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-11-13T07:34:11.407315 (delta: 1.563436)         elapsed: 197.277892 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-c27dq\")].status.phase}'", "delta": "0:00:01.186441", "end": "2019-11-13 07:34:12.821505", "rc": 0, "start": "2019-11-13 07:34:11.635064", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-11-13T07:34:12.894110 (delta: 1.486731)         elapsed: 198.764687 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-c27dq\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.349468", "end": "2019-11-13 07:34:14.450248", "rc": 0, "start": "2019-11-13 07:34:13.100780", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-11-13T07:34:05Z]]", "stdout_lines": ["map[running:map[startedAt:2019-11-13T07:34:05Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-11-13T07:34:14.544285 (delta: 1.650112)         elapsed: 200.414862 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-c27dq -n app-percona-ns -- mysqlcheck -c backup -uroot -pk8sDem0", "delta": "0:00:01.610503", "end": "2019-11-13 07:34:16.400072", "failed_when_result": false, "rc": 0, "start": "2019-11-13 07:34:14.789569", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "backup.ttbl                                        OK", "stdout_lines": ["backup.ttbl                                        OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-11-13T07:34:16.499109 (delta: 1.954748)         elapsed: 202.369686 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-c27dq -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' backup;", "delta": "0:00:01.604499", "end": "2019-11-13 07:34:18.398788", "failed_when_result": false, "rc": 0, "start": "2019-11-13 07:34:16.794289", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-11-13T07:34:18.519781 (delta: 2.020585)         elapsed: 204.390358 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-11-13T07:34:18.593712 (delta: 0.073864)         elapsed: 204.464289 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:127
2019-11-13T07:34:18.664667 (delta: 0.070833)         elapsed: 204.535244 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /apps/percona/functional/backup_and_restore/test.yml:135
2019-11-13T07:34:18.799951 (delta: 0.135187)         elapsed: 204.670528 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-13T07:34:18.939183 (delta: 0.139153)         elapsed: 204.80976 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-13T07:34:19.018596 (delta: 0.079337)         elapsed: 204.889173 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-13T07:34:19.097333 (delta: 0.078665)         elapsed: 204.96791 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-13T07:34:19.186087 (delta: 0.088683)         elapsed: 205.056664 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "218cc4cd06f4a20f4ce3c234b033d66800aa02b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9f2161a292cb589ce3599bf99ea6818b", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1573630459.29-20493148466741/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-13T07:34:22.030597 (delta: 2.844431)         elapsed: 207.901174 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.137381", "end": "2019-11-13 07:34:23.439788", "rc": 0, "start": "2019-11-13 07:34:22.302407", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-13T07:34:23.507858 (delta: 1.477186)         elapsed: 209.378435 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-13T03:47:50Z", "generation": 1, "name": "velero-backup-restore", "namespace": "", "resourceVersion": "269404", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "5d1e2160-05c8-11ea-81b5-00505698550d"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=55   changed=44   unreachable=0    failed=0 
```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
