### PR TITLE
feat[experiment]: Implemeted a litmus experiment to scale down the cstor volume replica

### DIFF
--- a/chaoslib/openebs/cvr_scaledown/scale_down_cstor_replica.yml
+++ b/chaoslib/openebs/cvr_scaledown/scale_down_cstor_replica.yml
@@ -1,0 +1,109 @@
+---
+       - name: Obtain the total number of cvr
+         shell: kubectl get cvr -n {{ namespace }} --no-headers -l cstorvolume.openebs.io/name={{ cstor_volume_name }} | wc -l
+         args:
+           executable: /bin/bash
+         register: cvr_count
+         failed_when: 'cvr_count.stdout == ""'
+
+       - name: Obtain the ReplicationFactor from cstorvolume and check if it is equal to the cvr count
+         shell: >
+           kubectl get cstorvolume {{ cstor_volume_name }} -n {{ namespace }} -o jsonpath='{.spec.replicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: rf
+         failed_when: "cvr_count.stdout != rf.stdout"
+
+       - name: Obtain the consistencyFactor from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cstor_volume_name }} -n {{ namespace }} -o jsonpath='{.spec.consistencyFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: cf
+         failed_when: 'cf.stdout == ""'
+
+       - name: Obtain the desiredReplicationFactor from cstorvolume
+         shell: >
+           kubectl get cstorvolume {{ cstor_volume_name }} -n {{ namespace }} -o jsonpath='{.spec.desiredReplicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: drf
+         failed_when: 'drf.stdout == ""'
+
+       - name: Obtain the replica id from the selected replica
+         shell: kubectl get cvr -n {{ namespace }} {{ targeted_cvr_name }} --no-headers -o custom-columns=:.spec.replicaid
+         args:
+           executable: /bin/bash
+         register: replica_id
+         failed_when: 'replica_id.stdout == ""'
+
+       - set_fact:
+           cvr_replica_id: "{{ replica_id.stdout }}"
+
+       - set_fact:
+           drf_scaledown_count: "{{ (drf.stdout)|int - 1 }}"
+
+       - name: Identify the patch to be invoked
+         template:
+            src: scale_down_replica_patch.j2
+            dest: scale_down_replica_patch.yml
+
+       - name: Patching cstorvolume to scaledown the replica
+         shell: >
+           kubectl patch cstorvolume {{ cstor_volume_name }} -n {{ namespace }}
+           --patch "$(cat scale_down_replica_patch.yml)" --type='json'
+         register: patch_status
+         failed_when: "'patched' not in patch_status.stdout"
+
+       - name: Check if the targeted CVR is in Offline state
+         shell: >
+           kubectl get cvr -n {{ namespace }} {{ targeted_cvr_name }}
+           -o custom-columns=:.status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: new_cvr_status
+         until: "'Offline' in new_cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Check if the cvr is scaled down successfully
+         shell: >
+           kubectl describe cstorvolume {{ cstor_volume_name }} 
+           -n {{ namespace }} | grep "Successfully updated the desiredReplicationFactor to {{ drf_scaledown_count }}"
+         args:
+           executable: /bin/bash
+         register: drf_status
+         until: "'Successfully updated the desiredReplicationFactor' in drf_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the ReplicationFactor after cvr scaledown and verify the its getting updated
+         shell: >
+           kubectl get cstorvolume {{ cstor_volume_name }} -n {{ namespace }}
+           -o jsonpath='{.spec.replicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_rf
+         failed_when: "after_rf.stdout != drf_scaledown_count"
+
+         # calculate the consistency factor to check whether it is updated
+       - set_fact:
+            cf_count: "{{ (((drf_scaledown_count)|int / 2) + 1 | round(0,'floor'))|int }}"
+
+       - name: Obtain the consistencyFactor after cvr scaledown and Verify the consistency factor is updated.
+         shell: >
+           kubectl get cstorvolume {{ cstor_volume_name }} -n {{ namespace }}
+           -o jsonpath='{.spec.consistencyFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_cf
+         failed_when: "after_cf.stdout != cf_count"
+
+       - name: Obtain the desiredReplicationFactor after cvr scaledown and Verify the value getting updated
+         shell: >
+           kubectl get cstorvolume {{ cstor_volume_name }} -n {{ namespace }}
+           -o jsonpath='{.spec.desiredReplicationFactor}{"\n"}'
+         args:
+           executable: /bin/bash
+         register: after_drf
+         failed_when: "after_drf.stdout != drf_scaledown_count"

