### PR TITLE
feat[yaml]: Added snapshot and clone litmusbook for cstor-csi

### DIFF
--- a/experiments/functional/cstor-csi/csi-clone/busybox.j2
+++ b/experiments/functional/cstor-csi/csi-clone/busybox.j2
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busyboxclone
+  namespace: "{{ namespace }}"
+  labels:
+    app: "{{ app_label }}"
+spec:
+  containers:
+  - name: app-busybox
+    imagePullPolicy: IfNotPresent
+    image: busybox
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do sleep 10;done"]
+    env:
+    volumeMounts:
+    - name: data-vol
+      mountPath: /busybox
+  volumes:
+  - name: data-vol
+    persistentVolumeClaim:
+      claimName: "{{ pvc_name }}"

--- a/experiments/functional/cstor-csi/csi-clone/busybox.j2
+++ b/experiments/functional/cstor-csi/csi-clone/busybox.j2
@@ -1,22 +1,30 @@
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: busyboxclone
   namespace: "{{ namespace }}"
   labels:
     app: "{{ app_label }}"
 spec:
-  containers:
-  - name: app-busybox
-    imagePullPolicy: IfNotPresent
-    image: busybox
-    command: ["/bin/sh"]
-    args: ["-c", "while true; do sleep 10;done"]
-    env:
-    volumeMounts:
-    - name: data-vol
-      mountPath: /busybox
-  volumes:
-  - name: data-vol
-    persistentVolumeClaim:
-      claimName: "{{ pvc_name }}"
+  selector:
+    matchLabels:
+      app: "{{ app_label }}"
+  template:
+    metadata:
+      labels:
+        app: "{{ app_label }}"
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: "{{ pvc_name }}"

--- a/experiments/functional/cstor-csi/csi-clone/clone.j2
+++ b/experiments/functional/cstor-csi/csi-clone/clone.j2
@@ -12,4 +12,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: "{{ storage_capacity }}"

--- a/experiments/functional/cstor-csi/csi-clone/clone.j2
+++ b/experiments/functional/cstor-csi/csi-clone/clone.j2
@@ -1,0 +1,15 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "{{ pvc_name }}"
+spec:
+  storageClassName: "{{ storage_class_name }}"
+  dataSource:
+    name: "{{ snapshot_name }}"
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
@@ -48,6 +48,9 @@ spec:
 
           - name: APP_LABEL
             value: 'busybox-cloned'
+
+          - name: STORAGE_CAPACITY
+            value: 5Gi  
             
           - name: DATA_PERSISTENCE
             value: ""

--- a/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: csi-clone
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-csi-clone-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: cstor-csi-clone
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: '' 
+
+          - name: STORAGE_CLASS_NAME
+            value: ''
+
+          - name: SNAPSHOT_CLASS
+            value: 'csi-cstor'
+
+          - name: SNAPSHOT_NAME
+            value: 'csi-snap'
+            
+          - name: APP_PVC
+            value: ''
+
+          - name: APP_LABEL
+            value: 'busybox-cloned'
+            
+          - name: DATA_PERSISTENCE
+            value: ""
+       
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-csi/csi-clone/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: csi-clone

--- a/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
@@ -37,6 +37,7 @@ spec:
           - name: STORAGE_CLASS_NAME
             value: ''
 
+            ## Name of CSI volumesnapshotclass
           - name: SNAPSHOT_CLASS
             value: 'csi-cstor'
 
@@ -52,6 +53,7 @@ spec:
           - name: STORAGE_CAPACITY
             value: 5Gi  
             
+            ## busybox for app busybox 
           - name: DATA_PERSISTENCE
             value: ""
        

--- a/experiments/functional/cstor-csi/csi-clone/test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test.yml
@@ -20,19 +20,20 @@
           template:
             src: clone.j2
             dest: clone.yml
-
-        - shell: cat clone.yml
-            
+         
         - name: create the Clone
           shell: >
             kubectl create -f clone.yml -n {{ namespace }}
           args:
             executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
 
         ## Deploy busybox app to check if the snapshot is cloned 
         - name: Check if the pvc is bound
           shell: >
-            kubectl get pvc {{ pvc_name }} -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+            kubectl get pvc {{ pvc_name }} -n {{ namespace }} 
+            --no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash
           register: pvc_status
@@ -40,51 +41,56 @@
           delay: 30
           retries: 5
 
-        - name: Generaete the yaml file to deploy busybox
+        - name: Generate the yaml file to deploy busybox
           template:
             src: busybox.j2
             dest: busybox.yml
 
