### PR TITLE
feat[yaml]: Included cstor csi snapshot and clone deletion litmusbook

### DIFF
--- a/experiments/functional/cstor-csi/csi-clone/busybox.j2
+++ b/experiments/functional/cstor-csi/csi-clone/busybox.j2
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: busyboxclone
+  name: "{{ app_name }}"
   namespace: "{{ namespace }}"
   labels:
     app: "{{ app_label }}"
@@ -27,4 +27,4 @@ spec:
       volumes:
       - name: data-vol
         persistentVolumeClaim:
-          claimName: "{{ pvc_name }}"
+          claimName: "{{ cloned_pvc }}"

--- a/experiments/functional/cstor-csi/csi-clone/clone.j2
+++ b/experiments/functional/cstor-csi/csi-clone/clone.j2
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ pvc_name }}"
+  name: "{{ cloned_pvc }}"
 spec:
   storageClassName: "{{ storage_class_name }}"
   dataSource:

--- a/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/run_litmus_test.yml
@@ -47,6 +47,12 @@ spec:
           - name: APP_PVC
             value: ''
 
+          - name: CLONED_PVC
+            value: ''
+
+          - name: APP_NAME
+            value: 
+            
           - name: APP_LABEL
             value: 'busybox-cloned'
 

--- a/experiments/functional/cstor-csi/csi-clone/test.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test.yml
@@ -32,7 +32,7 @@
         ## Deploy busybox app to check if the snapshot is cloned 
         - name: Check if the pvc is bound
           shell: >
-            kubectl get pvc {{ pvc_name }} -n {{ namespace }} 
+            kubectl get pvc {{ cloned_pvc }} -n {{ namespace }} 
             --no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash

--- a/experiments/functional/cstor-csi/csi-clone/test_vars.yml
+++ b/experiments/functional/cstor-csi/csi-clone/test_vars.yml
@@ -4,6 +4,8 @@ namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 
 pvc_name: "{{ lookup('env','APP_PVC') }}"
 
+app_name: "{{ lookup('env','APP_NAME') }}"
+
 app_label: "{{ lookup('env','APP_LABEL') }}"
 
 snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"
@@ -15,3 +17,7 @@ data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 storage_class_name: "{{ lookup('env','STORAGE_CLASS_NAME') }}"
 
 storage_capacity: "{{ lookup('env','STORAGE_CAPACITY') }}"
+
+cloned_pvc: "{{ lookup('env','CLONED_PVC') }}"
+
+operator_ns: 'openebs'

--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -38,7 +38,7 @@
             ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"  
           when: data_persistence != ''
-
+       
         - name: generating yaml file for snapshot
           template: 
             src: snapshot.j2

--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -101,11 +101,11 @@
             - "{{ pools.results }}"
 
         - name: Checking if the snapshot is created in all the pool pods.
-          shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -c cstor-pool -- zfs list -t snapshot
+          shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -c cstor-pool -- zfs list -t snapshot | grep {{volume_snapshot}}
           args:
             executable: /bin/bash
           register: snap
-          failed_when: "volume_snapshot not in snap.stdout"
+          failed_when: "snap.stdout == ''"
           with_items:
             - "{{ pool_pods.results }}"
                           

--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -53,10 +53,10 @@
           failed_when: "status.rc != 0"
 
        #  Verify if the snapshot created successfully
-        - name: Get the content of the snapshot taken
+        - name: Get the uid of the snapshot taken
           shell: >
-            kubectl get volumesnapshots.snapshot {{ snapshot_name }} -n {{ namespace }} 
-            --no-headers -o custom-columns=:spec.snapshotContentName | sed 's/snapcontent-//g'
+            kubectl get volumesnapshot.snapshot {{ snapshot_name }} -n {{ namespace }} 
+            --no-headers -o custom-columns=:.metadata.uid
           args:
             executable: /bin/bash
           register: snapcontent
@@ -108,7 +108,7 @@
           failed_when: "volume_snapshot not in snap.stdout"
           with_items:
             - "{{ pool_pods.results }}"
-        
+                          
         - set_fact:
             flag: "Pass"
 

--- a/utils/scm/applications/busybox/busybox_data_persistence.yml
+++ b/utils/scm/applications/busybox/busybox_data_persistence.yml
@@ -12,6 +12,7 @@
      with_items:
        - "dd if=/dev/urandom of=/busybox/{{ testfile }} bs={{ blocksize }} count={{ blockcount }}"
        - "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-pre-chaos-md5"
+       - "sync;sync;sync"
 
   when: status == "LOAD"
 

--- a/utils/scm/openebs/delete_cstor_csi_clone.yml
+++ b/utils/scm/openebs/delete_cstor_csi_clone.yml
@@ -83,7 +83,7 @@
   failed_when: "status.rc != 0"
 
 ## verify if the cloned pvc is deleted
-- name: try to obtain the cloned pvc
+- name: check if the cloned pvc is deleted
   shell: >
     kubectl get pvc -n {{ namespace }}
   args:
@@ -94,7 +94,7 @@
   retries: 15   
 
   ## verify if the pv for cloned pvc is deleted
-- name: try to obtain the pv for cloned pvc
+- name: check if the pv for cloned pvc is deleted
   shell: >
     kubectl get pv -n {{ namespace }}
   args:
@@ -106,7 +106,7 @@
   wait_for: timeout=30
 
   ## verify if the cvrs for cloned pvc is deleted
-- name: try to obtain the cvrs for cloned pvc
+- name: check if the cvrs for cloned pvc is deleted
   shell: >
     kubectl get cvr {{ item }} -n {{ operator_ns }} --no-headers -o custom-columns=:metadata.name
   args:

--- a/utils/scm/openebs/delete_cstor_csi_clone.yml
+++ b/utils/scm/openebs/delete_cstor_csi_clone.yml
@@ -38,9 +38,6 @@
     executable: /bin/bash
   register: cvr
 
-- set_fact:
-    cloned_cvr_name: "{{ cvr.stdout }}"
-
 ## obtain the application pod name
 - name: Get the app pod name
   shell: >

--- a/utils/scm/openebs/delete_cstor_csi_clone.yml
+++ b/utils/scm/openebs/delete_cstor_csi_clone.yml
@@ -32,7 +32,7 @@
 
 - name: Obtaining the CVR from PV
   shell: >
-    kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} 
+    kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ cloned_pv_name }} 
     --no-headers  -o custom-columns=:metadata.name
   args:
     executable: /bin/bash
@@ -56,7 +56,7 @@
 ## delete the busybox deployment  
 - name: delete the busybox_app 
   shell: > 
-    kubectl delete deploy {{ app_name }} -n {{ namespace }}
+    kubectl delete -f busybox.yml
   args:
     executable: /bin/bash
   register: status
@@ -89,27 +89,30 @@
   args:
     executable: /bin/bash
   register: cloned_pvc_name
-  until: "cloned_pvc not in cloned_pvc_name  .stdout"
+  until: "cloned_pvc not in cloned_pvc_name.stdout"
   delay: 30
   retries: 15   
 
   ## verify if the pv for cloned pvc is deleted
 - name: try to obtain the pv for cloned pvc
   shell: >
-    kubectl get pvc -n {{ namespace }}
+    kubectl get pv -n {{ namespace }}
   args:
     executable: /bin/bash
   register: cloned_pv
   failed_when: "cloned_pv_name in cloned_pv.stdout"
 
+- name: sleep for 30 seconds and continue with play
+  wait_for: timeout=30
+
   ## verify if the cvrs for cloned pvc is deleted
 - name: try to obtain the cvrs for cloned pvc
   shell: >