--- a/chaoslib/openebs/cvr_scaledown/scale_down_replica_patch.j2
+++ b/chaoslib/openebs/cvr_scaledown/scale_down_replica_patch.j2
@@ -1,0 +1,11 @@
+[
+ {
+    "op": "replace",
+    "path": "/spec/desiredReplicationFactor",
+    "value": {{ drf_scaledown_count }}
+ },
+ {
+    "op": "remove",
+    "path": "/spec/replicaDetails/knownReplicas/{{ cvr_replica_id }}",
+ }
+]

--- a/experiments/functional/cstor-volume-replica-scaledown/README.md
+++ b/experiments/functional/cstor-volume-replica-scaledown/README.md
@@ -1,0 +1,63 @@
+## Experiment Metadata
+
+| Type       | Description                                                                              | Storage | K8s Platform |
+| ---------- | ---------------------------------------------------------------------------------------- | ------- | ------------ |
+| Functional | Scale to the cStor volume Replica and validates the applicatin and cstorvolume behaviour.| OpenEBS | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- cStor SPC should be created.
+- Application should be deployed and it has more than one replica.
+
+## Exit-Criteria
+
+- Volume should be scaled down successfully and application should be accessible seamlessly.
+- cStor volume replica should be in Healthy state. Scale Down CVRs should be in OFFILNE state
+
+## Notes
+
+- This functional test checks if the cStor volume can be scaled down successfuly.
+- This litmusbook accepts the parameters in form of job environmental variables.
+
+## Associated Utils
+
+- `scale_down_cstor_replica.yml`,`mysql_data_persistence.yml`,`busybox_data_persistence.yml`
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS cStor volumes when the volume replica is scale down.
+
+Based on the value of env `DATA_PERSISTENCE`, the corresponding data consistency util will be executed. At present, only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+```
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+```
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+```
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+```
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario.
+
+Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
+## Litmusbook Environment Variables
+
+| Parameters     | Description                                            |
+| -------------  | ------------------------------------------------------ |
+| APP_NAMESPACE  | Namespace where application and volume is deployed.    |
+| PVC_NAME       | Name of PVC whose cvr has to be scaled down            |
+| APP_LABEL      | Label of application pod                               |
+| OPERATOR_NS    | Namespace where OpenEBS is deployed                    |
+|DATA_PERSISTENCE| Specify the application name against which data consistency has to be ensured. Example: busybox |

--- a/experiments/functional/cstor-volume-replica-scaledown/data_persistence.j2
+++ b/experiments/functional/cstor-volume-replica-scaledown/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/functional/cstor-volume-replica-scaledown/run_litmus_test.yml
+++ b/experiments/functional/cstor-volume-replica-scaledown/run_litmus_test.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cvr-scaledown
+  namespace: litmus
+data:
+  parameters.yml: |
+    
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-cstor-volume-replica-scaledown-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cvr-scaledown
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: ""
+
+          - name: APP_LABEL
+            value: ""
+          
+          - name: PVC_NAME
+            value: ""
+
+          - name: OPERATOR_NS
+            value: ""
+
+          - name: DATA_PERSISTENCE
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-volume-replica-scaledown/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: cvr-scaledown