+          ## Cloned PV is mounted in this app
         - name: Deploying the busybox app
           shell: >
             kubectl create -f busybox.yml -n {{ namespace }}
           args:
             executable: /bin/bash
+        
+        - name: Get the app pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l app={{ app_label }} 
+            --no-headers -o custom-columns=:.metadata.name
+          args: 
+            executable: /bin/bash
+          register: app_pod_name
 
         - name: Verify if the app is in Running state
           shell: >
-            kubectl get po -n {{ namespace }} -l app={{ app_label }} --no-headers -o custom-columns=:.status.phase
+            kubectl get po -n {{ namespace }} -l app={{ app_label }} 
+            --no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash
           register: app_status
           until: "'Running' in app_status.stdout"
           delay: 30
           retries: 15
+               
+        - block:
+          - name: Check the md5sum of stored data file
+            shell: >
+              kubectl exec {{ app_pod_name.stdout }} -n {{ namespace }}
+              -- sh -c "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-post-clone-md5"
+            args:
+              executable: /bin/bash
+            register: status 
+            failed_when: "status.rc != 0"
 
-        - name: Get the app pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l app={{ app_label }} --no-headers -o custom-columns=:.metadata.name
-          args: 
-            executable: /bin/bash
-          register: app_pod_name
-
-        - name: Check the md5sum of stored data file
-          shell: >
-            kubectl exec {{ app_pod_name.stdout }} -n {{ namespace }}
-            -- sh -c "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-post-clone-md5"
-          args:
-            executable: /bin/bash
-          register: status 
-          failed_when: "status.rc != 0"
-
-        - name: Verify whether data is consistent
-          shell: >
-                kubectl exec {{ app_pod_name.stdout }} -n {{ namespace }}
-                -- sh -c "diff /busybox/{{ testfile }}-pre-chaos-md5 /busybox/{{ testfile }}-post-clone-md5"
-          args:
-            executable: /bin/bash
-          register: result 
-          failed_when: "result.rc != 0 or result.stdout != ''"
+          - name: Verify whether data is consistent
+            shell: >
+                  kubectl exec {{ app_pod_name.stdout }} -n {{ namespace }}
+                  -- sh -c "diff /busybox/{{ testfile }}-pre-chaos-md5 /busybox/{{ testfile }}-post-clone-md5"
+            args:
+              executable: /bin/bash
+            register: result 
+            failed_when: "result.rc != 0 or result.stdout != ''"
+          when: data_persistence != ''
 
         - set_fact:
             flag: "Pass"

--- a/experiments/functional/cstor-csi/csi-clone/test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test.yml
@@ -21,13 +21,13 @@
             src: clone.j2
             dest: clone.yml
 
+        - shell: cat clone.yml
+            
         - name: create the Clone
           shell: >
             kubectl create -f clone.yml -n {{ namespace }}
           args:
             executable: /bin/bash
-
-        - shell: cat clone.yml
 
         ## Deploy busybox app to check if the snapshot is cloned 
         - name: Check if the pvc is bound

