### PR TITLE
refactor(litmusbook): Backup&Restore experiment to run on openshift container platform

### DIFF
--- a/experiments/functional/backup_and_restore/patch.yml
+++ b/experiments/functional/backup_and_restore/patch.yml
@@ -1,0 +1,18 @@
+{
+    "spec": {
+        "template": {
+            "spec": {
+                "containers": [ 
+                    {
+                        "image": "gcr.io/heptio-images/velero:v1.1.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "restic",
+                        "securityContext": { 
+                           "privileged": true
+                         }
+                            }
+                 ]
+                    }
+            }
+}
+}

--- a/experiments/functional/backup_and_restore/setup_dependency.yml
+++ b/experiments/functional/backup_and_restore/setup_dependency.yml
@@ -32,13 +32,29 @@
 
    - name: Installing velero server inside cluster
      shell: >
-       velero install \
-         --provider aws \
-         --bucket velero \
-         --secret-file ./credentials-velero \
-         --use-volume-snapshots=false \
-         --use-restic \
-         --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+        velero install \
+          --provider aws \
+          --bucket velero \
+          --secret-file ./credentials-velero \
+          --use-volume-snapshots=false \
+          --use-restic \
+          --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+
+   - name: Patching restic demonset for privileged access
+     shell: kubectl patch ds restic -n velero --patch "$(cat patch.yml)"
+     register: patch_status
+     failed_when: "'patched' not in patch_status.stdout"
+
+   - name: Getting the number of compute nodes
+     shell: kubectl get nodes | grep worker | wc -l
+     register: node_count
+
+   - name: Checking the status of restic demonset pods
+     shell: kubectl get po -n velero -o jsonpath='{.items[?(@.metadata.labels.name=="restic")].status.phase}' | wc -w
+     register: restic_pod_count
+     until: (node_count.stdout)|int == (restic_pod_count.stdout)|int
+     delay: 5
+     retries: 60
 
   when: "storage_engine == 'jiva' or storage_engine == 'localpv'"  
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Extends backup and restore litmusbook to run on openshift platform.
- Includes patch.yml which patched restic demonset to run in privileged mode.

**Special notes for your reviewer**:
- **Prerequisite to perform this test**
`oc adm policy add-scc-to-group privileged system:serviceaccounts:velero:velero`

**Following is the log of ansible-test container on Openshift-4.1**
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/backup_and_restore/test.yml

PLAY [localhost] ***************************************************************
2019-12-03T19:57:19.131805 (delta: 0.070246)         elapsed: 0.070246 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:1
2019-12-03T19:57:19.147564 (delta: 0.01572)         elapsed: 0.086005 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:12
2019-12-03T19:57:29.243917 (delta: 10.096316)         elapsed: 10.182358 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-12-03T19:57:29.348063 (delta: 0.104094)         elapsed: 10.286504 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-12-03T19:57:29.418148 (delta: 0.070013)         elapsed: 10.356589 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:15
2019-12-03T19:57:29.526904 (delta: 0.108674)         elapsed: 10.465345 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-03T19:57:29.657788 (delta: 0.130581)         elapsed: 10.596229 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cb23761ee0ecfea3a093f94c0443739c777b3007", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0da5664e16958d4f3c263662ebe36b5c", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1575403049.73-66539455242774/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-03T19:57:30.741974 (delta: 1.084124)         elapsed: 11.680415 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.054416", "end": "2019-12-03 19:57:32.321237", "rc": 0, "start": "2019-12-03 19:57:31.266821", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-03T19:57:32.395600 (delta: 1.653561)         elapsed: 13.334041 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-03T19:50:51Z", "generation": 3, "name": "velero-backup-restore", "resourceVersion": "743295", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "35c351d5-1606-11ea-bf7d-005056985283"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-03T19:57:34.078485 (delta: 1.682821)         elapsed: 15.016926 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-03T19:57:34.210433 (delta: 0.131863)         elapsed: 15.148874 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-03T19:57:34.362928 (delta: 0.15235)         elapsed: 15.301369 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /experiments/functional/backup_and_restore/test.yml:19
2019-12-03T19:57:34.469724 (delta: 0.106613)         elapsed: 15.408165 ******* 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2019-12-03T19:57:34.630611 (delta: 0.160813)         elapsed: 15.569052 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.487298", "end": "2019-12-03 19:57:36.527662", "rc": 0, "start": "2019-12-03 19:57:35.040364", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2019-12-03T19:57:36.602361 (delta: 1.971671)         elapsed: 17.540802 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2019-12-03T19:57:36.680583 (delta: 0.07815)         elapsed: 17.619024 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:22
2019-12-03T19:57:36.758523 (delta: 0.077849)         elapsed: 17.696964 ******* 
included: /experiments/functional/backup_and_restore/setup_dependency.yml for 127.0.0.1