--- a/experiments/functional/cstor-volume-replica-scaledown/test.yml
+++ b/experiments/functional/cstor-volume-replica-scaledown/test.yml
@@ -1,0 +1,186 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+
+  tasks:
+
+   - block:
+
+       - include_tasks: /utils/fcm/create_testname.yml
+
+      ## RECORD START-OF-TEST IN LITMUS RESULT CR
+       - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+         vars:
+           status: 'SOT'
+
+       - name: Identify the data consistency util to be invoked
+         template:
+           src: data_persistence.j2
+           dest: data_persistence.yml
+
+       - include_vars:
+           file: data_persistence.yml
+
+       - name: Record the data consistency util path
+         set_fact:
+           data_consistency_util_path: "{{ consistencyutil }}"
+         when: data_persistence != ''
+
+       - name: Checking the status of application pod
+         shell: kubectl get pod -n {{ app_ns }} -l {{ label }} -o jsonpath='{.items[0].status.phase}'
+         args:
+           executable: /bin/bash
+         register: app_pod_status
+         until: "'Running' in app_pod_status.stdout"
+         delay: 5
+         retries: 30
+
+       - name: Getting the pod name of Application
+         shell: kubectl get pod -n {{ app_ns }} -l {{ label }} -o jsonpath='{.items[0].metadata.name}'
+         args:
+           executable: /bin/bash
+         register: app_pod_name
+
+       - name: Obtain the Persistent Volume name
+         shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers -o custom-columns=:.spec.volumeName
+         args:
+           executable: /bin/bash
+         register: pv
+         failed_when: 'pv.stdout == ""'
+
+       - name: Create some test data
+         include: "{{ data_consistency_util_path }}"
+         vars:
+           status: 'LOAD'
+           ns: "{{ app_ns }}"
+           pod_name: "{{ app_pod_name.stdout }}"
+         when: data_persistence != ''
+
+       - name: Get the cStorVolume name
+         shell: >
+           kubectl get cstorvolume -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: cv_name
+         failed_when: 'cv_name.stdout == ""'
+
+       - name: Check if the CVRs in healthy state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ cv_name.stdout }}
+           -o custom-columns=:.status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: cvr_status
+         until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the List of CVR's
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: cvr_list
+         failed_when: 'cvr_list.stdout == ""'
+
+       - name: Select random cvr from the list of cvr as target cvr to scaledown
+         set_fact:
+           target_cvr: "{{ item }}"
+         with_random_choice: "{{ cvr_list.stdout_lines }}"
+
+       - include_tasks: "/chaoslib/openebs/cvr_scaledown/scale_down_cstor_replica.yml"
+         vars:
+           cstor_volume_name: "{{ cv_name.stdout }}"
+           namespace: "{{ operator_ns }}"
+           targeted_cvr_name: "{{ target_cvr }}"
+
+       - name: Remove the scale down cstor volume replica
+         shell: kubectl delete cvr -n {{ operator_ns }} {{ target_cvr }}
+         args:
+           executable: /bin/bash
+
+       - name: Check if the cvr got removed
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: new_cvr_list
+         until: "target_cvr not in new_cvr_list.stdout"
+         delay: 5
+         retries: 30
+
+       - name: Check if the CVRs in healthy state
+         shell: >
+           kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: new_cvr_status
+         until: "((new_cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in new_cvr_status.stdout"
+         retries: 30
+         delay: 10
+
+       - name: Obtain the cstor target name
+         shell: >
+           kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: target_pod
+         failed_when: 'target_pod.stdout == ""'
+
+       - name: Restart the cstor target pod
+         shell: kubectl delete pod -n {{ operator_ns }} {{ target_pod.stdout }}
+         args:
+           executable: /bin/bash
+
+       - name: Check if the cstor target is deleted
+         shell: >
+           kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: new_target
+         until: "target_pod.stdout not in new_target.stdout"
+         delay: 5
+         retries: 30
+
+       - name: check if the cstor target is in Running state
+         shell: >
+           kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+           -o custom-columns=:.status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: target_status
+         until: "'Running' in target_status.stdout"
+         delay: 5
+         retries: 30
+
+       - name: Verify application data persistence
+         include: "{{ data_consistency_util_path }}"
+         vars:
+            status: 'VERIFY'
+            ns: "{{ app_ns }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+         when: data_persistence != ''
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/cstor-volume-replica-scaledown/test_vars.yml
+++ b/experiments/functional/cstor-volume-replica-scaledown/test_vars.yml
@@ -1,0 +1,6 @@
+test_name: cstor-volume-replica-scaledown
+app_pvc: "{{ lookup('env','PVC_NAME') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Litmus Experiment to Perform cstor volume replica sclale down.
- Check the application data consistency and cstor target status.
- This PR contains a util under the chaoslib/openebs/cvr/scaledown.yml to perform the patch operation in cstorvolume for scaledown.

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [x] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
[root@master-1552853078 ~]# kubectl logs -f litmus-cstor-volume-replica-scaledown-ljfkc-jn72j -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-11-21T06:26:03.787833 (delta: 0.067354)         elapsed: 0.067354 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-11-21T06:26:03.804324 (delta: 0.01643)         elapsed: 0.083845 ********* 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-11-21T06:26:15.410211 (delta: 11.605865)         elapsed: 11.689732 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-11-21T06:26:15.550935 (delta: 0.140672)         elapsed: 11.830456 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-11-21T06:26:15.632128 (delta: 0.081087)         elapsed: 11.911649 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-11-21T06:26:15.692109 (delta: 0.05993)         elapsed: 11.97163 ********* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-11-21T06:26:15.828526 (delta: 0.13636)         elapsed: 12.108047 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "aa1756539f8faf686b22987555f8254dc2c3376b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5f813594ed7abd75e54bdce7ff0cb7af", "mode": "0644", "owner": "root", "size": 431, "src": "/root/.ansible/tmp/ansible-tmp-1574317575.9-36777507722036/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-11-21T06:26:16.718120 (delta: 0.889512)         elapsed: 12.997641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.256825", "end": "2019-11-21 06:26:18.575672", "rc": 0, "start": "2019-11-21 06:26:17.318847", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-volume-replica-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-volume-replica-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-11-21T06:26:18.639988 (delta: 1.921769)         elapsed: 14.919509 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-20T08:17:35Z", "generation": 1, "name": "cstor-volume-replica-scaledown", "namespace": "", "resourceVersion": "678237", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-volume-replica-scaledown", "uid": "356eed85-0b6e-11ea-98b9-005056985c20"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-11-21T06:26:20.201160 (delta: 1.561096)         elapsed: 16.480681 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-11-21T06:26:20.352322 (delta: 0.151084)         elapsed: 16.631843 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-11-21T06:26:20.475984 (delta: 0.123565)         elapsed: 16.755505 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the data consistency util to be invoked] ************************
2019-11-21T06:26:20.599266 (delta: 0.123174)         elapsed: 16.878787 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1574317580.72-274681937320880/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
2019-11-21T06:26:21.221626 (delta: 0.622248)         elapsed: 17.501147 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/functional/cstor-volume-replica-scaledown/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
2019-11-21T06:26:21.380216 (delta: 0.158497)         elapsed: 17.659737 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [Checking the status of application pod] **********************************
2019-11-21T06:26:21.480557 (delta: 0.100287)         elapsed: 17.760078 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.373907", "end": "2019-11-21 06:26:23.078887", "rc": 0, "start": "2019-11-21 06:26:21.704980", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Getting the pod name of Application] *************************************
2019-11-21T06:26:23.142533 (delta: 1.661905)         elapsed: 19.422054 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.456171", "end": "2019-11-21 06:26:24.818336", "rc": 0, "start": "2019-11-21 06:26:23.362165", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-85cgb", "stdout_lines": ["app-busybox-546d66979-85cgb"]}