-    kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} 
-    --no-headers  -o custom-columns=:metadata.name
+    kubectl get cvr {{ item }} -n {{ operator_ns }} --no-headers -o custom-columns=:metadata.name
   args:
     executable: /bin/bash
   register: cloned_cvr
-  until: "cloned_cvr_name not in cloned_cvr.stdout"
-  delay: 30
-  retries: 15  
+  failed_when: "cloned_cvr.stdout != ''"
+  with_items: 
+    - "{{ cvr.stdout_lines }}"
+    

--- a/utils/scm/openebs/delete_cstor_csi_clone.yml
+++ b/utils/scm/openebs/delete_cstor_csi_clone.yml
@@ -1,0 +1,115 @@
+---
+
+## verify that parent pvc should not be deleted
+- name: delete pvc from which snapshot is created 
+  shell: >
+    kubectl delete pvc {{ pvc_name }} -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "status.rc ==0"
+
+## verify snapshot cr should not be deleted
+# - name: delete snapshot cr
+#   shell: >
+#     kubectl delete volumesnapshot.snapshot {{ snapshot_name }} -n {{ namespace }}
+#   args:
+#     executable: /bin/bash
+#   register: status
+#   failed_when: "status.rc ==0"
+
+## store the PV and CVRs for corresponding cloned pvc 
+- name: Derive PV name from PVC
+  shell: >
+    kubectl get pvc {{ cloned_pvc }} -n {{ namespace }}
+    --no-headers -o custom-columns=:spec.volumeName
+  args:
+    executable: /bin/bash
+  register: pv
+
+- set_fact:
+    cloned_pv_name: "{{ pv.stdout }}"
+
+- name: Obtaining the CVR from PV
+  shell: >
+    kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} 
+    --no-headers  -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  register: cvr
+
+- set_fact:
+    cloned_cvr_name: "{{ cvr.stdout }}"
+
+## obtain the application pod name
+- name: Get the app pod name
+  shell: >
+    kubectl get pods -n {{ namespace }} -l app={{ app_label }} 
+    --no-headers -o custom-columns=:.metadata.name
+  args: 
+    executable: /bin/bash
+  register: app_pod_name
+
+- set_fact: 
+    application_podname: "{{ app_pod_name.stdout }}"
+
+## delete the busybox deployment  
+- name: delete the busybox_app 
+  shell: > 
+    kubectl delete deploy {{ app_name }} -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "status.rc != 0"
+
+## verify if the pod is deleted
+- name: Check if the pod is deleted successfully
+  shell: >
+    kubectl get po -n {{ namespace }} 
+  args:
+    executable: /bin/bash
+  register: app_status
+  until: "application_podname not in app_status.stdout"
+  delay: 30
+  retries: 15   
+
+## verify and delete the cloned pvc 
+- name: delete the cloned pvc
+  shell: >
+    kubectl delete pvc {{ cloned_pvc }} -n {{ namespace }} 
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "status.rc != 0"
+
+## verify if the cloned pvc is deleted
+- name: try to obtain the cloned pvc
+  shell: >
+    kubectl get pvc -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: cloned_pvc_name
+  until: "cloned_pvc not in cloned_pvc_name  .stdout"
+  delay: 30
+  retries: 15   
+
+  ## verify if the pv for cloned pvc is deleted
+- name: try to obtain the pv for cloned pvc
+  shell: >
+    kubectl get pvc -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: cloned_pv
+  failed_when: "cloned_pv_name in cloned_pv.stdout"
+
+  ## verify if the cvrs for cloned pvc is deleted
+- name: try to obtain the cvrs for cloned pvc
+  shell: >
+    kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} 
+    --no-headers  -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  register: cloned_cvr
+  until: "cloned_cvr_name not in cloned_cvr.stdout"
+  delay: 30
+  retries: 15  

--- a/utils/scm/openebs/delete_cstor_csi_snapshot.yml
+++ b/utils/scm/openebs/delete_cstor_csi_snapshot.yml
@@ -1,6 +1,5 @@
 ---
 
-
 - name: Obtain the SnapshotContent of the snapshot
   shell: >
     kubectl get volumesnapshot.snapshot {{ snapshot_name }} -n {{ namespace }} 
@@ -49,9 +48,7 @@
   register: ss_content
   failed_when: "snapshotcontent in ss_content.stdout"  
 
-
 ## verify if the snapshot is deleted from all the pool pods
-
 - name: Derive PV name from PVC
   shell: >
     kubectl get pvc {{ pvc_name }} -n {{ namespace }}