--- a/experiments/functional/cstor-csi/csi-clone/test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test.yml
@@ -1,0 +1,100 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+    
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Generate the yaml file to clone the snapshot
+          template:
+            src: clone.j2
+            dest: clone.yml
+
+        - name: create the Clone
+          shell: >
+            kubectl create -f clone.yml -n {{ namespace }}
+          args:
+            executable: /bin/bash
+
+        - shell: cat clone.yml
+
+        ## Deploy busybox app to check if the snapshot is cloned 
+        - name: Check if the pvc is bound
+          shell: >
+            kubectl get pvc {{ pvc_name }} -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: pvc_status
+          until: "'Bound' in pvc_status.stdout"
+          delay: 30
+          retries: 5
+
+        - name: Generaete the yaml file to deploy busybox
+          template:
+            src: busybox.j2
+            dest: busybox.yml
+
+        - name: Deploying the busybox app
+          shell: >
+            kubectl create -f busybox.yml -n {{ namespace }}
+          args:
+            executable: /bin/bash
+
+        - name: Verify if the app is in Running state
+          shell: >
+            kubectl get po -n {{ namespace }} -l app={{ app_label }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Get the app pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l app={{ app_label }} --no-headers -o custom-columns=:.metadata.name
+          args: 
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Check the md5sum of stored data file
+          shell: >
+            kubectl exec {{ app_pod_name.stdout }} -n {{ namespace }}
+            -- sh -c "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-post-clone-md5"
+          args:
+            executable: /bin/bash
+          register: status 
+          failed_when: "status.rc != 0"
+
+        - name: Verify whether data is consistent
+          shell: >
+                kubectl exec {{ app_pod_name.stdout }} -n {{ namespace }}
+                -- sh -c "diff /busybox/{{ testfile }}-pre-chaos-md5 /busybox/{{ testfile }}-post-clone-md5"
+          args:
+            executable: /bin/bash
+          register: result 
+          failed_when: "result.rc != 0 or result.stdout != ''"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/cstor-csi/csi-clone/test_vars.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test_vars.yml
@@ -13,3 +13,5 @@ snapshot_name: "{{ lookup('env','SNAPSHOT_NAME') }}"
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 
 storage_class_name: "{{ lookup('env','STORAGE_CLASS_NAME') }}"
+
+storage_capacity: "{{ lookup('env','STORAGE_CAPACITY') }}"

--- a/experiments/functional/cstor-csi/csi-clone/test_vars.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: cstor-csi-clone
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc_name: "{{ lookup('env','APP_PVC') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"
+
+snapshot_name: "{{ lookup('env','SNAPSHOT_NAME') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
+storage_class_name: "{{ lookup('env','STORAGE_CLASS_NAME') }}"

--- a/experiments/functional/cstor-csi/csi-snapshot/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/run_litmus_test.yml
@@ -34,6 +34,7 @@ spec:
           - name: APP_NAMESPACE
             value: '' 
 
+          ##Name of CSI volumesnapshotclass
           - name: SNAPSHOT_CLASS
             value: 'csi-cstor'
 
@@ -43,6 +44,7 @@ spec:
           - name: APP_PVC
             value: ''
 
+          ##busybox for app busybox 
           - name: DATA_PERSISTENCE
             value: ""
        

--- a/experiments/functional/cstor-csi/csi-snapshot/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/run_litmus_test.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: csi-snapshot
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-csi-snapshot-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: cstor-csi-snapshot
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: '' 
+
+          - name: SNAPSHOT_CLASS
+            value: 'csi-cstor'
+
+          - name: SNAPSHOT_NAME
+            value: 'csi-snap'
+            
+          - name: APP_PVC
+            value: ''
+
+          - name: DATA_PERSISTENCE
+            value: ""
+       
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-csi/csi-snapshot/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: csi-snapshot

--- a/experiments/functional/cstor-csi/csi-snapshot/snapshot.j2
+++ b/experiments/functional/cstor-csi/csi-snapshot/snapshot.j2
@@ -1,0 +1,9 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshot
+metadata:
+  name: "{{ snapshot_name }}"
+spec:
+  snapshotClassName: "{{ snapshot_class }}"
+  source:
+    name: "{{ pvc_name }}"
+    kind: PersistentVolumeClaim

--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -49,11 +49,16 @@
             kubectl create -f snapshot.yml -n "{{ namespace }}"
           args:
             executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
 
        #  Verify if the snapshot created successfully
         - name: Get the content of the snapshot taken
           shell: >
-            kubectl get volumesnapshots.snapshot {{ snapshot_name }} -n {{ namespace }} --no-headers -o custom-columns=:spec.snapshotContentName | sed 's/snapcontent-//g'
+            kubectl get volumesnapshots.snapshot {{ snapshot_name }} -n {{ namespace }} 
+            --no-headers -o custom-columns=:spec.snapshotContentName | sed 's/snapcontent-//g'
+          args:
+            executable: /bin/bash
           register: snapcontent
           
         - set_fact:
@@ -69,14 +74,16 @@
 
         - name: Obtaining the CVR from PV
           shell: >
-            kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} --no-headers  -o custom-columns=:metadata.name
+            kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} 
+            --no-headers  -o custom-columns=:metadata.name
           args:
             executable: /bin/bash
           register: cvr
         
-        - name: Obtaining the pools
+        - name: Obtaining the pools where CVRs are mounted
           shell: >
-            kubectl get cvr {{ item }} -n {{ operator_ns }} --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\.openebs\.io/name}{"\n"}'
+            kubectl get cvr {{ item }} -n {{ operator_ns }} --no-headers 
+            -o jsonpath='{.metadata.labels.cstorpoolinstance\.openebs\.io/name}{"\n"}'
           args:
             executable: /bin/bash
           register: pools
@@ -85,7 +92,8 @@
          
         - name: Obtaining the pool pods
           shell: >