TASK [Obtain the Persistent Volume name] ***************************************
2019-11-21T06:26:24.880086 (delta: 1.737506)         elapsed: 21.159607 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.416895", "end": "2019-11-21 06:26:26.507820", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:25.090925", "stderr": "", "stderr_lines": [], "stdout": "pvc-209efa0d-0c27-11ea-98b9-005056985c20", "stdout_lines": ["pvc-209efa0d-0c27-11ea-98b9-005056985c20"]}

TASK [Create some test data] ***************************************************
2019-11-21T06:26:26.581949 (delta: 1.701801)         elapsed: 22.86147 ******** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
2019-11-21T06:26:26.742675 (delta: 0.160653)         elapsed: 23.022196 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/cvrscaledown bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-85cgb -n app-busybox-ns -- sh -c \"dd if=/dev/urandom of=/busybox/cvrscaledown bs=4k count=1024\"", "delta": "0:00:01.743639", "end": "2019-11-21 06:26:28.733844", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/cvrscaledown bs=4k count=1024", "rc": 0, "start": "2019-11-21 06:26:26.990205", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.073273 seconds, 54.6MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.073273 seconds, 54.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/cvrscaledown > /busybox/cvrscaledown-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-85cgb -n app-busybox-ns -- sh -c \"md5sum /busybox/cvrscaledown > /busybox/cvrscaledown-pre-chaos-md5\"", "delta": "0:00:02.929515", "end": "2019-11-21 06:26:32.052250", "failed_when_result": false, "item": "md5sum /busybox/cvrscaledown > /busybox/cvrscaledown-pre-chaos-md5", "rc": 0, "start": "2019-11-21 06:26:29.122735", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
2019-11-21T06:26:32.198492 (delta: 5.455747)         elapsed: 28.478013 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
2019-11-21T06:26:32.274689 (delta: 0.076098)         elapsed: 28.55421 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
2019-11-21T06:26:32.338883 (delta: 0.064107)         elapsed: 28.618404 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
2019-11-21T06:26:32.410096 (delta: 0.07113)         elapsed: 28.689617 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
2019-11-21T06:26:32.494267 (delta: 0.084097)         elapsed: 28.773788 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
2019-11-21T06:26:32.595092 (delta: 0.100737)         elapsed: 28.874613 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
2019-11-21T06:26:32.740540 (delta: 0.145342)         elapsed: 29.020061 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
2019-11-21T06:26:32.871590 (delta: 0.130913)         elapsed: 29.151111 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
2019-11-21T06:26:32.990986 (delta: 0.119285)         elapsed: 29.270507 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
2019-11-21T06:26:33.101381 (delta: 0.110288)         elapsed: 29.380902 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the cStorVolume name] ************************************************
2019-11-21T06:26:33.161534 (delta: 0.060046)         elapsed: 29.441055 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:02.381232", "end": "2019-11-21 06:26:35.848284", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:33.467052", "stderr": "", "stderr_lines": [], "stdout": "pvc-209efa0d-0c27-11ea-98b9-005056985c20", "stdout_lines": ["pvc-209efa0d-0c27-11ea-98b9-005056985c20"]}

