### PR TITLE
feat(experiment): Included a litmus experiment to induce the app pod failure in nfs provisioner

### DIFF
--- a/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/README.md
+++ b/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/README.md
@@ -1,0 +1,49 @@
+## Experiment Metadata
+
+| Type  | Description                  | Storage | Applications  | K8s Platform |
+| ----- | ---------------------------- | ------- | ------------- | ------------ |
+| Chaos | Fail the nfs application pod | OpenEBS | NFS           | Any          |
+
+## Entry-Criteria
+
+- NFS provisoner services are accessible & pods are healthy
+- Application pods that are using NFS provisioner are healthy
+- Application writes are successful 
+
+## Exit-Criteria
+
+- Applications that are using NFS provisioner are accessible & pods are healthy
+- Data written prior to chaos is successfully retrieved/read
+
+## Associated Utils 
+
+- `chaoslib/pumba/pod_failure_by_sigkill.yaml` when the container runtime is pumba
+- `chaoslib/containerd_chaos/crictl-chaos.yml` when the container runtime is containerd
+- `chaoslib/crio_chaos/crio-crictl-chaos.yml` when the container runtime is cro 
+   
+
+## Litmusbook Environment Variables
+
+### Application
+
+| Parameter         | Description                                                   |
+| -------------     | ------------------------------------------------------------  |
+| APP_NAMESPACE     | Namespace in which application pods are deployed              |
+| APP_LABEL         | Unique Labels in `key=value` format of application deployment |
+| CONTAINER_RUNTIME | container runtime to induce the chaos                         |
+| NFS_NAMESPACE     | Namespace in which nfs provisioner is deployed                |
+| NFS_LABEL         | Unique Labels in `key=value` format of NFS deployment         |
+
+### Health Checks 
+
+| Parameter              | Description                                                           |
+| ---------------------- | --------------------------------------------------------------------- |
+| LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any        |
+| LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
+
+## Procedure
+
+This experiment kills the application container and verifies if the container is scheduled back and the data is intact. Based on CRI used, uses the relevant util to kill the application container.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding Application.
+

--- a/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/run_litmus_test.yml
+++ b/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/run_litmus_test.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: nfs-application-pod-failure-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: nfs-app-pod-failure
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: NFS_NAMESPACE
+            value: ""
+
+          - name: NFS_LABEL
+            value: ""
+
+          - name: APP_LABEL
+            value: ""
+
+          - name: APP_NAMESPACE
+            value: ""
+
+          # Specify the container runtime used , to pick the relevant chaos util
+          - name: CONTAINER_RUNTIME
+            value: ""
+
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/test.yml
+++ b/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/test.yml
@@ -1,0 +1,129 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        - include_tasks: /utils/k8s/application_liveness_check.yml
+          when: liveness_label != ''
+
+         ## Creating test name
+
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "nfs-app-pod-failure"
+
+        - name: Verify that the NFS Provisioner is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ nfs_app_ns }}"
+            app_lkey: "{{ nfs_app_label.split('=')[0] }}"
+            app_lvalue: "{{ nfs_app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ app_namespace }}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Obtain the NFS provisioner application pod name
+          shell: >
+            kubectl get pods -n {{ nfs_app_ns }} -l {{ nfs_app_label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+          ## APPLICATION FAULT INJECTION
+
+        - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
+          vars:
+            action: "killapp"
+            app_pod: "{{ app_pod_name.stdout }}"
+            namespace: "{{ nfs_app_ns }}"
+            label: "{{ nfs_app_label }}"
+          when: cri == 'docker'
+
+        - include_tasks: /chaoslib/containerd_chaos/crictl-chaos.yml
+          vars:
+            action: "killapp"
+            app_pod: "{{ app_pod_name.stdout }}"
+            namespace: "{{ nfs_app_ns }}"
+            label: "{{ nfs_app_label }}"
+          when: cri == 'containerd'
+
+        - include_tasks: /chaoslib/crio_chaos/crio-crictl-chaos.yml
+          vars:
+            action: "killapp"
+            app_pod: "{{ app_pod_name.stdout }}"
+            namespace: "{{ nfs_app_ns }}"
+            label: "{{ nfs_app_label }}"
+          when: cri == 'cri-o'
+
+        - name: Verify that the NFS provisioner is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ nfs_app_ns }}"
+            app_lkey: "{{ nfs_app_label.split('=')[0] }}"
+            app_lvalue: "{{ nfs_app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ app_namespace }}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - include_tasks: /utils/k8s/application_liveness_check.yml
+          when: liveness_label != ''
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "nfs-app-pod-failure"
+
+        - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
+          vars:
+            action: "deletepumba"
+            namespace: "{{ nfs_app_ns }}"
+          when: cri == 'docker'
+
+        - include_tasks: /chaoslib/containerd_chaos/crictl-chaos.yml
+          vars:
+            action: "delete-containerd"
+            namespace: "{{ nfs_app_ns }}"
+          when: cri == 'containerd'
+
+        - include_tasks: /chaoslib/crio_chaos/crio-crictl-chaos.yml
+          vars:
+            action: "delete-crio"
+            namespace: "{{ nfs_app_ns }}"
+          when: cri == 'cri-o'