--- a/utils/scm/openebs/delete_cstor_csi_snapshot.yml
+++ b/utils/scm/openebs/delete_cstor_csi_snapshot.yml
@@ -1,0 +1,98 @@
+---
+
+
+- name: Obtain the SnapshotContent of the snapshot
+  shell: >
+    kubectl get volumesnapshot.snapshot {{ snapshot_name }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:.spec.snapshotContentName
+  args:
+    executable: /bin/bash
+  register: snapshot_content
+  
+- set_fact:
+    snapshotcontent: "{{ snapshot_content.stdout }}"
+
+- name: Get the uid of the snapshot taken
+  shell: >
+    kubectl get volumesnapshot.snapshot {{ snapshot_name }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:.metadata.uid
+  args:
+    executable: /bin/bash
+  register: snap_uid
+
+- set_fact:
+    uid_snapshot: "{{ snap_uid.stdout }}"
+
+- name: Delete the snapshot created
+  shell: >
+    kubectl delete volumesnapshot.snapshot {{ snapshot_name }} -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "status.rc != 0"
+
+##Check if the snapshot is deleted
+- name: Verify if the snapshot is deleted
+  shell: >
+    kubectl get volumesnapshot.snapshot -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: ss_name
+  failed_when: "snapshot_name in ss_name.stdout"
+
+##Check if the volumesnapshotcontent is deleted
+- name: Verify if the volumesnapshotcontent is deleted
+  shell: >
+    kubectl get volumesnapshotcontent -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: ss_content
+  failed_when: "snapshotcontent in ss_content.stdout"  
+
+
+## verify if the snapshot is deleted from all the pool pods
+
+- name: Derive PV name from PVC
+  shell: >
+    kubectl get pvc {{ pvc_name }} -n {{ namespace }}
+    --no-headers -o custom-columns=:spec.volumeName
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Obtaining the CVR from PV
+  shell: >
+    kubectl get cvr -n {{ operator_ns }} -l cstorvolume.openebs.io/name={{ pv.stdout }} 
+    --no-headers  -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  register: cvr
+
+- name: Obtaining the pools where CVRs are mounted
+  shell: >
+    kubectl get cvr {{ item }} -n {{ operator_ns }} --no-headers 
+    -o jsonpath='{.metadata.labels.cstorpoolinstance\.openebs\.io/name}{"\n"}'
+  args:
+    executable: /bin/bash
+  register: pools
+  with_items:
+    - "{{ cvr.stdout_lines }}"
+  
+- name: Obtaining the pool pods
+  shell: >
+    kubectl get po -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item.stdout }} 
+    --no-headers -o custom-columns=:.metadata.name
+  args:
+    executable: /bin/bash
+  register: pool_pods
+  with_items:
+    - "{{ pools.results }}"
+
+- name: Checking if the snapshot is deleted in all the pool pods.
+  shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -c cstor-pool -- zfs list -t snapshot
+  args:
+    executable: /bin/bash
+  register: snap
+  failed_when: "uid_snapshot in snap.stdout"
+  with_items:
+    - "{{ pool_pods.results }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Included cstor csi snapshot and clone deletion litmusbook as an util
**Special notes for your reviewer**:
logs for csi_snapshot_deletion
```
PLAY [localhost] ***************************************************************
2019-11-25T11:42:15.044119 (delta: 0.071084)         elapsed: 0.071084 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:1
2019-11-25T11:42:15.060971 (delta: 0.016783)         elapsed: 0.087936 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:12
2019-11-25T11:42:17.442665 (delta: 2.381656)         elapsed: 2.46963 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-25T11:42:17.533822 (delta: 0.09111)         elapsed: 2.560787 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-25T11:42:17.594335 (delta: 0.060466)         elapsed: 2.6213 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:15
2019-11-25T11:42:17.655659 (delta: 0.061262)         elapsed: 2.682624 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-25T11:42:17.760179 (delta: 0.104471)         elapsed: 2.787144 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "38905ed675e1acbe09ef09ebbd828cd4ed76543c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "676606b46d0b402569366f6b1102f1e3", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1574682137.83-265254113756603/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-25T11:42:18.510147 (delta: 0.749922)         elapsed: 3.537112 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.143831", "end": "2019-11-25 11:42:19.009519", "rc": 0, "start": "2019-11-25 11:42:18.865688", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-25T11:42:19.074127 (delta: 0.563919)         elapsed: 4.101092 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-25T08:17:44Z", "generation": 31, "name": "cstor-csi-snapshot", "resourceVersion": "771371", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-snapshot", "uid": "3ee21e31-4023-4a39-b7c6-32ddf0cc91e7"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-25T11:42:20.411219 (delta: 1.337034)         elapsed: 5.438184 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-25T11:42:20.474502 (delta: 0.063227)         elapsed: 5.501467 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-25T11:42:20.536718 (delta: 0.062169)         elapsed: 5.563683 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application pod name] ********************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:19
2019-11-25T11:42:20.597299 (delta: 0.060529)         elapsed: 5.624264 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n sam --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.434668", "end": "2019-11-25 11:42:21.245146", "rc": 0, "start": "2019-11-25 11:42:20.810478", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-76d469c9dc-8gpsp", "stdout_lines": ["app-busybox-76d469c9dc-8gpsp"]}

TASK [Check if the application pod is in running state] ************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:26
2019-11-25T11:42:21.307840 (delta: 0.710489)         elapsed: 6.334805 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.336326", "end": "2019-11-25 11:42:21.876506", "failed_when_result": false, "rc": 0, "start": "2019-11-25 11:42:21.540180", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Create some test data] ***************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:34
2019-11-25T11:42:21.957870 (delta: 0.649981)         elapsed: 6.984835 ******** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2019-11-25T11:42:22.110060 (delta: 0.152138)         elapsed: 7.137025 ******** 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-76d469c9dc-8gpsp -n sam -- sh -c \"dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024\"", "delta": "0:00:00.775085", "end": "2019-11-25 11:42:23.104353", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/difiletest bs=4k count=1024", "rc": 0, "start": "2019-11-25 11:42:22.329268", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.036062 seconds, 110.9MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.036062 seconds, 110.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-76d469c9dc-8gpsp -n sam -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5\"", "delta": "0:00:00.667241", "end": "2019-11-25 11:42:23.998267", "failed_when_result": false, "item": "md5sum /busybox/difiletest > /busybox/difiletest-pre-chaos-md5", "rc": 0, "start": "2019-11-25 11:42:23.331026", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:20
2019-11-25T11:42:24.067646 (delta: 1.957508)         elapsed: 9.094611 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the applicaion pod is deleted] *********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:26
2019-11-25T11:42:24.124585 (delta: 0.056885)         elapsed: 9.15155 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:36
2019-11-25T11:42:24.184980 (delta: 0.060341)         elapsed: 9.211945 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:43
2019-11-25T11:42:24.245002 (delta: 0.059971)         elapsed: 9.271967 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:50
2019-11-25T11:42:24.306949 (delta: 0.061897)         elapsed: 9.333914 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:60
2019-11-25T11:42:24.364929 (delta: 0.057931)         elapsed: 9.391894 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:69
2019-11-25T11:42:24.424715 (delta: 0.059739)         elapsed: 9.45168 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for applicaion] ******************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:82
2019-11-25T11:42:24.490136 (delta: 0.065377)         elapsed: 9.517101 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:89
2019-11-25T11:42:24.550086 (delta: 0.059898)         elapsed: 9.577051 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:97
2019-11-25T11:42:24.611064 (delta: 0.06091)         elapsed: 9.638029 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [generating yaml file for snapshot] ***************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:42
2019-11-25T11:42:24.667713 (delta: 0.056579)         elapsed: 9.694678 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8f735609ddbaf82668115f988eabb467bacbf705", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "143d3fff28e4099bd9519099a1a868b0", "mode": "0644", "owner": "root", "size": 196, "src": "/root/.ansible/tmp/ansible-tmp-1574682144.71-152292166509107/source", "state": "file", "uid": 0}

TASK [create snapshot] *********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:47
2019-11-25T11:42:25.172840 (delta: 0.50508)         elapsed: 10.199805 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f snapshot.yml -n \"sam\"", "delta": "0:00:00.687796", "end": "2019-11-25 11:42:26.069986", "failed_when_result": false, "rc": 0, "start": "2019-11-25 11:42:25.382190", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.snapshot.storage.k8s.io/csi-snap1 created", "stdout_lines": ["volumesnapshot.snapshot.storage.k8s.io/csi-snap1 created"]}

TASK [Get the uid of the snapshot taken] ***************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:56
2019-11-25T11:42:26.153072 (delta: 0.980156)         elapsed: 11.180037 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot.snapshot csi-snap1 -n sam --no-headers -o custom-columns=:.metadata.uid", "delta": "0:00:00.296714", "end": "2019-11-25 11:42:26.702672", "rc": 0, "start": "2019-11-25 11:42:26.405958", "stderr": "", "stderr_lines": [], "stdout": "8a11ebd0-517e-4a93-82b6-7cee08d919d7", "stdout_lines": ["8a11ebd0-517e-4a93-82b6-7cee08d919d7"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:64
2019-11-25T11:42:26.763251 (delta: 0.610103)         elapsed: 11.790216 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"volume_snapshot": "8a11ebd0-517e-4a93-82b6-7cee08d919d7"}, "changed": false}

TASK [Derive PV name from PVC] *************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:67
2019-11-25T11:42:26.852237 (delta: 0.088938)         elapsed: 11.879202 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi-vol -n sam --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.305510", "end": "2019-11-25 11:42:27.359441", "rc": 0, "start": "2019-11-25 11:42:27.053931", "stderr": "", "stderr_lines": [], "stdout": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715", "stdout_lines": ["pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715"]}

TASK [Obtaining the CVR from PV] ***********************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:75
2019-11-25T11:42:27.457665 (delta: 0.605374)         elapsed: 12.48463 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715 --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.299706", "end": "2019-11-25 11:42:27.980215", "rc": 0, "start": "2019-11-25 11:42:27.680509", "stderr": "", "stderr_lines": [], "stdout": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4\npvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w\npvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "stdout_lines": ["pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9"]}

TASK [Obtaining the pools where CVRs are mounted] ******************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:83
2019-11-25T11:42:28.043158 (delta: 0.585439)         elapsed: 13.070123 ******* 
changed: [127.0.0.1] => (item=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4) => {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.295237", "end": "2019-11-25 11:42:28.534360", "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "rc": 0, "start": "2019-11-25 11:42:28.239123", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4", "stdout_lines": ["cstor-cspc-disk-pool-46n4"]}
changed: [127.0.0.1] => (item=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w) => {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.345217", "end": "2019-11-25 11:42:29.065778", "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "rc": 0, "start": "2019-11-25 11:42:28.720561", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w", "stdout_lines": ["cstor-cspc-disk-pool-np9w"]}
changed: [127.0.0.1] => (item=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9) => {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.299393", "end": "2019-11-25 11:42:30.536085", "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "rc": 0, "start": "2019-11-25 11:42:29.236692", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9", "stdout_lines": ["cstor-cspc-disk-pool-v2d9"]}

TASK [Obtaining the pool pods] *************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:93
2019-11-25T11:42:30.602434 (delta: 2.559223)         elapsed: 15.629399 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-46n4', '_ansible_item_result': True, u'delta': u'0:00:00.295237', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'end': u'2019-11-25 11:42:28.534360', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:28.239123', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.319696", "end": "2019-11-25 11:42:31.142517", "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.295237", "end": "2019-11-25 11:42:28.534360", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "rc": 0, "start": "2019-11-25 11:42:28.239123", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4", "stdout_lines": ["cstor-cspc-disk-pool-46n4"]}, "rc": 0, "start": "2019-11-25 11:42:30.822821", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl", "stdout_lines": ["cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-np9w', '_ansible_item_result': True, u'delta': u'0:00:00.345217', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'end': u'2019-11-25 11:42:29.065778', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:28.720561', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.325764", "end": "2019-11-25 11:42:31.657722", "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.345217", "end": "2019-11-25 11:42:29.065778", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "rc": 0, "start": "2019-11-25 11:42:28.720561", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w", "stdout_lines": ["cstor-cspc-disk-pool-np9w"]}, "rc": 0, "start": "2019-11-25 11:42:31.331958", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w-7584db96f-g7kjh", "stdout_lines": ["cstor-cspc-disk-pool-np9w-7584db96f-g7kjh"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-v2d9', '_ansible_item_result': True, u'delta': u'0:00:01.299393', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'end': u'2019-11-25 11:42:30.536085', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:29.236692', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.307234", "end": "2019-11-25 11:42:32.150154", "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.299393", "end": "2019-11-25 11:42:30.536085", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "rc": 0, "start": "2019-11-25 11:42:29.236692", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9", "stdout_lines": ["cstor-cspc-disk-pool-v2d9"]}, "rc": 0, "start": "2019-11-25 11:42:31.842920", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn", "stdout_lines": ["cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn"]}

TASK [Checking if the snapshot is created in all the pool pods.] ***************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:103
2019-11-25T11:42:32.219225 (delta: 1.616735)         elapsed: 17.24619 ******** 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl', '_ansible_item_result': True, u'delta': u'0:00:00.319696', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-46n4', '_ansible_item_result': True, u'delta': u'0:00:00.295237', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'end': u'2019-11-25 11:42:28.534360', '_ansible_no_log': False, u'start': u'2019-11-25 11:42:28.239123', u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'failed': False, 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-11-25 11:42:31.142517', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-46n4', '_ansible_item_result': True, u'delta': u'0:00:00.295237', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'end': u'2019-11-25 11:42:28.534360', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'start': u'2019-11-25 11:42:28.239123', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:30.822821', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl -n openebs -c cstor-pool -- zfs list -t snapshot", "delta": "0:00:00.824540", "end": "2019-11-25 11:42:33.255967", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.319696", "end": "2019-11-25 11:42:31.142517", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.295237", "end": "2019-11-25 11:42:28.534360", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "rc": 0, "start": "2019-11-25 11:42:28.239123", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4", "stdout_lines": ["cstor-cspc-disk-pool-46n4"]}, "rc": 0, "start": "2019-11-25 11:42:30.822821", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl", "stdout_lines": ["cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl"]}, "rc": 0, "start": "2019-11-25 11:42:32.431427", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730  29.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945    49K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188  49.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052    30K      -  8.16M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360  49.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212  89.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631  6.50K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633  6.50K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937  70.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682146  6.50K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147     6K      -  12.2M  -", "stdout_lines": ["NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730  29.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945    49K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188  49.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052    30K      -  8.16M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360  49.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212  89.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631  6.50K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633  6.50K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937  70.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682146  6.50K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147     6K      -  12.2M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-np9w-7584db96f-g7kjh', '_ansible_item_result': True, u'delta': u'0:00:00.325764', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w-7584db96f-g7kjh'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-np9w', '_ansible_item_result': True, u'delta': u'0:00:00.345217', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'end': u'2019-11-25 11:42:29.065778', '_ansible_no_log': False, u'start': u'2019-11-25 11:42:28.720561', u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'failed': False, 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-11-25 11:42:31.657722', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-np9w', '_ansible_item_result': True, u'delta': u'0:00:00.345217', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'end': u'2019-11-25 11:42:29.065778', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'start': u'2019-11-25 11:42:28.720561', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:31.331958', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-cspc-disk-pool-np9w-7584db96f-g7kjh -n openebs -c cstor-pool -- zfs list -t snapshot", "delta": "0:00:00.769514", "end": "2019-11-25 11:42:34.224296", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.325764", "end": "2019-11-25 11:42:31.657722", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.345217", "end": "2019-11-25 11:42:29.065778", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "rc": 0, "start": "2019-11-25 11:42:28.720561", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w", "stdout_lines": ["cstor-cspc-disk-pool-np9w"]}, "rc": 0, "start": "2019-11-25 11:42:31.331958", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w-7584db96f-g7kjh", "stdout_lines": ["cstor-cspc-disk-pool-np9w-7584db96f-g7kjh"]}, "rc": 0, "start": "2019-11-25 11:42:33.454782", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682146     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147     6K      -  12.2M  -", "stdout_lines": ["NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682146     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147     6K      -  12.2M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn', '_ansible_item_result': True, u'delta': u'0:00:00.307234', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-v2d9', '_ansible_item_result': True, u'delta': u'0:00:01.299393', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'end': u'2019-11-25 11:42:30.536085', '_ansible_no_log': False, u'start': u'2019-11-25 11:42:29.236692', u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'failed': False, 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-11-25 11:42:32.150154', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-v2d9', '_ansible_item_result': True, u'delta': u'0:00:01.299393', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'end': u'2019-11-25 11:42:30.536085', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'start': u'2019-11-25 11:42:29.236692', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:31.842920', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn -n openebs -c cstor-pool -- zfs list -t snapshot", "delta": "0:00:00.772922", "end": "2019-11-25 11:42:35.209917", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.307234", "end": "2019-11-25 11:42:32.150154", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.299393", "end": "2019-11-25 11:42:30.536085", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "rc": 0, "start": "2019-11-25 11:42:29.236692", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9", "stdout_lines": ["cstor-cspc-disk-pool-v2d9"]}, "rc": 0, "start": "2019-11-25 11:42:31.842920", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn", "stdout_lines": ["cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn"]}, "rc": 0, "start": "2019-11-25 11:42:34.436995", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682146     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147     6K      -  12.2M  -", "stdout_lines": ["NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682146     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147     6K      -  12.2M  -"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:113
2019-11-25T11:42:35.300791 (delta: 3.081514)         elapsed: 20.327756 ******* 
included: /utils/scm/openebs/delete_cstor_csi_snapshot.yml for 127.0.0.1

TASK [Obtain the SnapshotContent of the snapshot] ******************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:4
2019-11-25T11:42:35.433657 (delta: 0.132818)         elapsed: 20.460622 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot.snapshot csi-snap1 -n sam --no-headers -o custom-columns=:.spec.snapshotContentName", "delta": "0:00:00.299720", "end": "2019-11-25 11:42:36.032602", "rc": 0, "start": "2019-11-25 11:42:35.732882", "stderr": "", "stderr_lines": [], "stdout": "snapcontent-8a11ebd0-517e-4a93-82b6-7cee08d919d7", "stdout_lines": ["snapcontent-8a11ebd0-517e-4a93-82b6-7cee08d919d7"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:12
2019-11-25T11:42:36.093081 (delta: 0.659368)         elapsed: 21.120046 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"snapshotcontent": "snapcontent-8a11ebd0-517e-4a93-82b6-7cee08d919d7"}, "changed": false}

TASK [Get the uid of the snapshot taken] ***************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:15
2019-11-25T11:42:36.196929 (delta: 0.10378)         elapsed: 21.223894 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot.snapshot csi-snap1 -n sam --no-headers -o custom-columns=:.metadata.uid", "delta": "0:00:00.298811", "end": "2019-11-25 11:42:36.713937", "rc": 0, "start": "2019-11-25 11:42:36.415126", "stderr": "", "stderr_lines": [], "stdout": "8a11ebd0-517e-4a93-82b6-7cee08d919d7", "stdout_lines": ["8a11ebd0-517e-4a93-82b6-7cee08d919d7"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:23
2019-11-25T11:42:36.793356 (delta: 0.596376)         elapsed: 21.820321 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"uid_snapshot": "8a11ebd0-517e-4a93-82b6-7cee08d919d7"}, "changed": false}

TASK [Delete the snapshot created] *********************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:26
2019-11-25T11:42:36.884725 (delta: 0.091304)         elapsed: 21.91169 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete volumesnapshot.snapshot csi-snap1 -n sam", "delta": "0:00:00.305891", "end": "2019-11-25 11:42:37.393795", "failed_when_result": false, "rc": 0, "start": "2019-11-25 11:42:37.087904", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.snapshot.storage.k8s.io \"csi-snap1\" deleted", "stdout_lines": ["volumesnapshot.snapshot.storage.k8s.io \"csi-snap1\" deleted"]}

TASK [Verify if the snapshot is deleted] ***************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:35
2019-11-25T11:42:37.462625 (delta: 0.577846)         elapsed: 22.48959 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot.snapshot -n sam", "delta": "0:00:00.302166", "end": "2019-11-25 11:42:37.964726", "failed_when_result": false, "rc": 0, "start": "2019-11-25 11:42:37.662560", "stderr": "", "stderr_lines": [], "stdout": "NAME       AGE\ncsi-snap   42m", "stdout_lines": ["NAME       AGE", "csi-snap   42m"]}

TASK [Verify if the volumesnapshotcontent is deleted] **************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:44
2019-11-25T11:42:38.033149 (delta: 0.570476)         elapsed: 23.060114 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshotcontent -n sam", "delta": "0:00:00.299706", "end": "2019-11-25 11:42:38.527428", "failed_when_result": false, "rc": 0, "start": "2019-11-25 11:42:38.227722", "stderr": "", "stderr_lines": [], "stdout": "NAME                                               AGE\nsnapcontent-0d6691cf-b5e6-4542-9410-9d48e55a30e9   42m", "stdout_lines": ["NAME                                               AGE", "snapcontent-0d6691cf-b5e6-4542-9410-9d48e55a30e9   42m"]}

TASK [Derive PV name from PVC] *************************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:55
2019-11-25T11:42:38.590573 (delta: 0.557373)         elapsed: 23.617538 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi-vol -n sam --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.292044", "end": "2019-11-25 11:42:39.090304", "rc": 0, "start": "2019-11-25 11:42:38.798260", "stderr": "", "stderr_lines": [], "stdout": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715", "stdout_lines": ["pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715"]}

TASK [Obtaining the CVR from PV] ***********************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:63
2019-11-25T11:42:39.171729 (delta: 0.581101)         elapsed: 24.198694 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715 --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.320774", "end": "2019-11-25 11:42:39.694611", "rc": 0, "start": "2019-11-25 11:42:39.373837", "stderr": "", "stderr_lines": [], "stdout": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4\npvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w\npvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "stdout_lines": ["pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9"]}

TASK [Obtaining the pools where CVRs are mounted] ******************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:71
2019-11-25T11:42:39.759417 (delta: 0.587623)         elapsed: 24.786382 ******* 
changed: [127.0.0.1] => (item=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4) => {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.347002", "end": "2019-11-25 11:42:41.320180", "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "rc": 0, "start": "2019-11-25 11:42:39.973178", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4", "stdout_lines": ["cstor-cspc-disk-pool-46n4"]}
changed: [127.0.0.1] => (item=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w) => {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.324094", "end": "2019-11-25 11:42:41.835059", "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "rc": 0, "start": "2019-11-25 11:42:41.510965", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w", "stdout_lines": ["cstor-cspc-disk-pool-np9w"]}
changed: [127.0.0.1] => (item=pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9) => {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.291729", "end": "2019-11-25 11:42:43.328296", "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "rc": 0, "start": "2019-11-25 11:42:42.036567", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9", "stdout_lines": ["cstor-cspc-disk-pool-v2d9"]}

TASK [Obtaining the pool pods] *************************************************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:81
2019-11-25T11:42:43.402702 (delta: 3.643234)         elapsed: 28.429667 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-46n4', '_ansible_item_result': True, u'delta': u'0:00:01.347002', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'end': u'2019-11-25 11:42:41.320180', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:39.973178', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.306765", "end": "2019-11-25 11:42:43.928489", "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.347002", "end": "2019-11-25 11:42:41.320180", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "rc": 0, "start": "2019-11-25 11:42:39.973178", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4", "stdout_lines": ["cstor-cspc-disk-pool-46n4"]}, "rc": 0, "start": "2019-11-25 11:42:43.621724", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl", "stdout_lines": ["cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-np9w', '_ansible_item_result': True, u'delta': u'0:00:00.324094', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'end': u'2019-11-25 11:42:41.835059', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:41.510965', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.298525", "end": "2019-11-25 11:42:44.422070", "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.324094", "end": "2019-11-25 11:42:41.835059", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "rc": 0, "start": "2019-11-25 11:42:41.510965", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w", "stdout_lines": ["cstor-cspc-disk-pool-np9w"]}, "rc": 0, "start": "2019-11-25 11:42:44.123545", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w-7584db96f-g7kjh", "stdout_lines": ["cstor-cspc-disk-pool-np9w-7584db96f-g7kjh"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-v2d9', '_ansible_item_result': True, u'delta': u'0:00:01.291729', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'end': u'2019-11-25 11:42:43.328296', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:42.036567', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.319099", "end": "2019-11-25 11:42:44.925895", "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.291729", "end": "2019-11-25 11:42:43.328296", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "rc": 0, "start": "2019-11-25 11:42:42.036567", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9", "stdout_lines": ["cstor-cspc-disk-pool-v2d9"]}, "rc": 0, "start": "2019-11-25 11:42:44.606796", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn", "stdout_lines": ["cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn"]}

TASK [Checking if the snapshot is deleted in all the pool pods.] ***************
task path: /utils/scm/openebs/delete_cstor_csi_snapshot.yml:91
2019-11-25T11:42:45.001840 (delta: 1.599074)         elapsed: 30.028805 ******* 
failed: [127.0.0.1] (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl', '_ansible_item_result': True, u'delta': u'0:00:00.306765', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-46n4', '_ansible_item_result': True, u'delta': u'0:00:01.347002', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'end': u'2019-11-25 11:42:41.320180', '_ansible_no_log': False, u'start': u'2019-11-25 11:42:39.973178', u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'failed': False, 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-11-25 11:42:43.928489', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-46n4', '_ansible_item_result': True, u'delta': u'0:00:01.347002', 'stdout_lines': [u'cstor-cspc-disk-pool-46n4'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'end': u'2019-11-25 11:42:41.320180', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'start': u'2019-11-25 11:42:39.973178', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:43.621724', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl -n openebs -c cstor-pool -- zfs list -t snapshot", "delta": "0:00:00.752248", "end": "2019-11-25 11:42:45.992787", "failed_when_result": true, "item": {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.306765", "end": "2019-11-25 11:42:43.928489", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-46n4 --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.347002", "end": "2019-11-25 11:42:41.320180", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-46n4", "rc": 0, "start": "2019-11-25 11:42:39.973178", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4", "stdout_lines": ["cstor-cspc-disk-pool-46n4"]}, "rc": 0, "start": "2019-11-25 11:42:43.621724", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl", "stdout_lines": ["cstor-cspc-disk-pool-46n4-568dd865b8-qvzxl"]}, "rc": 0, "start": "2019-11-25 11:42:45.240539", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730  29.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945    49K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188  49.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052    30K      -  8.16M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360  49.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212  89.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631  6.50K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633  6.50K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937  70.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147  15.5K      -  12.2M  -", "stdout_lines": ["NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730  29.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945    49K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188  49.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052    30K      -  8.16M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360  49.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212  89.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631  6.50K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633  6.50K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937  70.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147  15.5K      -  12.2M  -"]}
failed: [127.0.0.1] (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-np9w-7584db96f-g7kjh', '_ansible_item_result': True, u'delta': u'0:00:00.298525', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w-7584db96f-g7kjh'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-np9w', '_ansible_item_result': True, u'delta': u'0:00:00.324094', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'end': u'2019-11-25 11:42:41.835059', '_ansible_no_log': False, u'start': u'2019-11-25 11:42:41.510965', u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'failed': False, 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-11-25 11:42:44.422070', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-np9w', '_ansible_item_result': True, u'delta': u'0:00:00.324094', 'stdout_lines': [u'cstor-cspc-disk-pool-np9w'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'end': u'2019-11-25 11:42:41.835059', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'start': u'2019-11-25 11:42:41.510965', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:44.123545', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-cspc-disk-pool-np9w-7584db96f-g7kjh -n openebs -c cstor-pool -- zfs list -t snapshot", "delta": "0:00:00.715877", "end": "2019-11-25 11:42:46.917345", "failed_when_result": true, "item": {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.298525", "end": "2019-11-25 11:42:44.422070", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-np9w --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:00.324094", "end": "2019-11-25 11:42:41.835059", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-np9w", "rc": 0, "start": "2019-11-25 11:42:41.510965", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w", "stdout_lines": ["cstor-cspc-disk-pool-np9w"]}, "rc": 0, "start": "2019-11-25 11:42:44.123545", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-np9w-7584db96f-g7kjh", "stdout_lines": ["cstor-cspc-disk-pool-np9w-7584db96f-g7kjh"]}, "rc": 0, "start": "2019-11-25 11:42:46.201468", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147  15.5K      -  12.2M  -", "stdout_lines": ["NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147  15.5K      -  12.2M  -"]}
failed: [127.0.0.1] (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn', '_ansible_item_result': True, u'delta': u'0:00:00.319099', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-v2d9', '_ansible_item_result': True, u'delta': u'0:00:01.291729', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'end': u'2019-11-25 11:42:43.328296', '_ansible_no_log': False, u'start': u'2019-11-25 11:42:42.036567', u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', 'failed': False, 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-11-25 11:42:44.925895', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-cspc-disk-pool-v2d9', '_ansible_item_result': True, u'delta': u'0:00:01.291729', 'stdout_lines': [u'cstor-cspc-disk-pool-v2d9'], '_ansible_item_label': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'end': u'2019-11-25 11:42:43.328296', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'start': u'2019-11-25 11:42:42.036567', 'item': u'pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath=\'{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{"\\n"}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-11-25 11:42:44.606796', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn -n openebs -c cstor-pool -- zfs list -t snapshot", "delta": "0:00:00.710813", "end": "2019-11-25 11:42:47.842933", "failed_when_result": true, "item": {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.319099", "end": "2019-11-25 11:42:44.925895", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-v2d9 --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "delta": "0:00:01.291729", "end": "2019-11-25 11:42:43.328296", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get cvr pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9 -n openebs --no-headers -o jsonpath='{.metadata.labels.cstorpoolinstance\\.openebs\\.io/name}{\"\\n\"}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715-cstor-cspc-disk-pool-v2d9", "rc": 0, "start": "2019-11-25 11:42:42.036567", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9", "stdout_lines": ["cstor-cspc-disk-pool-v2d9"]}, "rc": 0, "start": "2019-11-25 11:42:44.606796", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn", "stdout_lines": ["cstor-cspc-disk-pool-v2d9-795f9c49c4-9x9gn"]}, "rc": 0, "start": "2019-11-25 11:42:47.132120", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -\ncstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147  15.5K      -  12.2M  -", "stdout_lines": ["NAME                                                                                                                                           USED  AVAIL  REFER  MOUNTPOINT", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-724b93ee-8348-4c9b-875a-fe56216885a4-1574666706  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-ced5e2d7-6783-49e1-8ff9-214ca9392a02-1574668216  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-3bb4cfa8-96e0-43e4-b7be-e87db7ea3b8b-1574669871  6.50K      -    64K  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8680c1bd-33d6-48cf-8ab1-46014688cdcc-1574670533  4.07M      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6b42379d-fbe5-409b-b26b-6f48f1076907-1574670730    29K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1664ab79-e573-420d-b696-fa2ec9acd9af-1574670945  48.5K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1d5683fb-a760-4bff-8e61-44450d50923f-1574671188    49K      -  8.15M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-784e55c9-f1ed-4de5-b6f7-2b0e2105ab71-1574677052  29.5K      -  8.16M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-bc16b208-9485-452f-8372-94eb8817d072-1574678360    49K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-7938f41c-649d-42ca-a99d-70ded803f5e7-1574678674  69.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-028baa98-d239-4f8d-8dc2-1dd4ebb9b388-1574678954  68.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-98714c82-131d-40e4-bad1-20de146ff99a-1574679212    89K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679631     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d6691cf-b5e6-4542-9410-9d48e55a30e9-1574679633     6K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-1eb71a1a-8adc-44c7-befd-684782bd0fb4-1574680196    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-0d922d8f-d348-4fc7-b39b-fce598a54a4a-1574681336    69K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-f35fa193-5f94-419a-9d07-d0382a3760a0-1574681575  90.5K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-6d5a1a4b-b7ef-4cdb-ac71-87daf5efa464-1574681937    70K      -  12.2M  -", "cstor-eab98434-feb2-4d3d-8dbf-845bd0585aa1/pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715@snapshot-8a11ebd0-517e-4a93-82b6-7cee08d919d7-1574682147  15.5K      -  12.2M  -"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:119
2019-11-25T11:42:47.932726 (delta: 2.930831)         elapsed: 32.959691 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-snapshot/test.yml:124
2019-11-25T11:42:48.026533 (delta: 0.09376)         elapsed: 33.053498 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-25T11:42:48.139220 (delta: 0.112636)         elapsed: 33.166185 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-25T11:42:48.198062 (delta: 0.058793)         elapsed: 33.225027 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-25T11:42:48.257659 (delta: 0.059529)         elapsed: 33.284624 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-25T11:42:48.324431 (delta: 0.06672)         elapsed: 33.351396 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b2948e04499e893824661a5e5ca7676172a5af77", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f506fd138a2eb6e7e5261ac2c26d69e1", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1574682168.38-67615439022461/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-25T11:42:49.017743 (delta: 0.693261)         elapsed: 34.044708 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.147317", "end": "2019-11-25 11:42:49.362200", "rc": 0, "start": "2019-11-25 11:42:49.214883", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-25T11:42:49.430083 (delta: 0.412286)         elapsed: 34.457048 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-25T08:17:44Z", "generation": 32, "name": "cstor-csi-snapshot", "resourceVersion": "771514", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-snapshot", "uid": "3ee21e31-4023-4a39-b7c6-32ddf0cc91e7"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Fail"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=36   changed=26   unreachable=0    failed=1   

2019-11-25T11:42:50.499442 (delta: 1.069275)         elapsed: 35.526407 ******* 
=============================================================================== 
```