TASK [Check if the CVRs in healthy state] **************************************
2019-11-21T06:26:35.998372 (delta: 2.836779)         elapsed: 32.277893 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.475789", "end": "2019-11-21 06:26:37.690322", "rc": 0, "start": "2019-11-21 06:26:36.214533", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Obtain the List of CVR's] ************************************************
2019-11-21T06:26:37.768471 (delta: 1.770014)         elapsed: 34.047992 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.454483", "end": "2019-11-21 06:26:39.481453", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:38.026970", "stderr": "", "stderr_lines": [], "stdout": "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-lf7e\npvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0\npvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-xgb2", "stdout_lines": ["pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-lf7e", "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0", "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-xgb2"]}

TASK [Select random cvr from the list of cvr as target cvr to scaledown] *******
2019-11-21T06:26:39.563643 (delta: 1.795116)         elapsed: 35.843164 ******* 
ok: [127.0.0.1] => (item=pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0) => {"ansible_facts": {"target_cvr": "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0"}, "changed": false, "item": "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0"}

TASK [include_tasks] ***********************************************************
2019-11-21T06:26:39.667861 (delta: 0.104154)         elapsed: 35.947382 ******* 
included: /chaoslib/openebs/cvr_scaledown/scale_down_cstor_replica.yml for 127.0.0.1

TASK [Obtain the total number of cvr] ******************************************
2019-11-21T06:26:39.854380 (delta: 0.186446)         elapsed: 36.133901 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs --no-headers -l cstorvolume.openebs.io/name=pvc-209efa0d-0c27-11ea-98b9-005056985c20 | wc -l", "delta": "0:00:01.411606", "end": "2019-11-21 06:26:41.495249", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:40.083643", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the ReplicationFactor from cstorvolume and check if it is equal to the cvr count] ***
2019-11-21T06:26:41.585994 (delta: 1.731526)         elapsed: 37.865515 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs -o jsonpath='{.spec.replicationFactor}{\"\\n\"}'", "delta": "0:00:01.412784", "end": "2019-11-21 06:26:43.276680", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:41.863896", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the consistencyFactor from cstorvolume] ***************************
2019-11-21T06:26:43.407515 (delta: 1.821435)         elapsed: 39.687036 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs -o jsonpath='{.spec.consistencyFactor}{\"\\n\"}'", "delta": "0:00:02.565747", "end": "2019-11-21 06:26:46.289941", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:43.724194", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the desiredReplicationFactor from cstorvolume] ********************
2019-11-21T06:26:46.440327 (delta: 3.032692)         elapsed: 42.719848 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs -o jsonpath='{.spec.desiredReplicationFactor}{\"\\n\"}'", "delta": "0:00:01.588813", "end": "2019-11-21 06:26:48.346342", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:46.757529", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the replica id from the selected replica] *************************
2019-11-21T06:26:48.416220 (delta: 1.975751)         elapsed: 44.695741 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0 --no-headers -o custom-columns=:.spec.replicaid", "delta": "0:00:01.504298", "end": "2019-11-21 06:26:50.255002", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:48.750704", "stderr": "", "stderr_lines": [], "stdout": "B8B5A36F7C778A098DFD22EB8924598D", "stdout_lines": ["B8B5A36F7C778A098DFD22EB8924598D"]}