-            kubectl get po -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item.stdout }} --no-headers -o custom-columns=:.metadata.name
+            kubectl get po -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item.stdout }} 
+            --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: pool_pods

--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -51,18 +51,14 @@
             executable: /bin/bash
 
        #  Verify if the snapshot created successfully
-        - name: Obtaining the storage class used from PVC
-          shell: kubectl get pvc {{ pvc_name }} -n {{ namespace }} --no-headers -o custom-columns=:.spec.storageClassName
-          args:
-            executable: /bin/bash
-          register: app_sc
-
-        - name: Obtaining the SPC from storage class
-          shell: kubectl get sc {{ app_sc.stdout }} --no-headers  -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/"//g'
-          args:
-            executable: /bin/bash
-          register: spc
-        
+        - name: Get the content of the snapshot taken
+          shell: >
+            kubectl get volumesnapshots.snapshot {{ snapshot_name }} -n {{ namespace }} --no-headers -o custom-columns=:spec.snapshotContentName | sed 's/snapcontent-//g'
+          register: snapcontent
+          
+        - set_fact:
+            volume_snapshot: "{{ snapcontent.stdout }}"
+          
         - name: Derive PV name from PVC
           shell: >
             kubectl get pvc {{ pvc_name }} -n {{ namespace }}
@@ -71,44 +67,40 @@
             executable: /bin/bash
           register: pv
 
-        - name: Obtaining the pool deployments from cvr
+        - name: Obtaining the CVR from PV
           shell: >
-            kubectl get cvr -n {{ operator_ns }}
-            -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
-            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+            kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} --no-headers  -o custom-columns=:metadata.name
           args:
             executable: /bin/bash
-          register: pool_deployment
-
-        - name: Obtaining the replicasets corresponding to pool deployements.
+          register: cvr
+        
+        - name: Obtaining the pools
           shell: >
-            kubectl get rs --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
-            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
+            kubectl get cvr {{ item }} -n {{ operator_ns }} --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\.openebs\.io/name}{"\n"}'
           args:
             executable: /bin/bash
-          register: rs_list
+          register: pools
           with_items:
-            - "{{ pool_deployment.stdout_lines }}"
-
+            - "{{ cvr.stdout_lines }}"
+         
         - name: Obtaining the pool pods
           shell: >
-            kubectl get pod --selector=app=cstor-pool -n {{ operator_ns }} --no-headers 
-            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
+            kubectl get po -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item.stdout }} --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: pool_pods
           with_items:
-            - "{{ rs_list.results }}"
+            - "{{ pools.results }}"
 
         - name: Checking if the snapshot is created in all the pool pods.
-          shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -- zfs list -t snapshot
+          shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -c cstor-pool -- zfs list -t snapshot
           args:
             executable: /bin/bash
-          register: snap_list
-          failed_when: "snapshot_name not in snap_list.stdout"
+          register: snap
+          failed_when: "volume_snapshot not in snap.stdout"
           with_items:
             - "{{ pool_pods.results }}"
-
+        
         - set_fact:
             flag: "Pass"
 

