### PR TITLE
refactor[yaml]: Modified litmusbook to create volume snapshotclass

### DIFF
--- a/providers/csi-provisioner/run_litmus_test.yml
+++ b/providers/csi-provisioner/run_litmus_test.yml
@@ -25,6 +25,9 @@ spec:
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-csi-cstor-sparse
 
+          - name: SNAPSHOT_CLASS
+            value: csi-cstor
+
           - name: NODE_OS
             value: ubuntu-16.04
 

--- a/providers/csi-provisioner/snapshot-class.j2
+++ b/providers/csi-provisioner/snapshot-class.j2
@@ -1,0 +1,8 @@
+kind: VolumeSnapshotClass
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+metadata:
+  name: "{{ snapshot_class }}"
+  namespace: kube-system
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+snapshotter: cstor.csi.openebs.io

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -78,6 +78,18 @@
           register: sc_result
           failed_when: "sc_result.rc != 0"
 
+        - name: Update the volume snapshotclass template with the variables
+          template:
+            src: snapshot-class.j2
+            dest: snapshot-class.yml
+
+        - name: Create volume snapshotclass
+          shell: kubectl apply -f snapshot-class.yml
+          args: 
+            executable: /bin/bash
+          register: result
+          failed_when: "result.rc != 0"
+              
         - set_fact:
             flag: "Pass"
 

--- a/providers/csi-provisioner/test_vars.yml
+++ b/providers/csi-provisioner/test_vars.yml
@@ -11,3 +11,5 @@ storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
 
 node_os: "{{ lookup('env','NODE_OS') }}"
+
+snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified litmusbook to create volume snapshotclass 

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2019-11-22T05:24:06.538239 (delta: 0.107358)         elapsed: 0.107358 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-11-22T05:24:06.561679 (delta: 0.023286)         elapsed: 0.130798 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-11-22T05:24:20.839857 (delta: 14.278133)         elapsed: 14.408976 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-11-22T05:24:21.017307 (delta: 0.177373)         elapsed: 14.586426 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-11-22T05:24:21.176333 (delta: 0.158926)         elapsed: 14.745452 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-11-22T05:24:21.358979 (delta: 0.182524)         elapsed: 14.928098 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-11-22T05:24:21.604659 (delta: 0.245574)         elapsed: 15.173778 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "af580fd43c60b8040cbac636c779b0cb4ebf449b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2d66fb549be9e3c9cae61b70ee95b9e0", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1574400261.68-219445697790059/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-11-22T05:24:22.874153 (delta: 1.269423)         elapsed: 16.443272 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.306831", "end": "2019-11-22 05:24:24.876188", "rc": 0, "start": "2019-11-22 05:24:23.569357", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-11-22T05:24:24.962548 (delta: 2.088217)         elapsed: 18.531667 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-22T05:24:26Z", "generation": 1, "name": "csi-provision", "resourceVersion": "528889", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "45829c95-bfab-490b-a1ae-3d60e8c84867"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-11-22T05:24:26.927866 (delta: 1.965206)         elapsed: 20.496985 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-11-22T05:24:27.025003 (delta: 0.096847)         elapsed: 20.594122 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-11-22T05:24:27.125752 (delta: 0.100637)         elapsed: 20.694871 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy CSI Driver if OS is either centos or ubuntu-16.04] ****************
2019-11-22T05:24:27.226732 (delta: 0.100893)         elapsed: 20.795851 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml", "delta": "0:00:03.065862", "end": "2019-11-22 05:24:30.681700", "rc": 0, "start": "2019-11-22 05:24:27.615838", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged\nserviceaccount/openebs-cstor-csi-controller-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding unchanged\nstatefulset.apps/openebs-cstor-csi-controller unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding unchanged\nserviceaccount/openebs-cstor-csi-node-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding unchanged\ndaemonset.apps/openebs-cstor-csi-node unchanged", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged", "serviceaccount/openebs-cstor-csi-controller-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding unchanged", "statefulset.apps/openebs-cstor-csi-controller unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding unchanged", "serviceaccount/openebs-cstor-csi-node-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding unchanged", "daemonset.apps/openebs-cstor-csi-node unchanged"]}