TASK [Downloading velero binary] ***********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:1
2019-12-03T19:57:36.915565 (delta: 0.156956)         elapsed: 17.854006 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "24c98ca1c9cfe5c754c76c07ba6cbc517bc68f92", "dest": "./velero-v1.1.0-linux-amd64.tar.gz", "gid": 0, "group": "root", "md5sum": "2f8fb6505764a6f937b8b5645d4b8fb8", "mode": "0644", "msg": "OK (26731554 bytes)", "owner": "root", "size": 26731554, "src": "/root/.ansible/tmp/ansible-tmp-1575403056.99-102538900689562/tmpOfK1Xw", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/vmware-tanzu/velero/releases/download/v1.1.0/velero-v1.1.0-linux-amd64.tar.gz"}

TASK [Installing velero inside litmus container] *******************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:11
2019-12-03T19:57:44.520677 (delta: 7.605051)         elapsed: 25.459118 ******* 
 [WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "tar -xvf velero-v1.1.0-linux-amd64.tar.gz\n mv velero-v1.1.0-linux-amd64/velero /usr/local/bin/", "delta": "0:00:02.209732", "end": "2019-12-03 19:57:47.083356", "rc": 0, "start": "2019-12-03 19:57:44.873624", "stderr": "", "stderr_lines": [], "stdout": "velero-v1.1.0-linux-amd64/LICENSE\nvelero-v1.1.0-linux-amd64/examples/README.md\nvelero-v1.1.0-linux-amd64/examples/minio\nvelero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app\nvelero-v1.1.0-linux-amd64/examples/nginx-app/README.md\nvelero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml\nvelero-v1.1.0-linux-amd64/velero", "stdout_lines": ["velero-v1.1.0-linux-amd64/LICENSE", "velero-v1.1.0-linux-amd64/examples/README.md", "velero-v1.1.0-linux-amd64/examples/minio", "velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app", "velero-v1.1.0-linux-amd64/examples/nginx-app/README.md", "velero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml", "velero-v1.1.0-linux-amd64/velero"]}

TASK [Checking the velero version] *********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:16
2019-12-03T19:57:47.149113 (delta: 2.62838)         elapsed: 28.087554 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero version", "delta": "0:00:01.284895", "end": "2019-12-03 19:57:48.774285", "failed_when_result": false, "rc": 0, "start": "2019-12-03 19:57:47.489390", "stderr": "", "stderr_lines": [], "stdout": "Client:\n\tVersion: v1.1.0\n\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608\n<error getting server version: namespaces \"velero\" not found>", "stdout_lines": ["Client:", "\tVersion: v1.1.0", "\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608", "<error getting server version: namespaces \"velero\" not found>"]}

TASK [Installing minio s3-bucket] **********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:21
2019-12-03T19:57:48.884124 (delta: 1.734953)         elapsed: 29.822565 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "delta": "0:00:02.449462", "end": "2019-12-03 19:57:51.687067", "rc": 0, "start": "2019-12-03 19:57:49.237605", "stderr": "", "stderr_lines": [], "stdout": "namespace/velero created\ndeployment.apps/minio created\nservice/minio created\njob.batch/minio-setup created", "stdout_lines": ["namespace/velero created", "deployment.apps/minio created", "service/minio created", "job.batch/minio-setup created"]}