TASK [set_fact] ****************************************************************
2019-11-21T06:26:50.411635 (delta: 1.995359)         elapsed: 46.691156 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cvr_replica_id": "B8B5A36F7C778A098DFD22EB8924598D"}, "changed": false}

TASK [set_fact] ****************************************************************
2019-11-21T06:26:50.656057 (delta: 0.244319)         elapsed: 46.935578 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"drf_scaledown_count": "2"}, "changed": false}

TASK [Identify the patch to be invoked] ****************************************
2019-11-21T06:26:50.852894 (delta: 0.196716)         elapsed: 47.132415 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "adbda9a0f6a476ce620039d02f3f32828c5ed39e", "dest": "./scale_down_replica_patch.yml", "gid": 0, "group": "root", "md5sum": "54a00b5cb803459ac0bc53ad2aed1905", "mode": "0644", "owner": "root", "size": 202, "src": "/root/.ansible/tmp/ansible-tmp-1574317610.92-216667831825214/source", "state": "file", "uid": 0}

TASK [Patching cstorvolume to scaledown the replica] ***************************
2019-11-21T06:26:51.438121 (delta: 0.585158)         elapsed: 47.717642 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs --patch \"$(cat scale_down_replica_patch.yml)\" --type='json'", "delta": "0:00:01.404538", "end": "2019-11-21 06:26:53.117024", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:26:51.712486", "stderr": "", "stderr_lines": [], "stdout": "cstorvolume.openebs.io/pvc-209efa0d-0c27-11ea-98b9-005056985c20 patched", "stdout_lines": ["cstorvolume.openebs.io/pvc-209efa0d-0c27-11ea-98b9-005056985c20 patched"]}

TASK [Check if the targeted CVR is in Offline state] ***************************
2019-11-21T06:26:53.214109 (delta: 1.7759)         elapsed: 49.49363 ********** 
FAILED - RETRYING: Check if the targeted CVR is in Offline state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get cvr -n openebs pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.285900", "end": "2019-11-21 06:27:06.639101", "rc": 0, "start": "2019-11-21 06:27:05.353201", "stderr": "", "stderr_lines": [], "stdout": "Offline", "stdout_lines": ["Offline"]}

TASK [Check if the cvr is scaled down successfully] ****************************
2019-11-21T06:27:06.716520 (delta: 13.502334)         elapsed: 62.996041 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs | grep \"Successfully updated the desiredReplicationFactor to 2\"", "delta": "0:00:01.357523", "end": "2019-11-21 06:27:08.326140", "rc": 0, "start": "2019-11-21 06:27:06.968617", "stderr": "", "stderr_lines": [], "stdout": "  Normal   Updated     15s                  pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng, node1-1552853078.mayalabs.io  Successfully updated the desiredReplicationFactor to 2", "stdout_lines": ["  Normal   Updated     15s                  pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng, node1-1552853078.mayalabs.io  Successfully updated the desiredReplicationFactor to 2"]}

TASK [Obtain the ReplicationFactor after cvr scaledown and verify the its getting updated] ***
2019-11-21T06:27:08.392812 (delta: 1.67622)         elapsed: 64.672333 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs -o jsonpath='{.spec.replicationFactor}{\"\\n\"}'", "delta": "0:00:01.391011", "end": "2019-11-21 06:27:10.056605", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:27:08.665594", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [set_fact] ****************************************************************
2019-11-21T06:27:10.143151 (delta: 1.75028)         elapsed: 66.422672 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"cf_count": "2"}, "changed": false}

TASK [Obtain the consistencyFactor after cvr scaledown and Verify the consistency factor is updated.] ***
2019-11-21T06:27:10.249617 (delta: 0.106413)         elapsed: 66.529138 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs -o jsonpath='{.spec.consistencyFactor}{\"\\n\"}'", "delta": "0:00:01.357674", "end": "2019-11-21 06:27:11.924137", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:27:10.566463", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Obtain the desiredReplicationFactor after cvr scaledown and Verify the value getting updated] ***
2019-11-21T06:27:11.987568 (delta: 1.737883)         elapsed: 68.267089 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-209efa0d-0c27-11ea-98b9-005056985c20 -n openebs -o jsonpath='{.spec.desiredReplicationFactor}{\"\\n\"}'", "delta": "0:00:01.405554", "end": "2019-11-21 06:27:13.638252", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:27:12.232698", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Remove the scale down cstor volume replica] ******************************
2019-11-21T06:27:13.760945 (delta: 1.773323)         elapsed: 70.040466 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete cvr -n openebs pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0", "delta": "0:00:50.307115", "end": "2019-11-21 06:28:04.453322", "rc": 0, "start": "2019-11-21 06:27:14.146207", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io \"pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0\" deleted", "stdout_lines": ["cstorvolumereplica.openebs.io \"pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-v6g0\" deleted"]}