TASK [Deploy CSI Driver if os is ubuntu 18.04] *********************************
2019-11-22T05:24:30.807433 (delta: 3.580597)         elapsed: 24.376552 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if csi-controller pod is running] **********************************
2019-11-22T05:24:30.943830 (delta: 0.136305)         elapsed: 24.512949 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.635584", "end": "2019-11-22 05:24:32.976434", "rc": 0, "start": "2019-11-22 05:24:31.340850", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2019-11-22T05:24:33.137541 (delta: 2.193579)         elapsed: 26.70666 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:01.451144", "end": "2019-11-22 05:24:34.970839", "rc": 0, "start": "2019-11-22 05:24:33.519695", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Check if the desired count matches the ready pods] ***********************
2019-11-22T05:24:35.093305 (delta: 1.955609)         elapsed: 28.662424 ******* 
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": ["kubectl", "get", "ds", "-n", "kube-system", "openebs-cstor-csi-node", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:01.544403", "end": "2019-11-22 05:24:37.119050", "rc": 0, "start": "2019-11-22 05:24:35.574647", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Update the storage class template with the variables.] *******************
2019-11-22T05:24:37.266279 (delta: 2.172848)         elapsed: 30.835398 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "e75a5f7e15a3ee9d9ec01ab6bfead016430b709a", "dest": "./csi-cstor-sc.yml", "gid": 0, "group": "root", "md5sum": "6c6995cc6ef9f06fe134c2652c0fdb9c", "mode": "0644", "owner": "root", "size": 281, "src": "/root/.ansible/tmp/ansible-tmp-1574400277.36-248092157680683/source", "state": "file", "uid": 0}

TASK [Create Storageclass] *****************************************************
2019-11-22T05:24:37.972757 (delta: 0.706382)         elapsed: 31.541876 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-sc.yml", "delta": "0:00:01.918607", "end": "2019-11-22 05:24:40.198581", "failed_when_result": false, "rc": 0, "start": "2019-11-22 05:24:38.279974", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-csi created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-csi created"]}

TASK [Update the volume snapshotclass template with the variables] *************
2019-11-22T05:24:40.328790 (delta: 2.355936)         elapsed: 33.897909 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "02e2271c90ce59569a49dc852ce824fa54224dab", "dest": "./snapshot-class.yml", "gid": 0, "group": "root", "md5sum": "75e3a11ddb301d34b68626be558ad9a1", "mode": "0644", "owner": "root", "size": 234, "src": "/root/.ansible/tmp/ansible-tmp-1574400280.42-200187829752099/source", "state": "file", "uid": 0}

TASK [Create volume snapshotclass] *********************************************
2019-11-22T05:24:41.005011 (delta: 0.676062)         elapsed: 34.57413 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-class.yml", "delta": "0:00:01.767474", "end": "2019-11-22 05:24:43.102188", "failed_when_result": false, "rc": 0, "start": "2019-11-22 05:24:41.334714", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor created", "stdout_lines": ["volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor created"]}

TASK [set_fact] ****************************************************************
2019-11-22T05:24:43.212121 (delta: 2.20703)         elapsed: 36.78124 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-11-22T05:24:43.359509 (delta: 0.147308)         elapsed: 36.928628 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-11-22T05:24:43.554161 (delta: 0.194551)         elapsed: 37.12328 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-11-22T05:24:43.653458 (delta: 0.099186)         elapsed: 37.222577 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-11-22T05:24:43.731366 (delta: 0.07781)         elapsed: 37.300485 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-11-22T05:24:43.837885 (delta: 0.106438)         elapsed: 37.407004 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8465df021b7326c95c9856682eb50700e84d8dc7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "685bbc60e191086cf7d2cf0f55be2022", "mode": "0644", "owner": "root", "size": 412, "src": "/root/.ansible/tmp/ansible-tmp-1574400283.94-193727887625261/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-11-22T05:24:46.995925 (delta: 3.157933)         elapsed: 40.565044 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.443389", "end": "2019-11-22 05:24:48.905978", "rc": 0, "start": "2019-11-22 05:24:47.462589", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-11-22T05:24:49.007350 (delta: 2.011333)         elapsed: 42.576469 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-22T05:24:26Z", "generation": 2, "name": "csi-provision", "resourceVersion": "529031", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "45829c95-bfab-490b-a1ae-3d60e8c84867"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=19   changed=14   unreachable=0    failed=0   

2019-11-22T05:24:50.657927 (delta: 1.650498)         elapsed: 44.227046 ******* 
=============================================================================== 
```