TASK [Checking for minio pod status] *******************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:24
2019-12-03T19:57:51.785384 (delta: 2.901177)         elapsed: 32.723825 ******* 
FAILED - RETRYING: Checking for minio pod status (15 retries left).
FAILED - RETRYING: Checking for minio pod status (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.213518", "end": "2019-12-03 19:58:06.909889", "rc": 0, "start": "2019-12-03 19:58:05.696371", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:33
2019-12-03T19:58:06.979819 (delta: 15.19433)         elapsed: 47.91826 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero install --provider aws --bucket velero --secret-file ./credentials-velero --use-volume-snapshots=false --use-restic --backup-location-config region=minio,s3ForcePathStyle=\"true\",s3Url=http://minio.velero.svc:9000", "delta": "0:00:03.070470", "end": "2019-12-03 19:58:10.264353", "rc": 0, "start": "2019-12-03 19:58:07.193883", "stderr": "", "stderr_lines": [], "stdout": "CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumebackups.velero.io: created\nCustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumerestores.velero.io: created\nCustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource\nCustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding\nCustomResourceDefinition/volumesnapshotlocations.velero.io: created\nCustomResourceDefinition/resticrepositories.velero.io: attempting to create resource\nCustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding\nCustomResourceDefinition/resticrepositories.velero.io: created\nCustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource\nCustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding\nCustomResourceDefinition/backupstoragelocations.velero.io: created\nCustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource\nCustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/serverstatusrequests.velero.io: created\nCustomResourceDefinition/backups.velero.io: attempting to create resource\nCustomResourceDefinition/backups.velero.io: already exists, proceeding\nCustomResourceDefinition/backups.velero.io: created\nCustomResourceDefinition/restores.velero.io: attempting to create resource\nCustomResourceDefinition/restores.velero.io: already exists, proceeding\nCustomResourceDefinition/restores.velero.io: created\nCustomResourceDefinition/schedules.velero.io: attempting to create resource\nCustomResourceDefinition/schedules.velero.io: already exists, proceeding\nCustomResourceDefinition/schedules.velero.io: created\nCustomResourceDefinition/downloadrequests.velero.io: attempting to create resource\nCustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/downloadrequests.velero.io: created\nCustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource\nCustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding\nCustomResourceDefinition/deletebackuprequests.velero.io: created\nWaiting for resources to be ready in cluster...\nNamespace/velero: attempting to create resource\nNamespace/velero: already exists, proceeding\nNamespace/velero: created\nClusterRoleBinding/velero: attempting to create resource\nClusterRoleBinding/velero: already exists, proceeding\nClusterRoleBinding/velero: created\nServiceAccount/velero: attempting to create resource\nServiceAccount/velero: created\nSecret/cloud-credentials: attempting to create resource\nSecret/cloud-credentials: created\nBackupStorageLocation/default: attempting to create resource\nBackupStorageLocation/default: created\nDeployment/velero: attempting to create resource\nDeployment/velero: created\nDaemonSet/restic: attempting to create resource\nDaemonSet/restic: created\nVelero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status.", "stdout_lines": ["CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumebackups.velero.io: created", "CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumerestores.velero.io: created", "CustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource", "CustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding", "CustomResourceDefinition/volumesnapshotlocations.velero.io: created", "CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource", "CustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding", "CustomResourceDefinition/resticrepositories.velero.io: created", "CustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource", "CustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding", "CustomResourceDefinition/backupstoragelocations.velero.io: created", "CustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource", "CustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/serverstatusrequests.velero.io: created", "CustomResourceDefinition/backups.velero.io: attempting to create resource", "CustomResourceDefinition/backups.velero.io: already exists, proceeding", "CustomResourceDefinition/backups.velero.io: created", "CustomResourceDefinition/restores.velero.io: attempting to create resource", "CustomResourceDefinition/restores.velero.io: already exists, proceeding", "CustomResourceDefinition/restores.velero.io: created", "CustomResourceDefinition/schedules.velero.io: attempting to create resource", "CustomResourceDefinition/schedules.velero.io: already exists, proceeding", "CustomResourceDefinition/schedules.velero.io: created", "CustomResourceDefinition/downloadrequests.velero.io: attempting to create resource", "CustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/downloadrequests.velero.io: created", "CustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource", "CustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding", "CustomResourceDefinition/deletebackuprequests.velero.io: created", "Waiting for resources to be ready in cluster...", "Namespace/velero: attempting to create resource", "Namespace/velero: already exists, proceeding", "Namespace/velero: created", "ClusterRoleBinding/velero: attempting to create resource", "ClusterRoleBinding/velero: already exists, proceeding", "ClusterRoleBinding/velero: created", "ServiceAccount/velero: attempting to create resource", "ServiceAccount/velero: created", "Secret/cloud-credentials: attempting to create resource", "Secret/cloud-credentials: created", "BackupStorageLocation/default: attempting to create resource", "BackupStorageLocation/default: created", "Deployment/velero: attempting to create resource", "Deployment/velero: created", "DaemonSet/restic: attempting to create resource", "DaemonSet/restic: created", "Velero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status."]}

TASK [Getting the number of compute nodes] *************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:43
2019-12-03T19:58:10.414273 (delta: 3.434394)         elapsed: 51.352714 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes | grep worker | wc -l", "delta": "0:00:01.307244", "end": "2019-12-03 19:58:12.014837", "rc": 0, "start": "2019-12-03 19:58:10.707593", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Patching restic demonset for privileged access] **************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:47
2019-12-03T19:58:12.101918 (delta: 1.687502)         elapsed: 53.040359 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch ds restic -n velero --patch \"$(cat patch.yml)\"", "delta": "0:00:01.387743", "end": "2019-12-03 19:58:13.909125", "failed_when_result": false, "rc": 0, "start": "2019-12-03 19:58:12.521382", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/restic patched", "stdout_lines": ["daemonset.extensions/restic patched"]}