TASK [Check if the cvr got removed] ********************************************
2019-11-21T06:28:04.534146 (delta: 50.773101)         elapsed: 120.813667 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.437249", "end": "2019-11-21 06:28:06.210499", "rc": 0, "start": "2019-11-21 06:28:04.773250", "stderr": "", "stderr_lines": [], "stdout": "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-lf7e\npvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-xgb2", "stdout_lines": ["pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-lf7e", "pvc-209efa0d-0c27-11ea-98b9-005056985c20-cstor-block-disk-pool-xgb2"]}

TASK [Check if the CVRs in healthy state] **************************************
2019-11-21T06:28:06.344942 (delta: 1.81071)         elapsed: 122.624463 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.434414", "end": "2019-11-21 06:28:08.085780", "rc": 0, "start": "2019-11-21 06:28:06.651366", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy", "stdout_lines": ["Healthy", "Healthy"]}

TASK [Obtain the cstor target name] ********************************************
2019-11-21T06:28:08.210097 (delta: 1.865027)         elapsed: 124.489618 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.329305", "end": "2019-11-21 06:28:09.766981", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:28:08.437676", "stderr": "", "stderr_lines": [], "stdout": "pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng", "stdout_lines": ["pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng"]}

TASK [Restart the cstor target pod] ********************************************
2019-11-21T06:28:09.849762 (delta: 1.639554)         elapsed: 126.129283 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod -n openebs pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng", "delta": "0:00:38.902883", "end": "2019-11-21 06:28:49.071712", "rc": 0, "start": "2019-11-21 06:28:10.168829", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng\" deleted", "stdout_lines": ["pod \"pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9zvkng\" deleted"]}

TASK [Check if the cstor target is deleted] ************************************
2019-11-21T06:28:49.128183 (delta: 39.278324)         elapsed: 165.407704 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.441565", "end": "2019-11-21 06:28:50.785921", "rc": 0, "start": "2019-11-21 06:28:49.344356", "stderr": "", "stderr_lines": [], "stdout": "pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9b2t5d", "stdout_lines": ["pvc-209efa0d-0c27-11ea-98b9-005056985c20-target-74b46965b9b2t5d"]}

TASK [check if the cstor target is in Running state] ***************************
2019-11-21T06:28:50.857624 (delta: 1.729376)         elapsed: 167.137145 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-209efa0d-0c27-11ea-98b9-005056985c20 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.420467", "end": "2019-11-21 06:28:52.513655", "rc": 0, "start": "2019-11-21 06:28:51.093188", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify application data persistence] *************************************
2019-11-21T06:28:52.604331 (delta: 1.746637)         elapsed: 168.883852 ****** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
2019-11-21T06:28:52.860552 (delta: 0.256136)         elapsed: 169.140073 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/cvrscaledown bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/cvrscaledown bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/cvrscaledown > /busybox/cvrscaledown-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/cvrscaledown > /busybox/cvrscaledown-pre-chaos-md5", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
2019-11-21T06:28:52.949525 (delta: 0.088916)         elapsed: 169.229046 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-546d66979-85cgb -n app-busybox-ns", "delta": "0:00:35.882743", "end": "2019-11-21 06:29:29.091219", "rc": 0, "start": "2019-11-21 06:28:53.208476", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-546d66979-85cgb\" deleted", "stdout_lines": ["pod \"app-busybox-546d66979-85cgb\" deleted"]}