--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -1,0 +1,124 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+    
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+        - name: Get the application pod name
+          shell: >
+            kubectl get po -n {{ namespace }} --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Check if the application pod is in running state
+          shell: >
+            kubectl get pods -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: pod_status
+          failed_when: "'Running' not in pod_status.stdout"
+
+        - name: Create some test data
+          include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"  
+          when: data_persistence != ''
+
+        - name: generating yaml file for snapshot
+          template: 
+            src: snapshot.j2
+            dest: snapshot.yml
+
+        - name: create snapshot    
+          shell: >
+            kubectl create -f snapshot.yml -n "{{ namespace }}"
+          args:
+            executable: /bin/bash
+
+       #  Verify if the snapshot created successfully
+        - name: Obtaining the storage class used from PVC
+          shell: kubectl get pvc {{ pvc_name }} -n {{ namespace }} --no-headers -o custom-columns=:.spec.storageClassName
+          args:
+            executable: /bin/bash
+          register: app_sc
+
+        - name: Obtaining the SPC from storage class
+          shell: kubectl get sc {{ app_sc.stdout }} --no-headers  -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/"//g'
+          args:
+            executable: /bin/bash
+          register: spc
+        
+        - name: Derive PV name from PVC
+          shell: >
+            kubectl get pvc {{ pvc_name }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv
+
+        - name: Obtaining the pool deployments from cvr
+          shell: >
+            kubectl get cvr -n {{ operator_ns }}
+            -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+          args:
+            executable: /bin/bash
+          register: pool_deployment
+
+        - name: Obtaining the replicasets corresponding to pool deployements.
+          shell: >
+            kubectl get rs --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
+            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: rs_list
+          with_items:
+            - "{{ pool_deployment.stdout_lines }}"
+
+        - name: Obtaining the pool pods
+          shell: >
+            kubectl get pod --selector=app=cstor-pool -n {{ operator_ns }} --no-headers 
+            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: pool_pods
+          with_items:
+            - "{{ rs_list.results }}"
+
+        - name: Checking if the snapshot is created in all the pool pods.
+          shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -- zfs list -t snapshot
+          args:
+            executable: /bin/bash
+          register: snap_list
+          failed_when: "snapshot_name not in snap_list.stdout"
+          with_items:
+            - "{{ pool_pods.results }}"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+    

--- a/experiments/functional/cstor-csi/csi-snapshot/test_vars.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test_vars.yml
@@ -1,0 +1,13 @@
+test_name: cstor-csi-snapshot
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc_name: "{{ lookup('env','APP_PVC') }}"
+
+snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"
+
+snapshot_name: "{{ lookup('env','SNAPSHOT_NAME') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
+operator_ns: 'openebs'


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Added snapshot and clone litmusbook for cstor-csi

**Special notes for your reviewer**:
logs for snapshot:
```
PLAY [localhost] ***************************************************************
2019-11-19T13:30:33.176102 (delta: 0.090843)         elapsed: 0.090843 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:1
2019-11-19T13:30:33.205631 (delta: 0.029434)         elapsed: 0.120372 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:12
2019-11-19T13:30:48.221301 (delta: 15.015624)         elapsed: 15.136042 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-19T13:30:48.328588 (delta: 0.107206)         elapsed: 15.243329 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-19T13:30:48.409762 (delta: 0.081109)         elapsed: 15.324503 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:15
2019-11-19T13:30:48.504015 (delta: 0.094182)         elapsed: 15.418756 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-19T13:30:48.693398 (delta: 0.189303)         elapsed: 15.608139 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "38905ed675e1acbe09ef09ebbd828cd4ed76543c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "676606b46d0b402569366f6b1102f1e3", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1574170248.79-167089516700819/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-19T13:30:49.844725 (delta: 1.15123)         elapsed: 16.759466 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.613045", "end": "2019-11-19 13:30:52.047367", "rc": 0, "start": "2019-11-19 13:30:50.434322", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-19T13:30:52.122079 (delta: 2.277287)         elapsed: 19.03682 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-19T11:30:16Z", "generation": 15, "name": "cstor-csi-snapshot", "resourceVersion": "143280", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-snapshot", "uid": "33d2144c-365c-44b3-8206-252e7570c2af"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-19T13:30:53.920728 (delta: 1.798593)         elapsed: 20.835469 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-19T13:30:54.004952 (delta: 0.084153)         elapsed: 20.919693 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-19T13:30:54.108862 (delta: 0.103812)         elapsed: 21.023603 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application pod name] ********************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:19
2019-11-19T13:30:54.239909 (delta: 0.130933)         elapsed: 21.15465 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n sam --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:03.131624", "end": "2019-11-19 13:30:57.710967", "rc": 0, "start": "2019-11-19 13:30:54.579343", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-76d469c9dc-4spsj", "stdout_lines": ["app-busybox-76d469c9dc-4spsj"]}

TASK [Check if the application pod is in running state] ************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:26
2019-11-19T13:30:57.806289 (delta: 3.566192)         elapsed: 24.72103 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.494051", "end": "2019-11-19 13:30:59.674937", "failed_when_result": false, "rc": 0, "start": "2019-11-19 13:30:58.180886", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Create some test data] ***************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:34
2019-11-19T13:30:59.767687 (delta: 1.961308)         elapsed: 26.682428 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-11-19T13:31:00.002680 (delta: 0.23492)         elapsed: 26.917421 ******** 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-76d469c9dc-4spsj -n sam -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:02.323034", "end": "2019-11-19 13:31:02.645870", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-11-19 13:31:00.322836", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.115430 seconds, 34.7MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.115430 seconds, 34.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-76d469c9dc-4spsj -n sam -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:02.062157", "end": "2019-11-19 13:31:05.132278", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-11-19 13:31:03.070121", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-11-19T13:31:05.313285 (delta: 5.310504)         elapsed: 32.228026 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-11-19T13:31:05.430690 (delta: 0.117293)         elapsed: 32.345431 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-11-19T13:31:05.504812 (delta: 0.07405)         elapsed: 32.419553 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-11-19T13:31:05.587864 (delta: 0.082983)         elapsed: 32.502605 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-11-19T13:31:05.682952 (delta: 0.095012)         elapsed: 32.597693 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-11-19T13:31:05.753454 (delta: 0.070416)         elapsed: 32.668195 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-11-19T13:31:05.865348 (delta: 0.111802)         elapsed: 32.780089 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-11-19T13:31:05.959553 (delta: 0.094103)         elapsed: 32.874294 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-11-19T13:31:06.074341 (delta: 0.114701)         elapsed: 32.989082 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-11-19T13:31:06.181801 (delta: 0.107375)         elapsed: 33.096542 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [generating yaml file for snapshot] ***************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:42
2019-11-19T13:31:06.300772 (delta: 0.118857)         elapsed: 33.215513 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "c2b19c5c35ac8f126b048a8f5d1b1d255a135d1b", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "767e9e27a4a2b69a39f8226c540032ea", "mode": "0644", "owner": "root", "size": 199, "src": "/root/.ansible/tmp/ansible-tmp-1574170266.44-198530343774835/source", "state": "file", "uid": 0}

TASK [create snapshot] *********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:47
2019-11-19T13:31:07.078209 (delta: 0.777317)         elapsed: 33.99295 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f snapshot.yml -n \"sam\"", "delta": "0:00:02.095387", "end": "2019-11-19 13:31:09.513695", "rc": 0, "start": "2019-11-19 13:31:07.418308", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.snapshot.storage.k8s.io/csi-snapshot created", "stdout_lines": ["volumesnapshot.snapshot.storage.k8s.io/csi-snapshot created"]}

TASK [Obtaining the storage class used from PVC] *******************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:54
2019-11-19T13:31:09.641516 (delta: 2.563213)         elapsed: 36.556257 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi-vol -n sam --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:01.383739", "end": "2019-11-19 13:31:11.378682", "rc": 0, "start": "2019-11-19 13:31:09.994943", "stderr": "", "stderr_lines": [], "stdout": "csi-sc", "stdout_lines": ["csi-sc"]}

TASK [Obtaining the SPC from storage class] ************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:60
2019-11-19T13:31:11.460303 (delta: 1.818634)         elapsed: 38.375044 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc csi-sc --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g'", "delta": "0:00:01.457693", "end": "2019-11-19 13:31:13.347407", "rc": 0, "start": "2019-11-19 13:31:11.889714", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Derive PV name from PVC] *************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:66
2019-11-19T13:31:13.508972 (delta: 2.048593)         elapsed: 40.423713 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi-vol -n sam --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.425917", "end": "2019-11-19 13:31:15.372061", "rc": 0, "start": "2019-11-19 13:31:13.946144", "stderr": "", "stderr_lines": [], "stdout": "pvc-4ea3b2cd-bfb4-4f02-811a-2bc19d0ede05", "stdout_lines": ["pvc-4ea3b2cd-bfb4-4f02-811a-2bc19d0ede05"]}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:74
2019-11-19T13:31:15.458027 (delta: 1.948923)         elapsed: 42.372768 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-4ea3b2cd-bfb4-4f02-811a-2bc19d0ede05 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.374476", "end": "2019-11-19 13:31:17.145453", "rc": 0, "start": "2019-11-19 13:31:15.770977", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:83
2019-11-19T13:31:17.242130 (delta: 1.784013)         elapsed: 44.156871 ******* 

TASK [Obtaining the pool pods] *************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:93
2019-11-19T13:31:17.383898 (delta: 0.141687)         elapsed: 44.298639 ******* 

TASK [Checking if the snapshot is created in all the pool pods.] ***************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:103
2019-11-19T13:31:17.526187 (delta: 0.142183)         elapsed: 44.440928 ******* 

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:112
2019-11-19T13:31:17.688879 (delta: 0.16258)         elapsed: 44.60362 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:121
2019-11-19T13:31:17.840055 (delta: 0.151034)         elapsed: 44.754796 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-19T13:31:17.993961 (delta: 0.153836)         elapsed: 44.908702 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-19T13:31:18.065371 (delta: 0.071304)         elapsed: 44.980112 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-19T13:31:18.135885 (delta: 0.070418)         elapsed: 45.050626 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-19T13:31:18.218885 (delta: 0.082941)         elapsed: 45.133626 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "657d97702102cdb89693831d51576ed6fb55d804", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8e6b890b48d11066ab45369024bbe2f2", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1574170278.32-120032534186208/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-19T13:31:21.578214 (delta: 3.359232)         elapsed: 48.492955 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.294855", "end": "2019-11-19 13:31:23.154427", "rc": 0, "start": "2019-11-19 13:31:21.859572", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-19T13:31:23.227452 (delta: 1.649159)         elapsed: 50.142193 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-19T11:30:16Z", "generation": 16, "name": "cstor-csi-snapshot", "resourceVersion": "143469", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-snapshot", "uid": "33d2144c-365c-44b3-8206-252e7570c2af"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=15   unreachable=0    failed=0   

2019-11-19T13:31:24.637099 (delta: 1.40954)         elapsed: 51.55184 ********* 
```

logs for clone:
```
PLAY [localhost] ***************************************************************
2019-11-20T06:04:38.416389 (delta: 0.083162)         elapsed: 0.083162 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:1
2019-11-20T06:04:38.439250 (delta: 0.022568)         elapsed: 0.106023 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:12
2019-11-20T06:04:52.911158 (delta: 14.471859)         elapsed: 14.577931 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-20T06:04:53.156751 (delta: 0.245508)         elapsed: 14.823524 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-20T06:04:53.290285 (delta: 0.133395)         elapsed: 14.957058 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:15
2019-11-20T06:04:53.394517 (delta: 0.104147)         elapsed: 15.06129 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-20T06:04:53.551573 (delta: 0.15697)         elapsed: 15.218346 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "00ecf3d3d3304a9e193474d3dfda7163aafefa41", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "88f24adaa51ab6501fc7e372c7089dbd", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1574229893.64-98586850379325/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-20T06:04:54.804243 (delta: 1.252576)         elapsed: 16.471016 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.296126", "end": "2019-11-20 06:04:56.783648", "rc": 0, "start": "2019-11-20 06:04:55.487522", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-20T06:04:56.869992 (delta: 2.065668)         elapsed: 18.536765 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-19T14:22:04Z", "generation": 7, "name": "cstor-csi-clone", "resourceVersion": "501463", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-clone", "uid": "fdae1c7b-6c51-412b-acbf-823edeae9715"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-20T06:04:58.905699 (delta: 2.035602)         elapsed: 20.572472 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-20T06:04:59.028550 (delta: 0.122702)         elapsed: 20.695323 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-20T06:04:59.135243 (delta: 0.106575)         elapsed: 20.802016 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the yaml file to clone the snapshot] ****************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:19
2019-11-20T06:04:59.253988 (delta: 0.118635)         elapsed: 20.920761 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "a7c515844a829f251cce79ea0911c76d8027531b", "dest": "./clone.yml", "gid": 0, "group": "root", "md5sum": "43a2c73b7b6eca1ad5b1160161503721", "mode": "0644", "owner": "root", "size": 290, "src": "/root/.ansible/tmp/ansible-tmp-1574229899.34-208609678877125/source", "state": "file", "uid": 0}

TASK [create the Clone] ********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:24
2019-11-20T06:05:00.025958 (delta: 0.771791)         elapsed: 21.692731 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f clone.yml -n sam", "delta": "0:00:02.394273", "end": "2019-11-20 06:05:02.803822", "rc": 0, "start": "2019-11-20 06:05:00.409549", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/csi-clone created", "stdout_lines": ["persistentvolumeclaim/csi-clone created"]}

TASK [shell] *******************************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:30
2019-11-20T06:05:02.955997 (delta: 2.929943)         elapsed: 24.62277 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat clone.yml", "delta": "0:00:01.334717", "end": "2019-11-20 06:05:04.739335", "rc": 0, "start": "2019-11-20 06:05:03.404618", "stderr": "", "stderr_lines": [], "stdout": "kind: PersistentVolumeClaim\napiVersion: v1\nmetadata:\n  name: \"csi-clone\"\nspec:\n  storageClassName: \"csi-sc\"\n  dataSource:\n    name: \"csi-snapshot\"\n    kind: VolumeSnapshot\n    apiGroup: snapshot.storage.k8s.io\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: 5Gi", "stdout_lines": ["kind: PersistentVolumeClaim", "apiVersion: v1", "metadata:", "  name: \"csi-clone\"", "spec:", "  storageClassName: \"csi-sc\"", "  dataSource:", "    name: \"csi-snapshot\"", "    kind: VolumeSnapshot", "    apiGroup: snapshot.storage.k8s.io", "  accessModes:", "    - ReadWriteOnce", "  resources:", "    requests:", "      storage: 5Gi"]}

TASK [Check if the pvc is bound] ***********************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:33
2019-11-20T06:05:04.822953 (delta: 1.86681)         elapsed: 26.489726 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc csi-clone -n sam --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.658744", "end": "2019-11-20 06:05:06.879951", "rc": 0, "start": "2019-11-20 06:05:05.221207", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Generaete the yaml file to deploy busybox] *******************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:43
2019-11-20T06:05:07.024646 (delta: 2.201617)         elapsed: 28.691419 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "256e4c2fb73878de89b774aaaa8836892ce62a9f", "dest": "./busybox.yml", "gid": 0, "group": "root", "md5sum": "a317375036725121bcf419a6df5f4514", "mode": "0644", "owner": "root", "size": 439, "src": "/root/.ansible/tmp/ansible-tmp-1574229907.19-162870540492357/source", "state": "file", "uid": 0}

TASK [Deploying the busybox app] ***********************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:48
2019-11-20T06:05:07.874416 (delta: 0.849658)         elapsed: 29.541189 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f busybox.yml -n sam", "delta": "0:00:01.876005", "end": "2019-11-20 06:05:10.106573", "rc": 0, "start": "2019-11-20 06:05:08.230568", "stderr": "", "stderr_lines": [], "stdout": "pod/busyboxclone created", "stdout_lines": ["pod/busyboxclone created"]}

TASK [Verify if the app is in Running state] ***********************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:54
2019-11-20T06:05:10.258469 (delta: 2.383957)         elapsed: 31.925242 ******* 
FAILED - RETRYING: Verify if the app is in Running state (15 retries left).
FAILED - RETRYING: Verify if the app is in Running state (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get po -n sam -l app=busybox-cloned --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.547379", "end": "2019-11-20 06:06:15.843104", "rc": 0, "start": "2019-11-20 06:06:14.295725", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the app pod name] ****************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:64
2019-11-20T06:06:15.954865 (delta: 65.696251)         elapsed: 97.621638 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l app=busybox-cloned --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.463883", "end": "2019-11-20 06:06:17.858106", "rc": 0, "start": "2019-11-20 06:06:16.394223", "stderr": "", "stderr_lines": [], "stdout": "busyboxclone", "stdout_lines": ["busyboxclone"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:71
2019-11-20T06:06:17.962583 (delta: 2.007628)         elapsed: 99.629356 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busyboxclone -n sam -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-clone-md5\"", "delta": "0:00:03.186361", "end": "2019-11-20 06:06:21.468500", "failed_when_result": false, "rc": 0, "start": "2019-11-20 06:06:18.282139", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:80
2019-11-20T06:06:21.664628 (delta: 3.701957)         elapsed: 103.331401 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busyboxclone -n sam -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-clone-md5\"", "delta": "0:00:02.051924", "end": "2019-11-20 06:06:24.041564", "failed_when_result": false, "rc": 0, "start": "2019-11-20 06:06:21.989640", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:89
2019-11-20T06:06:24.189483 (delta: 2.524737)         elapsed: 105.856256 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:98
2019-11-20T06:06:24.383342 (delta: 0.193762)         elapsed: 106.050115 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-20T06:06:24.564042 (delta: 0.180575)         elapsed: 106.230815 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-20T06:06:24.680911 (delta: 0.116744)         elapsed: 106.347684 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-20T06:06:24.771594 (delta: 0.090594)         elapsed: 106.438367 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-20T06:06:24.880145 (delta: 0.108464)         elapsed: 106.546918 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "9e74fbdeda5645715f05a69707cacb121dd396fb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4f7dbd6080791642133b998f65fb5d3b", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1574229985.06-250134648120352/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-20T06:06:28.310272 (delta: 3.430009)         elapsed: 109.977045 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.401022", "end": "2019-11-20 06:06:30.112249", "rc": 0, "start": "2019-11-20 06:06:28.711227", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-20T06:06:30.207126 (delta: 1.896746)         elapsed: 111.873899 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-19T14:22:04Z", "generation": 8, "name": "cstor-csi-clone", "resourceVersion": "502123", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-clone", "uid": "fdae1c7b-6c51-412b-acbf-823edeae9715"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=16   unreachable=0    failed=0   

2019-11-20T06:06:31.748253 (delta: 1.541041)         elapsed: 113.415026 ****** 
```