TASK [Checking the status of restic demonset pods] *****************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:52
2019-12-03T19:58:14.059889 (delta: 1.957802)         elapsed: 54.99833 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get po -n velero -o jsonpath='{.items[?(@.metadata.labels.name==\"restic\")].status.phase}' | wc -w", "delta": "0:00:01.327783", "end": "2019-12-03 19:58:15.891351", "rc": 0, "start": "2019-12-03 19:58:14.563568", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:63
2019-12-03T19:58:16.021714 (delta: 1.961604)         elapsed: 56.960155 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for velero server status] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:74
2019-12-03T19:58:16.166342 (delta: 0.144523)         elapsed: 57.104783 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
FAILED - RETRYING: Checking for velero server status (19 retries left).
FAILED - RETRYING: Checking for velero server status (18 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.290709", "end": "2019-12-03 19:58:37.566057", "rc": 0, "start": "2019-12-03 19:58:36.275348", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing development image of OpenEBS velero-plugin] *******************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:81
2019-12-03T19:58:37.643297 (delta: 21.47684)         elapsed: 78.581738 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for velero server status] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:85
2019-12-03T19:58:37.735624 (delta: 0.092263)         elapsed: 78.674065 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.290418", "end": "2019-12-03 19:58:39.257108", "rc": 0, "start": "2019-12-03 19:58:37.966690", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Creating volume snapshot location] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:92
2019-12-03T19:58:39.333620 (delta: 1.597924)         elapsed: 80.272061 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get Application pod details] *********************************************
task path: /experiments/functional/backup_and_restore/test.yml:24
2019-12-03T19:58:39.403029 (delta: 0.069276)         elapsed: 80.34147 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.273230", "end": "2019-12-03 19:58:41.072590", "rc": 0, "start": "2019-12-03 19:58:39.799360", "stderr": "", "stderr_lines": [], "stdout": "percona-755f6678bf-p95h5", "stdout_lines": ["percona-755f6678bf-p95h5"]}