TASK [Verify if the applicaion pod is deleted] *********************************
2019-11-21T06:29:29.217668 (delta: 36.268077)         elapsed: 205.497189 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns", "delta": "0:00:01.431740", "end": "2019-11-21 06:29:30.989586", "rc": 0, "start": "2019-11-21 06:29:29.557846", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS    RESTARTS   AGE\napp-busybox-546d66979-s8kjg    1/1     Running   0          36s\nbusybox-liveness-5ztmg-5flxm   1/1     Running   0          5m", "stdout_lines": ["NAME                           READY   STATUS    RESTARTS   AGE", "app-busybox-546d66979-s8kjg    1/1     Running   0          36s", "busybox-liveness-5ztmg-5flxm   1/1     Running   0          5m"]}

TASK [Obtain the newly created pod name for applicaion] ************************
2019-11-21T06:29:31.058746 (delta: 1.84095)         elapsed: 207.338267 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.362273", "end": "2019-11-21 06:29:32.638882", "rc": 0, "start": "2019-11-21 06:29:31.276609", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-546d66979-s8kjg", "stdout_lines": ["app-busybox-546d66979-s8kjg"]}

TASK [Checking application pod is in running state] ****************************
2019-11-21T06:29:32.697606 (delta: 1.638788)         elapsed: 208.977127 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-s8kjg\")].status.phase}'", "delta": "0:00:01.430318", "end": "2019-11-21 06:29:34.350013", "rc": 0, "start": "2019-11-21 06:29:32.919695", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
2019-11-21T06:29:34.433256 (delta: 1.735585)         elapsed: 210.712777 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-546d66979-s8kjg\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.476948", "end": "2019-11-21 06:29:36.167602", "rc": 0, "start": "2019-11-21 06:29:34.690654", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-11-21T06:28:57Z]]", "stdout_lines": ["map[running:map[startedAt:2019-11-21T06:28:57Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
2019-11-21T06:29:36.231192 (delta: 1.797872)         elapsed: 212.510713 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-s8kjg -n app-busybox-ns -- sh -c \"md5sum /busybox/cvrscaledown > /busybox/cvrscaledown-post-chaos-md5\"", "delta": "0:00:01.589428", "end": "2019-11-21 06:29:38.047110", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:29:36.457682", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
2019-11-21T06:29:38.117625 (delta: 1.886376)         elapsed: 214.397146 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-546d66979-s8kjg -n app-busybox-ns -- sh -c \"diff /busybox/cvrscaledown-pre-chaos-md5 /busybox/cvrscaledown-post-chaos-md5\"", "delta": "0:00:01.598686", "end": "2019-11-21 06:29:39.944714", "failed_when_result": false, "rc": 0, "start": "2019-11-21 06:29:38.346028", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for applicaion] ******************************
2019-11-21T06:29:40.025167 (delta: 1.907484)         elapsed: 216.304688 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
2019-11-21T06:29:40.093787 (delta: 0.06856)         elapsed: 216.373308 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
2019-11-21T06:29:40.152736 (delta: 0.058884)         elapsed: 216.432257 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-11-21T06:29:40.211666 (delta: 0.058864)         elapsed: 216.491187 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-11-21T06:29:40.310201 (delta: 0.098471)         elapsed: 216.589722 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-11-21T06:29:40.443145 (delta: 0.132869)         elapsed: 216.722666 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-11-21T06:29:40.513485 (delta: 0.070279)         elapsed: 216.793006 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-11-21T06:29:40.577625 (delta: 0.064075)         elapsed: 216.857146 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-11-21T06:29:40.639741 (delta: 0.062058)         elapsed: 216.919262 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d195ec4b3bf92c002f06ebd1acd30d7e49b65f6f", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "ac199262c1cae7a77d02853349e01381", "mode": "0644", "owner": "root", "size": 429, "src": "/root/.ansible/tmp/ansible-tmp-1574317780.71-258311440750457/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-11-21T06:29:44.099053 (delta: 3.459253)         elapsed: 220.378574 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.220891", "end": "2019-11-21 06:29:45.571742", "rc": 0, "start": "2019-11-21 06:29:44.350851", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-volume-replica-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-volume-replica-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-11-21T06:29:45.638485 (delta: 1.539358)         elapsed: 221.918006 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2019-11-20T08:17:35Z", "generation": 1, "name": "cstor-volume-replica-scaledown", "namespace": "", "resourceVersion": "679037", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-volume-replica-scaledown", "uid": "356eed85-0b6e-11ea-98b9-005056985c20"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=40   unreachable=0    failed=0   

2019-11-21T06:29:46.840155 (delta: 1.20161)         elapsed: 223.119676 ******* 
=============================================================================== 
```