--- a/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/test_vars.yml
+++ b/experiments/chaos/nfs_chaos/nfs_provisioner_pod_kill/test_vars.yml
@@ -1,0 +1,15 @@
+test_name: nfs-application-pod-failure
+
+nfs_app_ns: "{{ lookup('env','NFS_NAMESPACE') }}"
+
+nfs_app_label: "{{ lookup('env','NFS_LABEL') }}"
+
+cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
+
+app_namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a LitmusExperiment to perform the application pod failure 
- This litmus experiment will perform the pod kill and checks the behaviour of nfs provisioner pod and application that uses the application pod.

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [x] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Oct  7 2019, 17:39:04) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/nfs_chaos/nfs_app_kill/test.yml

PLAY [localhost] ***************************************************************
2019-12-03T09:42:10.728396 (delta: 0.109375)         elapsed: 0.109375 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:2
2019-12-03T09:42:10.750947 (delta: 0.022463)         elapsed: 0.131926 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:11
2019-12-03T09:42:25.961213 (delta: 15.210216)         elapsed: 15.342192 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:16
2019-12-03T09:42:26.067540 (delta: 0.106255)         elapsed: 15.448519 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-12-03T09:42:26.241864 (delta: 0.174249)         elapsed: 15.622843 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-12-03T09:42:26.371703 (delta: 0.12972)         elapsed: 15.752682 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:20
2019-12-03T09:42:26.493072 (delta: 0.121247)         elapsed: 15.874051 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-03T09:42:26.719028 (delta: 0.22585)         elapsed: 16.100007 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2fafba7e03a289d765083bfa757532d60f45b109", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3ee0c1a847b6d3f716df1bcf4c0199df", "mode": "0644", "owner": "root", "size": 447, "src": "/root/.ansible/tmp/ansible-tmp-1575366146.84-64445857876892/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-03T09:42:28.088846 (delta: 1.369718)         elapsed: 17.469825 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.462621", "end": "2019-12-03 09:42:30.320548", "rc": 0, "start": "2019-12-03 09:42:28.857927", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: nfs-application-pod-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: nfs-app-pod-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: nfs-application-pod-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: nfs-app-pod-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-03T09:42:30.444192 (delta: 2.355243)         elapsed: 19.825171 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-03T09:35:24Z", "generation": 3, "name": "nfs-application-pod-failure", "resourceVersion": "67048", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/nfs-application-pod-failure", "uid": "69b699c1-dc17-493c-b0d2-b2da012f458e"}, "spec": {"testMetadata": {"chaostype": "nfs-app-pod-failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-03T09:42:32.680928 (delta: 2.236622)         elapsed: 22.061907 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-03T09:42:32.779147 (delta: 0.098128)         elapsed: 22.160126 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-03T09:42:32.887819 (delta: 0.108594)         elapsed: 22.268798 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:25
2019-12-03T09:42:32.996374 (delta: 0.108471)         elapsed: 22.377353 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-03T09:42:33.207021 (delta: 0.210507)         elapsed: 22.588 ********** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-nfsv4-ns -l app=\"nfs\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.883906", "end": "2019-12-03 09:42:35.461342", "rc": 0, "start": "2019-12-03 09:42:33.577436", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-03T09:36:07Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-03T09:36:07Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-03T09:42:35.598704 (delta: 2.391597)         elapsed: 24.979683 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-nfsv4-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"nfs\")].status.phase}'", "delta": "0:00:01.766880", "end": "2019-12-03 09:42:37.859023", "rc": 0, "start": "2019-12-03 09:42:36.092143", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:34
2019-12-03T09:42:38.003654 (delta: 2.404838)         elapsed: 27.384633 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-03T09:42:38.199528 (delta: 0.195726)         elapsed: 27.580507 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n minio -l app=\"minio3\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.639144", "end": "2019-12-03 09:42:40.247075", "rc": 0, "start": "2019-12-03 09:42:38.607931", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-03T09:23:22Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-03T09:23:22Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-03T09:42:40.386837 (delta: 2.187217)         elapsed: 29.767816 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n minio -o jsonpath='{.items[?(@.metadata.labels.app==\"minio3\")].status.phase}'", "delta": "0:00:01.645685", "end": "2019-12-03 09:42:42.424287", "rc": 0, "start": "2019-12-03 09:42:40.778602", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:43
2019-12-03T09:42:42.575280 (delta: 2.188374)         elapsed: 31.956259 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-nfsv4-ns -l app=nfs --no-headers -o=custom-columns=NAME:\".metadata.name\" | shuf -n 1", "delta": "0:00:01.574000", "end": "2019-12-03 09:42:44.480806", "rc": 0, "start": "2019-12-03 09:42:42.906806", "stderr": "", "stderr_lines": [], "stdout": "nfs-provisioner-56c54bcbf8-42gj2", "stdout_lines": ["nfs-provisioner-56c54bcbf8-42gj2"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:53
2019-12-03T09:42:44.587493 (delta: 2.012128)         elapsed: 33.968472 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:61
2019-12-03T09:42:44.711570 (delta: 0.123975)         elapsed: 34.092549 ******* 
included: /chaoslib/containerd_chaos/crictl-chaos.yml for 127.0.0.1

TASK [Setup containerd chaos infrastructure.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:3
2019-12-03T09:42:45.010261 (delta: 0.298565)         elapsed: 34.39124 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/containerd_chaos/containerd-chaos-ds.yml -n app-nfsv4-ns", "delta": "0:00:03.119169", "end": "2019-12-03 09:42:48.483001", "rc": 0, "start": "2019-12-03 09:42:45.363832", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/containerd-chaos created", "stdout_lines": ["daemonset.apps/containerd-chaos created"]}

TASK [Confirm that the containerd-chaos ds is running on all nodes.] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:11
2019-12-03T09:42:48.631924 (delta: 3.621563)         elapsed: 38.012903 ******* 
FAILED - RETRYING: Confirm that the containerd-chaos ds is running on all nodes. (60 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=crictl --no-headers -o custom-columns=:status.phase -n app-nfsv4-ns | sort | uniq", "delta": "0:00:01.707658", "end": "2019-12-03 09:42:55.681149", "rc": 0, "start": "2019-12-03 09:42:53.973491", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Identify the node where application is running] **************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:24
2019-12-03T09:42:55.843855 (delta: 7.211814)         elapsed: 45.224834 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod nfs-provisioner-56c54bcbf8-42gj2 -n app-nfsv4-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.784373", "end": "2019-12-03 09:42:58.066007", "failed_when_result": false, "rc": 0, "start": "2019-12-03 09:42:56.281634", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node5.mayalabs.io", "stdout_lines": ["d2iq-node5.mayalabs.io"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:33
2019-12-03T09:42:58.227018 (delta: 2.38304)         elapsed: 47.607997 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "d2iq-node5.mayalabs.io"}, "changed": false}

TASK [Record the containerd-chaos pod on app node] *****************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:37
2019-12-03T09:42:58.364371 (delta: 0.137249)         elapsed: 47.74535 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=crictl -o wide -n app-nfsv4-ns | grep d2iq-node5.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.603318", "end": "2019-12-03 09:43:00.319369", "failed_when_result": false, "rc": 0, "start": "2019-12-03 09:42:58.716051", "stderr": "", "stderr_lines": [], "stdout": "containerd-chaos-5qqmb", "stdout_lines": ["containerd-chaos-5qqmb"]}

TASK [Record the application container] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:49
2019-12-03T09:43:00.546190 (delta: 2.18172)         elapsed: 49.927169 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=nfs -n app-nfsv4-ns -o jsonpath='{.items[0].spec.containers[0].name}'", "delta": "0:00:01.620533", "end": "2019-12-03 09:43:02.598030", "rc": 0, "start": "2019-12-03 09:43:00.977497", "stderr": "", "stderr_lines": [], "stdout": "nfs-provisioner", "stdout_lines": ["nfs-provisioner"]}

TASK [Record the app_container] ************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:56
2019-12-03T09:43:02.716106 (delta: 2.169819)         elapsed: 52.097085 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_container": "nfs-provisioner"}, "changed": false}

TASK [Obtain the pod ID through Pod name] **************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:62
2019-12-03T09:43:02.861525 (delta: 0.145291)         elapsed: 52.242504 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec containerd-chaos-5qqmb -n app-nfsv4-ns -- crictl pods | grep \"nfs-provisioner-56c54bcbf8-42gj2\" | awk '{print $1}'", "delta": "0:00:01.985814", "end": "2019-12-03 09:43:05.182411", "failed_when_result": false, "rc": 0, "start": "2019-12-03 09:43:03.196597", "stderr": "", "stderr_lines": [], "stdout": "8fe7d8e1cf9b1", "stdout_lines": ["8fe7d8e1cf9b1"]}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:71
2019-12-03T09:43:05.352558 (delta: 2.490914)         elapsed: 54.733537 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec containerd-chaos-5qqmb -n app-nfsv4-ns -- crictl ps | grep 8fe7d8e1cf9b1 | grep nfs-provisioner | awk '{print $1}'", "delta": "0:00:02.084940", "end": "2019-12-03 09:43:07.800531", "failed_when_result": false, "rc": 0, "start": "2019-12-03 09:43:05.715591", "stderr": "", "stderr_lines": [], "stdout": "45932fb5b4eb0", "stdout_lines": ["45932fb5b4eb0"]}

TASK [Kill the container] ******************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:80
2019-12-03T09:43:07.920250 (delta: 2.567549)         elapsed: 57.301229 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec containerd-chaos-5qqmb -n app-nfsv4-ns -- crictl stop \"45932fb5b4eb0\"", "delta": "0:00:02.460273", "end": "2019-12-03 09:43:10.792981", "failed_when_result": false, "rc": 0, "start": "2019-12-03 09:43:08.332708", "stderr": "", "stderr_lines": [], "stdout": "45932fb5b4eb0", "stdout_lines": ["45932fb5b4eb0"]}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:89
2019-12-03T09:43:10.896335 (delta: 2.975995)         elapsed: 60.277314 ******* 
FAILED - RETRYING: Obtain the container ID using pod name and container name (20 retries left).
FAILED - RETRYING: Obtain the container ID using pod name and container name (19 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec containerd-chaos-5qqmb -n app-nfsv4-ns -- crictl ps | grep 8fe7d8e1cf9b1 | grep nfs-provisioner | awk '{print $1}'", "delta": "0:00:02.378970", "end": "2019-12-03 09:43:28.792454", "rc": 0, "start": "2019-12-03 09:43:26.413484", "stderr": "", "stderr_lines": [], "stdout": "8e5fe4977cd87", "stdout_lines": ["8e5fe4977cd87"]}

TASK [Check if the new container is running.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:100
2019-12-03T09:43:28.956743 (delta: 18.060325)         elapsed: 78.337722 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec containerd-chaos-5qqmb -n app-nfsv4-ns -- crictl ps | grep 8e5fe4977cd87", "delta": "0:00:02.001823", "end": "2019-12-03 09:43:31.419286", "rc": 0, "start": "2019-12-03 09:43:29.417463", "stderr": "", "stderr_lines": [], "stdout": "8e5fe4977cd87       e7656e1410441       5 seconds ago        Running             nfs-provisioner                                     2                   8fe7d8e1cf9b1", "stdout_lines": ["8e5fe4977cd87       e7656e1410441       5 seconds ago        Running             nfs-provisioner                                     2                   8fe7d8e1cf9b1"]}

TASK [Delete the crictl-chaos daemonset] ***************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:115
2019-12-03T09:43:31.695119 (delta: 2.738268)         elapsed: 81.076098 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the containerd-chaos pod is deleted successfully] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:123
2019-12-03T09:43:31.816539 (delta: 0.121244)         elapsed: 81.197518 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:69
2019-12-03T09:43:31.937794 (delta: 0.121157)         elapsed: 81.318773 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:77
2019-12-03T09:43:32.071313 (delta: 0.133417)         elapsed: 81.452292 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-03T09:43:32.239751 (delta: 0.168335)         elapsed: 81.62073 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-nfsv4-ns -l app=\"nfs\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.592298", "end": "2019-12-03 09:43:34.211888", "rc": 0, "start": "2019-12-03 09:43:32.619590", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-03T09:43:26Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-03T09:43:26Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-03T09:43:34.347735 (delta: 2.107868)         elapsed: 83.728714 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-nfsv4-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"nfs\")].status.phase}'", "delta": "0:00:01.604286", "end": "2019-12-03 09:43:36.341021", "rc": 0, "start": "2019-12-03 09:43:34.736735", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:86
2019-12-03T09:43:36.463995 (delta: 2.116129)         elapsed: 85.844974 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-03T09:43:36.686815 (delta: 0.222724)         elapsed: 86.067794 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n minio -l app=\"minio3\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.635198", "end": "2019-12-03 09:43:38.692347", "rc": 0, "start": "2019-12-03 09:43:37.057149", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-03T09:23:22Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-03T09:23:22Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-03T09:43:38.823545 (delta: 2.136614)         elapsed: 88.204524 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n minio -o jsonpath='{.items[?(@.metadata.labels.app==\"minio3\")].status.phase}'", "delta": "0:00:01.711750", "end": "2019-12-03 09:43:40.885703", "rc": 0, "start": "2019-12-03 09:43:39.173953", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:95
2019-12-03T09:43:41.098177 (delta: 2.274524)         elapsed: 90.479156 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:98
2019-12-03T09:43:41.256813 (delta: 0.15849)         elapsed: 90.637792 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:108
2019-12-03T09:43:41.444418 (delta: 0.187491)         elapsed: 90.825397 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-03T09:43:41.720452 (delta: 0.275897)         elapsed: 91.101431 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-03T09:43:41.850024 (delta: 0.129461)         elapsed: 91.231003 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-03T09:43:41.986723 (delta: 0.136573)         elapsed: 91.367702 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-03T09:43:42.140441 (delta: 0.153598)         elapsed: 91.52142 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2e30a5868a72705404c299dd334297b40312a8b3", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "94a567647ee2622f4624ed9006c3d291", "mode": "0644", "owner": "root", "size": 445, "src": "/root/.ansible/tmp/ansible-tmp-1575366222.45-65675410546140/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-03T09:43:46.125474 (delta: 3.984899)         elapsed: 95.506453 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.455853", "end": "2019-12-03 09:43:48.094334", "rc": 0, "start": "2019-12-03 09:43:46.638481", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: nfs-application-pod-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: nfs-app-pod-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: nfs-application-pod-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: nfs-app-pod-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-03T09:43:48.227052 (delta: 2.101441)         elapsed: 97.608031 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-03T09:35:24Z", "generation": 4, "name": "nfs-application-pod-failure", "resourceVersion": "68271", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/nfs-application-pod-failure", "uid": "69b699c1-dc17-493c-b0d2-b2da012f458e"}, "spec": {"testMetadata": {"chaostype": "nfs-app-pod-failure"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:113
2019-12-03T09:43:49.880631 (delta: 1.653488)         elapsed: 99.26161 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:119
2019-12-03T09:43:50.045447 (delta: 0.164686)         elapsed: 99.426426 ******* 
included: /chaoslib/containerd_chaos/crictl-chaos.yml for 127.0.0.1

TASK [Setup containerd chaos infrastructure.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:3
2019-12-03T09:43:50.477466 (delta: 0.431906)         elapsed: 99.858445 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the containerd-chaos ds is running on all nodes.] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:11
2019-12-03T09:43:50.607129 (delta: 0.129549)         elapsed: 99.988108 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the node where application is running] **************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:24
2019-12-03T09:43:50.771152 (delta: 0.163898)         elapsed: 100.152131 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application node name] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:33
2019-12-03T09:43:50.929435 (delta: 0.157949)         elapsed: 100.310414 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the containerd-chaos pod on app node] *****************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:37
2019-12-03T09:43:51.050539 (delta: 0.120984)         elapsed: 100.431518 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application container] ****************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:49
2019-12-03T09:43:51.145571 (delta: 0.094875)         elapsed: 100.52655 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:56
2019-12-03T09:43:51.255584 (delta: 0.109857)         elapsed: 100.636563 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the pod ID through Pod name] **************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:62
2019-12-03T09:43:51.368001 (delta: 0.112279)         elapsed: 100.74898 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:71
2019-12-03T09:43:51.478784 (delta: 0.110662)         elapsed: 100.859763 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Kill the container] ******************************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:80
2019-12-03T09:43:51.648286 (delta: 0.169365)         elapsed: 101.029265 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the container ID using pod name and container name] ***************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:89
2019-12-03T09:43:51.849343 (delta: 0.200941)         elapsed: 101.230322 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the new container is running.] **********************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:100
2019-12-03T09:43:51.993083 (delta: 0.143628)         elapsed: 101.374062 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the crictl-chaos daemonset] ***************************************
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:115
2019-12-03T09:43:52.115190 (delta: 0.122012)         elapsed: 101.496169 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/containerd_chaos/containerd-chaos-ds.yml -n app-nfsv4-ns", "delta": "0:00:01.471852", "end": "2019-12-03 09:43:53.917325", "rc": 0, "start": "2019-12-03 09:43:52.445473", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps \"containerd-chaos\" deleted", "stdout_lines": ["daemonset.apps \"containerd-chaos\" deleted"]}

TASK [Confirm that the containerd-chaos pod is deleted successfully] ***********
task path: /chaoslib/containerd_chaos/crictl-chaos.yml:123
2019-12-03T09:43:54.038569 (delta: 1.923276)         elapsed: 103.419548 ****** 
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (50 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (49 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (48 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (47 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (46 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (45 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (44 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (43 retries left).
FAILED - RETRYING: Confirm that the containerd-chaos pod is deleted successfully (42 retries left).
changed: [127.0.0.1] => {"attempts": 10, "changed": true, "cmd": "kubectl get pod -l app=crictl --no-headers -n app-nfsv4-ns", "delta": "0:00:01.454478", "end": "2019-12-03 09:44:40.671691", "rc": 0, "start": "2019-12-03 09:44:39.217213", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_app_kill/test.yml:125
2019-12-03T09:44:40.779603 (delta: 46.740868)         elapsed: 150.160582 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=40   changed=27   unreachable=0    failed=0   

2019-12-03T09:44:40.841311 (delta: 0.061588)         elapsed: 150.22229 ******* 
===============================================================================
```