TASK [Create new database in the mysql] ****************************************
task path: /experiments/functional/backup_and_restore/test.yml:28
2019-12-03T19:58:41.188159 (delta: 1.785075)         elapsed: 82.1266 ********* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-12-03T19:58:41.522402 (delta: 0.334138)         elapsed: 82.460843 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;') => {"changed": true, "cmd": "kubectl exec percona-755f6678bf-p95h5 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database backup;'", "delta": "0:00:01.526694", "end": "2019-12-03 19:58:43.331464", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "rc": 0, "start": "2019-12-03 19:58:41.804770", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup) => {"changed": true, "cmd": "kubectl exec percona-755f6678bf-p95h5 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "delta": "0:00:01.645960", "end": "2019-12-03 19:58:45.428569", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "rc": 0, "start": "2019-12-03 19:58:43.782609", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup) => {"changed": true, "cmd": "kubectl exec percona-755f6678bf-p95h5 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "delta": "0:00:01.723018", "end": "2019-12-03 19:58:47.557885", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "rc": 0, "start": "2019-12-03 19:58:45.834867", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-12-03T19:58:47.721538 (delta: 6.199079)         elapsed: 88.659979 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-12-03T19:58:47.860467 (delta: 0.138822)         elapsed: 88.798908 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-12-03T19:58:48.016044 (delta: 0.155464)         elapsed: 88.954485 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-12-03T19:58:48.151013 (delta: 0.134847)         elapsed: 89.089454 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-12-03T19:58:48.292678 (delta: 0.141552)         elapsed: 89.231119 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-12-03T19:58:48.446169 (delta: 0.153376)         elapsed: 89.38461 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-12-03T19:58:48.553728 (delta: 0.10742)         elapsed: 89.492169 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-12-03T19:58:48.628050 (delta: 0.074244)         elapsed: 89.566491 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-12-03T19:58:48.752008 (delta: 0.123902)         elapsed: 89.690449 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application deployment name] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:40
2019-12-03T19:58:48.889114 (delta: 0.136999)         elapsed: 89.827555 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n app-percona-ns -l name=percona -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.312478", "end": "2019-12-03 19:58:50.570561", "rc": 0, "start": "2019-12-03 19:58:49.258083", "stderr": "", "stderr_lines": [], "stdout": "percona", "stdout_lines": ["percona"]}

TASK [Fetching the volume name of application] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:44
2019-12-03T19:58:50.669002 (delta: 1.779737)         elapsed: 91.607443 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy percona -n app-percona-ns -o jsonpath='{.spec.template.spec.volumes[0].name}'", "delta": "0:00:01.295511", "end": "2019-12-03 19:58:52.453920", "rc": 0, "start": "2019-12-03 19:58:51.158409", "stderr": "", "stderr_lines": [], "stdout": "data-vol", "stdout_lines": ["data-vol"]}

TASK [Annotating the application pod] ******************************************
task path: /experiments/functional/backup_and_restore/test.yml:48
2019-12-03T19:58:52.572462 (delta: 1.903379)         elapsed: 93.510903 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl -n app-percona-ns annotate pod/percona-755f6678bf-p95h5 backup.velero.io/backup-volumes=data-vol", "delta": "0:00:01.336535", "end": "2019-12-03 19:58:54.256238", "rc": 0, "start": "2019-12-03 19:58:52.919703", "stderr": "", "stderr_lines": [], "stdout": "pod/percona-755f6678bf-p95h5 annotated", "stdout_lines": ["pod/percona-755f6678bf-p95h5 annotated"]}

TASK [Creating Backup for the provided application] ****************************
task path: /experiments/functional/backup_and_restore/test.yml:53
2019-12-03T19:58:54.375975 (delta: 1.803395)         elapsed: 95.314416 ******* 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2019-12-03T19:58:54.665036 (delta: 0.288948)         elapsed: 95.603477 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:16
2019-12-03T19:58:54.764920 (delta: 0.099816)         elapsed: 95.703361 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero backup create percona-backup --selector '!openebs.io/controller,!openebs.io/replica' --include-namespaces=app-percona-ns", "delta": "0:00:01.155018", "end": "2019-12-03 19:58:56.327742", "rc": 0, "start": "2019-12-03 19:58:55.172724", "stderr": "", "stderr_lines": [], "stdout": "Backup request \"percona-backup\" submitted successfully.\nRun `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details.", "stdout_lines": ["Backup request \"percona-backup\" submitted successfully.", "Run `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details."]}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:26
2019-12-03T19:58:56.423455 (delta: 1.658374)         elapsed: 97.361896 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:34
2019-12-03T19:58:56.529506 (delta: 0.10596)         elapsed: 97.467947 ******** 
FAILED - RETRYING: Getting the state of Backup (60 retries left).
FAILED - RETRYING: Getting the state of Backup (59 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get backup percona-backup -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.202316", "end": "2019-12-03 19:59:10.995638", "rc": 0, "start": "2019-12-03 19:59:09.793322", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:45
2019-12-03T19:59:11.099343 (delta: 14.56978)         elapsed: 112.037784 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:51
2019-12-03T19:59:11.214152 (delta: 0.114712)         elapsed: 112.152593 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:57
2019-12-03T19:59:11.299709 (delta: 0.085454)         elapsed: 112.23815 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:61
2019-12-03T19:59:11.367926 (delta: 0.068157)         elapsed: 112.306367 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting Application] ****************************************************
task path: /experiments/functional/backup_and_restore/test.yml:58
2019-12-03T19:59:11.456440 (delta: 0.088432)         elapsed: 112.394881 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc,deploy,svc --all -n app-percona-ns\n kubectl delete ns app-percona-ns", "delta": "0:02:17.462082", "end": "2019-12-03 20:01:29.344740", "rc": 0, "start": "2019-12-03 19:59:11.882658", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"percona-mysql-claim\" deleted\ndeployment.extensions \"percona\" deleted\ndeployment.extensions \"pvc-83491455-15fc-11ea-bf7d-005056985283-ctrl\" deleted\ndeployment.extensions \"pvc-83491455-15fc-11ea-bf7d-005056985283-rep\" deleted\nservice \"percona-mysql\" deleted\nservice \"pvc-83491455-15fc-11ea-bf7d-005056985283-ctrl-svc\" deleted\nnamespace \"app-percona-ns\" deleted", "stdout_lines": ["persistentvolumeclaim \"percona-mysql-claim\" deleted", "deployment.extensions \"percona\" deleted", "deployment.extensions \"pvc-83491455-15fc-11ea-bf7d-005056985283-ctrl\" deleted", "deployment.extensions \"pvc-83491455-15fc-11ea-bf7d-005056985283-rep\" deleted", "service \"percona-mysql\" deleted", "service \"pvc-83491455-15fc-11ea-bf7d-005056985283-ctrl-svc\" deleted", "namespace \"app-percona-ns\" deleted"]}