logs for csi_clone_deletion
```
PLAY [localhost] ***************************************************************
2019-11-26T06:35:15.838669 (delta: 0.076758)         elapsed: 0.076758 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:1
2019-11-26T06:35:15.852582 (delta: 0.013842)         elapsed: 0.090671 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:12
2019-11-26T06:35:18.291227 (delta: 2.438603)         elapsed: 2.529316 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-11-26T06:35:18.403555 (delta: 0.112269)         elapsed: 2.641644 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-11-26T06:35:18.474642 (delta: 0.071031)         elapsed: 2.712731 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:15
2019-11-26T06:35:18.549760 (delta: 0.075044)         elapsed: 2.787849 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-26T06:35:18.662300 (delta: 0.112487)         elapsed: 2.900389 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "00ecf3d3d3304a9e193474d3dfda7163aafefa41", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "88f24adaa51ab6501fc7e372c7089dbd", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1574750118.72-135189014551980/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-26T06:35:19.380248 (delta: 0.717892)         elapsed: 3.618337 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.148339", "end": "2019-11-26 06:35:19.958524", "rc": 0, "start": "2019-11-26 06:35:19.810185", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-26T06:35:20.043503 (delta: 0.663199)         elapsed: 4.281592 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-25T12:05:18Z", "generation": 16, "name": "cstor-csi-clone", "resourceVersion": "1073361", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-clone", "uid": "f9b74cd9-b29a-4d05-b41b-24f7aed952fb"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-26T06:35:21.368115 (delta: 1.324551)         elapsed: 5.606204 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-26T06:35:21.434673 (delta: 0.066486)         elapsed: 5.672762 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-26T06:35:21.501656 (delta: 0.06691)         elapsed: 5.739745 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the yaml file to clone the snapshot] ****************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:19
2019-11-26T06:35:21.566543 (delta: 0.064794)         elapsed: 5.804632 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e8a58af0c7b404b6e4f5574fa608447cc857ad78", "dest": "./clone.yml", "gid": 0, "group": "root", "md5sum": "4c332e4759c48a96541081bb2557416e", "mode": "0644", "owner": "root", "size": 288, "src": "/root/.ansible/tmp/ansible-tmp-1574750121.63-262585600396268/source", "state": "file", "uid": 0}

TASK [create the Clone] ********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:24
2019-11-26T06:35:22.059449 (delta: 0.492844)         elapsed: 6.297538 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f clone.yml -n sam", "delta": "0:00:00.775330", "end": "2019-11-26 06:35:23.040763", "failed_when_result": false, "rc": 0, "start": "2019-11-26 06:35:22.265433", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/csi-clone created", "stdout_lines": ["persistentvolumeclaim/csi-clone created"]}

TASK [Check if the pvc is bound] ***********************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:33
2019-11-26T06:35:23.113416 (delta: 1.053915)         elapsed: 7.351505 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc csi-clone -n sam --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.331458", "end": "2019-11-26 06:35:23.657764", "rc": 0, "start": "2019-11-26 06:35:23.326306", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [Generate the yaml file to deploy busybox] ********************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:44
2019-11-26T06:35:23.724651 (delta: 0.611169)         elapsed: 7.96274 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b6479ac4cb9da815819c57a61caf252c6975097a", "dest": "./busybox.yml", "gid": 0, "group": "root", "md5sum": "0a09caee907a089869e06abb2ac05c31", "mode": "0644", "owner": "root", "size": 647, "src": "/root/.ansible/tmp/ansible-tmp-1574750123.78-7333770096531/source", "state": "file", "uid": 0}

TASK [Deploying the busybox app] ***********************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:50
2019-11-26T06:35:24.131949 (delta: 0.407222)         elapsed: 8.370038 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f busybox.yml -n sam", "delta": "0:00:00.483919", "end": "2019-11-26 06:35:24.822154", "rc": 0, "start": "2019-11-26 06:35:24.338235", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/busyboxclone created", "stdout_lines": ["deployment.apps/busyboxclone created"]}

TASK [Get the app pod name] ****************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:56
2019-11-26T06:35:24.889209 (delta: 0.757206)         elapsed: 9.127298 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l app=busybox-cloned --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.299195", "end": "2019-11-26 06:35:25.399158", "rc": 0, "start": "2019-11-26 06:35:25.099963", "stderr": "", "stderr_lines": [], "stdout": "busyboxclone-74f6dfb5bd-w76sc", "stdout_lines": ["busyboxclone-74f6dfb5bd-w76sc"]}

TASK [Verify if the app is in Running state] ***********************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:64
2019-11-26T06:35:25.465898 (delta: 0.576636)         elapsed: 9.703987 ******** 
FAILED - RETRYING: Verify if the app is in Running state (15 retries left).
FAILED - RETRYING: Verify if the app is in Running state (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get po -n sam -l app=busybox-cloned --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.278614", "end": "2019-11-26 06:36:27.052869", "rc": 0, "start": "2019-11-26 06:36:26.774255", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:76
2019-11-26T06:36:27.124018 (delta: 61.658065)         elapsed: 71.362107 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busyboxclone-74f6dfb5bd-w76sc -n sam -- sh -c \"md5sum /busybox/difiletest > /busybox/difiletest-post-clone-md5\"", "delta": "0:00:00.676027", "end": "2019-11-26 06:36:28.005315", "failed_when_result": false, "rc": 0, "start": "2019-11-26 06:36:27.329288", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:85
2019-11-26T06:36:28.087031 (delta: 0.962955)         elapsed: 72.32512 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busyboxclone-74f6dfb5bd-w76sc -n sam -- sh -c \"diff /busybox/difiletest-pre-chaos-md5 /busybox/difiletest-post-clone-md5\"", "delta": "0:00:00.646922", "end": "2019-11-26 06:36:28.983910", "failed_when_result": false, "rc": 0, "start": "2019-11-26 06:36:28.336988", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:95
2019-11-26T06:36:29.051045 (delta: 0.963954)         elapsed: 73.289134 ******* 
included: /utils/scm/openebs/delete_cstor_csi_clone.yml for 127.0.0.1

TASK [delete pvc from which snapshot is created] *******************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:4
2019-11-26T06:36:29.183097 (delta: 0.131983)         elapsed: 73.421186 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc csi-vol -n sam", "delta": "0:00:00.331583", "end": "2019-11-26 06:36:29.718303", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2019-11-26 06:36:29.386720", "stderr": "Error from server (PVC with cloned volumes can't be deleted): admission webhook \"admission-webhook.openebs.io\" denied the request: pvc \"csi-vol\" has '1' cloned volume(s)", "stderr_lines": ["Error from server (PVC with cloned volumes can't be deleted): admission webhook \"admission-webhook.openebs.io\" denied the request: pvc \"csi-vol\" has '1' cloned volume(s)"], "stdout": "", "stdout_lines": []}

TASK [Derive PV name from PVC] *************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:22
2019-11-26T06:36:29.790479 (delta: 0.607327)         elapsed: 74.028568 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi-clone -n sam --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.339376", "end": "2019-11-26 06:36:30.368765", "rc": 0, "start": "2019-11-26 06:36:30.029389", "stderr": "", "stderr_lines": [], "stdout": "pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c", "stdout_lines": ["pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:30
2019-11-26T06:36:30.451128 (delta: 0.66059)         elapsed: 74.689217 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"cloned_pv_name": "pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c"}, "changed": false}

TASK [Obtaining the CVR from PV] ***********************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:33
2019-11-26T06:36:30.547061 (delta: 0.09586)         elapsed: 74.78515 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.297984", "end": "2019-11-26 06:36:31.043373", "rc": 0, "start": "2019-11-26 06:36:30.745389", "stderr": "", "stderr_lines": [], "stdout": "pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-46n4\npvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-np9w\npvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-v2d9", "stdout_lines": ["pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-46n4", "pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-np9w", "pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-v2d9"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:41
2019-11-26T06:36:31.108952 (delta: 0.561835)         elapsed: 75.347041 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cloned_cvr_name": "pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-46n4\npvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-np9w\npvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c-cstor-cspc-disk-pool-v2d9"}, "changed": false}

TASK [Get the app pod name] ****************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:45
2019-11-26T06:36:31.194008 (delta: 0.085004)         elapsed: 75.432097 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l app=busybox-cloned --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.298953", "end": "2019-11-26 06:36:32.679359", "rc": 0, "start": "2019-11-26 06:36:31.380406", "stderr": "", "stderr_lines": [], "stdout": "busyboxclone-74f6dfb5bd-w76sc", "stdout_lines": ["busyboxclone-74f6dfb5bd-w76sc"]}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:53
2019-11-26T06:36:32.742958 (delta: 1.548888)         elapsed: 76.981047 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"application_podname": "busyboxclone-74f6dfb5bd-w76sc"}, "changed": false}

TASK [delete the busybox_app] **************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:57
2019-11-26T06:36:32.848271 (delta: 0.105239)         elapsed: 77.08636 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete deploy busyboxclone -n sam", "delta": "0:00:00.334703", "end": "2019-11-26 06:36:33.430568", "failed_when_result": false, "rc": 0, "start": "2019-11-26 06:36:33.095865", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions \"busyboxclone\" deleted", "stdout_lines": ["deployment.extensions \"busyboxclone\" deleted"]}

TASK [Check if the pod is deleted successfully] ********************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:66
2019-11-26T06:36:33.520383 (delta: 0.672047)         elapsed: 77.758472 ******* 
FAILED - RETRYING: Check if the pod is deleted successfully (15 retries left).
FAILED - RETRYING: Check if the pod is deleted successfully (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get po -n sam", "delta": "0:00:00.295012", "end": "2019-11-26 06:37:36.010872", "rc": 0, "start": "2019-11-26 06:37:35.715860", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS    RESTARTS   AGE\napp-busybox-76d469c9dc-8gpsp   1/1     Running   0          23h", "stdout_lines": ["NAME                           READY   STATUS    RESTARTS   AGE", "app-busybox-76d469c9dc-8gpsp   1/1     Running   0          23h"]}

TASK [delete the cloned pvc] ***************************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:77
2019-11-26T06:37:36.100330 (delta: 62.57987)         elapsed: 140.338419 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc csi-clone -n sam", "delta": "0:00:00.382994", "end": "2019-11-26 06:37:36.708363", "failed_when_result": false, "rc": 0, "start": "2019-11-26 06:37:36.325369", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"csi-clone\" deleted", "stdout_lines": ["persistentvolumeclaim \"csi-clone\" deleted"]}

TASK [try to obtain the cloned pvc] ********************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:86
2019-11-26T06:37:36.786953 (delta: 0.686555)         elapsed: 141.025042 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n sam", "delta": "0:00:00.289205", "end": "2019-11-26 06:37:37.308423", "rc": 0, "start": "2019-11-26 06:37:37.019218", "stderr": "", "stderr_lines": [], "stdout": "NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE\ncsi-vol   Bound    pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715   5Gi        RWO            csi-sc         23h", "stdout_lines": ["NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE", "csi-vol   Bound    pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715   5Gi        RWO            csi-sc         23h"]}

TASK [try to obtain the pv for cloned pvc] *************************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:97
2019-11-26T06:37:37.380754 (delta: 0.593726)         elapsed: 141.618843 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n sam", "delta": "0:00:01.292413", "end": "2019-11-26 06:37:38.940361", "failed_when_result": false, "rc": 0, "start": "2019-11-26 06:37:37.647948", "stderr": "", "stderr_lines": [], "stdout": "NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE\ncsi-vol   Bound    pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715   5Gi        RWO            csi-sc         23h", "stdout_lines": ["NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE", "csi-vol   Bound    pvc-1931c9d1-3f66-4893-bbdc-4aa68ec93715   5Gi        RWO            csi-sc         23h"]}

TASK [try to obtain the cvrs for cloned pvc] ***********************************
task path: /utils/scm/openebs/delete_cstor_csi_clone.yml:106
2019-11-26T06:37:39.018161 (delta: 1.637339)         elapsed: 143.25625 ******* 
FAILED - RETRYING: try to obtain the cvrs for cloned pvc (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-bf55fd7e-c2b6-46cb-ae71-1521cee6e52c --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.387591", "end": "2019-11-26 06:38:10.160049", "rc": 0, "start": "2019-11-26 06:38:09.772458", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:97
2019-11-26T06:38:10.244604 (delta: 31.226375)         elapsed: 174.482693 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cstor-csi/csi-clone/test.yml:106
2019-11-26T06:38:10.352730 (delta: 0.108031)         elapsed: 174.590819 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-11-26T06:38:10.480087 (delta: 0.127281)         elapsed: 174.718176 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-11-26T06:38:10.545104 (delta: 0.064944)         elapsed: 174.783193 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-11-26T06:38:10.610187 (delta: 0.065023)         elapsed: 174.848276 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-11-26T06:38:10.671025 (delta: 0.060778)         elapsed: 174.909114 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "9e74fbdeda5645715f05a69707cacb121dd396fb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4f7dbd6080791642133b998f65fb5d3b", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1574750290.74-215384282450622/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-11-26T06:38:11.456003 (delta: 0.784918)         elapsed: 175.694092 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.157103", "end": "2019-11-26 06:38:11.821949", "rc": 0, "start": "2019-11-26 06:38:11.664846", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-11-26T06:38:11.893712 (delta: 0.43764)         elapsed: 176.131801 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-11-25T12:05:18Z", "generation": 17, "name": "cstor-csi-clone", "resourceVersion": "1074276", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-clone", "uid": "f9b74cd9-b29a-4d05-b41b-24f7aed952fb"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=34   changed=25   unreachable=0    failed=0   

2019-11-26T06:38:12.846149 (delta: 0.952382)         elapsed: 177.084238 ****** 
```