TASK [Checking whether namespace is deleted] ***********************************
task path: /experiments/functional/backup_and_restore/test.yml:63
2019-12-03T20:01:29.444751 (delta: 137.988219)         elapsed: 250.383192 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.423877", "end": "2019-12-03 20:01:31.070128", "rc": 0, "start": "2019-12-03 20:01:29.646251", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-node-lease\nkube-public\nkube-system\nlitmus\nopenebs\nopenshift\nopenshift-apiserver\nopenshift-apiserver-operator\nopenshift-authentication\nopenshift-authentication-operator\nopenshift-cloud-credential-operator\nopenshift-cluster-machine-approver\nopenshift-cluster-node-tuning-operator\nopenshift-cluster-samples-operator\nopenshift-cluster-storage-operator\nopenshift-cluster-version\nopenshift-config\nopenshift-config-managed\nopenshift-console\nopenshift-console-operator\nopenshift-controller-manager\nopenshift-controller-manager-operator\nopenshift-dns\nopenshift-dns-operator\nopenshift-etcd\nopenshift-image-registry\nopenshift-infra\nopenshift-ingress\nopenshift-ingress-operator\nopenshift-insights\nopenshift-kni-infra\nopenshift-kube-apiserver\nopenshift-kube-apiserver-operator\nopenshift-kube-controller-manager\nopenshift-kube-controller-manager-operator\nopenshift-kube-scheduler\nopenshift-kube-scheduler-operator\nopenshift-machine-api\nopenshift-machine-config-operator\nopenshift-marketplace\nopenshift-monitoring\nopenshift-multus\nopenshift-network-operator\nopenshift-node\nopenshift-openstack-infra\nopenshift-operator-lifecycle-manager\nopenshift-operators\nopenshift-sdn\nopenshift-service-ca\nopenshift-service-ca-operator\nopenshift-service-catalog-apiserver-operator\nopenshift-service-catalog-controller-manager-operator\nvelero", "stdout_lines": ["default", "kube-node-lease", "kube-public", "kube-system", "litmus", "openebs", "openshift", "openshift-apiserver", "openshift-apiserver-operator", "openshift-authentication", "openshift-authentication-operator", "openshift-cloud-credential-operator", "openshift-cluster-machine-approver", "openshift-cluster-node-tuning-operator", "openshift-cluster-samples-operator", "openshift-cluster-storage-operator", "openshift-cluster-version", "openshift-config", "openshift-config-managed", "openshift-console", "openshift-console-operator", "openshift-controller-manager", "openshift-controller-manager-operator", "openshift-dns", "openshift-dns-operator", "openshift-etcd", "openshift-image-registry", "openshift-infra", "openshift-ingress", "openshift-ingress-operator", "openshift-insights", "openshift-kni-infra", "openshift-kube-apiserver", "openshift-kube-apiserver-operator", "openshift-kube-controller-manager", "openshift-kube-controller-manager-operator", "openshift-kube-scheduler", "openshift-kube-scheduler-operator", "openshift-machine-api", "openshift-machine-config-operator", "openshift-marketplace", "openshift-monitoring", "openshift-multus", "openshift-network-operator", "openshift-node", "openshift-openstack-infra", "openshift-operator-lifecycle-manager", "openshift-operators", "openshift-sdn", "openshift-service-ca", "openshift-service-ca-operator", "openshift-service-catalog-apiserver-operator", "openshift-service-catalog-controller-manager-operator", "velero"]}

TASK [Restoring Application] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:75
2019-12-03T20:01:31.236655 (delta: 1.791843)         elapsed: 252.175096 ****** 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2019-12-03T20:01:31.470577 (delta: 0.233799)         elapsed: 252.409018 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:16
2019-12-03T20:01:31.555273 (delta: 0.084641)         elapsed: 252.493714 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:26
2019-12-03T20:01:31.677680 (delta: 0.122352)         elapsed: 252.616121 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:34
2019-12-03T20:01:31.852462 (delta: 0.174669)         elapsed: 252.790903 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:45
2019-12-03T20:01:32.007353 (delta: 0.154747)         elapsed: 252.945794 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:51
2019-12-03T20:01:32.155472 (delta: 0.147998)         elapsed: 253.093913 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero restore create --from-backup percona-backup --restore-volumes=true", "delta": "0:00:01.125259", "end": "2019-12-03 20:01:33.690369", "rc": 0, "start": "2019-12-03 20:01:32.565110", "stderr": "", "stderr_lines": [], "stdout": "Restore request \"percona-backup-20191203200133\" submitted successfully.\nRun `velero restore describe percona-backup-20191203200133` or `velero restore logs percona-backup-20191203200133` for more details.", "stdout_lines": ["Restore request \"percona-backup-20191203200133\" submitted successfully.", "Run `velero restore describe percona-backup-20191203200133` or `velero restore logs percona-backup-20191203200133` for more details."]}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:57
2019-12-03T20:01:33.777014 (delta: 1.621447)         elapsed: 254.715455 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero get restore | grep percona-backup | awk '{print $1}'", "delta": "0:00:01.058707", "end": "2019-12-03 20:01:35.128546", "rc": 0, "start": "2019-12-03 20:01:34.069839", "stderr": "", "stderr_lines": [], "stdout": "percona-backup-20191203200133", "stdout_lines": ["percona-backup-20191203200133"]}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:61
2019-12-03T20:01:35.208491 (delta: 1.431387)         elapsed: 256.146932 ****** 
FAILED - RETRYING: Checking the restore status (45 retries left).
FAILED - RETRYING: Checking the restore status (44 retries left).
FAILED - RETRYING: Checking the restore status (43 retries left).
FAILED - RETRYING: Checking the restore status (42 retries left).
FAILED - RETRYING: Checking the restore status (41 retries left).
FAILED - RETRYING: Checking the restore status (40 retries left).
FAILED - RETRYING: Checking the restore status (39 retries left).
FAILED - RETRYING: Checking the restore status (38 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get restore percona-backup-20191203200133 -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.320987", "end": "2019-12-03 20:02:29.493838", "rc": 0, "start": "2019-12-03 20:02:28.172851", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Getting the volume name] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:82
2019-12-03T20:02:29.565623 (delta: 54.357066)         elapsed: 310.504064 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the target IP] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:86
2019-12-03T20:02:29.643029 (delta: 0.077355)         elapsed: 310.58147 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the volume name] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:93
2019-12-03T20:02:29.747067 (delta: 0.103982)         elapsed: 310.685508 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the CVR name from the corresponding PV] **************************
task path: /experiments/functional/backup_and_restore/test.yml:97
2019-12-03T20:02:29.895803 (delta: 0.148662)         elapsed: 310.834244 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Geting the CSP name corresponding to CVR] ********************************
task path: /experiments/functional/backup_and_restore/test.yml:101
2019-12-03T20:02:30.038932 (delta: 0.142951)         elapsed: 310.977373 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the pool pod name] ***********************************************
task path: /experiments/functional/backup_and_restore/test.yml:106
2019-12-03T20:02:30.191372 (delta: 0.152297)         elapsed: 311.129813 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the volume name inside cstor pool] *******************************
task path: /experiments/functional/backup_and_restore/test.yml:111
2019-12-03T20:02:30.337619 (delta: 0.146149)         elapsed: 311.27606 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Assigning the cstor-pool volume name to variable] ************************
task path: /experiments/functional/backup_and_restore/test.yml:116
2019-12-03T20:02:30.481644 (delta: 0.143933)         elapsed: 311.420085 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Setting target IP for volume inside cstor pool] **************************
task path: /experiments/functional/backup_and_restore/test.yml:120
2019-12-03T20:02:30.619642 (delta: 0.137902)         elapsed: 311.558083 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Waiting for application to be in running state] **************************
task path: /experiments/functional/backup_and_restore/test.yml:128
2019-12-03T20:02:30.770306 (delta: 0.150567)         elapsed: 311.708747 ****** 
FAILED - RETRYING: Waiting for application to be in running state (30 retries left).
FAILED - RETRYING: Waiting for application to be in running state (29 retries left).
FAILED - RETRYING: Waiting for application to be in running state (28 retries left).
FAILED - RETRYING: Waiting for application to be in running state (27 retries left).
FAILED - RETRYING: Waiting for application to be in running state (26 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl get pod percona-755f6678bf-p95h5 -n app-percona-ns -o jsonpath='{.status.phase}'", "delta": "0:00:01.412607", "end": "2019-12-03 20:03:06.000303", "rc": 0, "start": "2019-12-03 20:03:04.587696", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying Data persistense] **********************************************
task path: /experiments/functional/backup_and_restore/test.yml:135
2019-12-03T20:03:06.069345 (delta: 35.298933)         elapsed: 347.007786 ***** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-12-03T20:03:06.267849 (delta: 0.198445)         elapsed: 347.20629 ******* 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-12-03T20:03:06.378171 (delta: 0.110258)         elapsed: 347.316612 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-755f6678bf-p95h5 -n app-percona-ns", "delta": "0:00:19.257265", "end": "2019-12-03 20:03:25.849666", "rc": 0, "start": "2019-12-03 20:03:06.592401", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-755f6678bf-p95h5\" deleted", "stdout_lines": ["pod \"percona-755f6678bf-p95h5\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-12-03T20:03:25.994310 (delta: 19.61608)         elapsed: 366.932751 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:01.331822", "end": "2019-12-03 20:03:27.645371", "rc": 0, "start": "2019-12-03 20:03:26.313549", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY   STATUS    RESTARTS   AGE\npercona-755f6678bf-s2vzb                                         1/1     Running   0          20s\npvc-abc3a554-1607-11ea-bf7d-005056985283-ctrl-5c5f4d8894-q5dms   2/2     Running   0          113s\npvc-abc3a554-1607-11ea-bf7d-005056985283-rep-7c5c4f84b-c9xjm     1/1     Running   0          102s\npvc-abc3a554-1607-11ea-bf7d-005056985283-rep-7c5c4f84b-grr9b     1/1     Running   0          102s\npvc-abc3a554-1607-11ea-bf7d-005056985283-rep-7c5c4f84b-k8lbd     1/1     Running   0          102s", "stdout_lines": ["NAME                                                             READY   STATUS    RESTARTS   AGE", "percona-755f6678bf-s2vzb                                         1/1     Running   0          20s", "pvc-abc3a554-1607-11ea-bf7d-005056985283-ctrl-5c5f4d8894-q5dms   2/2     Running   0          113s", "pvc-abc3a554-1607-11ea-bf7d-005056985283-rep-7c5c4f84b-c9xjm     1/1     Running   0          102s", "pvc-abc3a554-1607-11ea-bf7d-005056985283-rep-7c5c4f84b-grr9b     1/1     Running   0          102s", "pvc-abc3a554-1607-11ea-bf7d-005056985283-rep-7c5c4f84b-k8lbd     1/1     Running   0          102s"]}

TASK [Obtain the newly created pod name for applicaion] ************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-12-03T20:03:27.749835 (delta: 1.755424)         elapsed: 368.688276 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.332307", "end": "2019-12-03 20:03:29.613443", "rc": 0, "start": "2019-12-03 20:03:28.281136", "stderr": "", "stderr_lines": [], "stdout": "percona-755f6678bf-s2vzb", "stdout_lines": ["percona-755f6678bf-s2vzb"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-12-03T20:03:29.708167 (delta: 1.958176)         elapsed: 370.646608 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-755f6678bf-s2vzb\")].status.phase}'", "delta": "0:00:01.216108", "end": "2019-12-03 20:03:31.405875", "rc": 0, "start": "2019-12-03 20:03:30.189767", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-12-03T20:03:31.526971 (delta: 1.818699)         elapsed: 372.465412 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-755f6678bf-s2vzb\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.243929", "end": "2019-12-03 20:03:33.098751", "rc": 0, "start": "2019-12-03 20:03:31.854822", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-03T20:02:11Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-03T20:02:11Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-12-03T20:03:33.176062 (delta: 1.648979)         elapsed: 374.114503 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-755f6678bf-s2vzb -n app-percona-ns -- mysqlcheck -c backup -uroot -pk8sDem0", "delta": "0:00:01.619839", "end": "2019-12-03 20:03:35.139837", "failed_when_result": false, "rc": 0, "start": "2019-12-03 20:03:33.519998", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "backup.ttbl                                        OK", "stdout_lines": ["backup.ttbl                                        OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-12-03T20:03:35.287127 (delta: 2.111006)         elapsed: 376.225568 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-755f6678bf-s2vzb -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' backup;", "delta": "0:00:01.366926", "end": "2019-12-03 20:03:37.036158", "failed_when_result": false, "rc": 0, "start": "2019-12-03 20:03:35.669232", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-12-03T20:03:37.107315 (delta: 1.820074)         elapsed: 378.045756 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-12-03T20:03:37.167050 (delta: 0.059678)         elapsed: 378.105491 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/backup_and_restore/test.yml:146
2019-12-03T20:03:37.228332 (delta: 0.061227)         elapsed: 378.166773 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:154
2019-12-03T20:03:37.319742 (delta: 0.091353)         elapsed: 378.258183 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-03T20:03:37.476152 (delta: 0.156348)         elapsed: 378.414593 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-03T20:03:37.536963 (delta: 0.06075)         elapsed: 378.475404 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-03T20:03:37.603753 (delta: 0.066728)         elapsed: 378.542194 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-03T20:03:37.674580 (delta: 0.070762)         elapsed: 378.613021 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "218cc4cd06f4a20f4ce3c234b033d66800aa02b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9f2161a292cb589ce3599bf99ea6818b", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1575403417.76-61278827823042/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-03T20:03:40.457910 (delta: 2.783253)         elapsed: 381.396351 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.960673", "end": "2019-12-03 20:03:41.855058", "rc": 0, "start": "2019-12-03 20:03:40.894385", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-03T20:03:41.933866 (delta: 1.475818)         elapsed: 382.872307 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-03T19:50:51Z", "generation": 4, "name": "velero-backup-restore", "resourceVersion": "746050", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "35c351d5-1606-11ea-bf7d-005056985283"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

TASK [Deprovisioning Velero server] ********************************************
task path: /experiments/functional/backup_and_restore/test.yml:158
2019-12-03T20:03:43.301918 (delta: 1.367997)         elapsed: 384.240359 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete namespace velero", "delta": "0:00:25.236126", "end": "2019-12-03 20:04:08.988418", "rc": 0, "start": "2019-12-03 20:03:43.752292", "stderr": "", "stderr_lines": [], "stdout": "namespace \"velero\" deleted", "stdout_lines": ["namespace \"velero\" deleted"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=50   changed=39   unreachable=0    failed=0
```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 
 
