### PR TITLE
feat(experiment): Included a litmus experiment to induce the openebs target failure in nfs provisioner

### DIFF
--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/README.md
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/README.md
@@ -1,0 +1,53 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | Storage | K8s Platform |
+| ----- | ------------------------------------------------------------ | ------- | ------------ |
+| Chaos | Kill the cstor target/Jiva controller container and check if gets created again | OpenEBS | Any          |
+
+## Entry-Criteria
+
+- NFS provisioner services are accessible.
+- Application pods that are using NFS provisioner are healthy
+- Application writes are successful 
+
+## Exit-Criteria
+
+- Application services are accessible & pods are healthy
+- Data written prior to chaos is successfully retrieved/read
+- Storage target pods are healthy
+
+### Notes
+
+- Typically used as a disruptive test, to cause loss of access to storage target by killing the containers.
+- The container should be created again and it should be healthy.
+
+## Associated Utils 
+
+- `cstor_target_container_kill.yml`,`cstor_target_failure.yaml`,`jiva_controller_pod_failure.yaml`
+
+## Litmus experiment Environment Variables
+
+### Application
+
+| Parameter        | Description                                                     |
+| ---------------- | --------------------------------------------------------------- |
+| APP_NAMESPACE    | Namespace in which application pods that are using nfs deployed |
+| APP_LABEL        | Unique Labels in `key=value` format of application deployment   |
+| NFS_NAMESPACE    | Namespace in which NFS provisioner pods are deployed            |
+| NFS_LABEL        | Unique Labels in `key=value` format of NFS deployment           | 
+| NFS_PVC          | Name of persistent volume claim used for NFS volume mounts      |
+| TARGET_NAMESPACE | Namespace where OpenEBS is installed                            |
+
+### Chaos 
+
+| Parameter        | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| CHAOS_TYPE       | The type of chaos to be induced.                     |
+| TARGET_CONTAINER | The container against which chaos has to be induced. |
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on OpenEBS data plane and control plane components.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/chaosutil.j2
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/chaosutil.j2
@@ -1,0 +1,18 @@
+{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+  {% if stg_engine is defined and stg_engine == 'cstor' %}
+    {% if chaos_type is defined and chaos_type == 'target-kill' or chaos_type == 'target-zrepl-kill' %}
+      chaosutil: openebs/cstor_target_container_kill.yml
+    {% else %}
+      chaosutil: openebs/cstor_target_failure.yaml
+    {% endif %}
+  {% endif %}
+{% endif %}
+{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+  {% if stg_engine is defined and stg_engine == 'jiva' %}
+    {% if chaos_type is defined and chaos_type == 'jiva-ctrl-kill' %}
+      chaosutil: openebs/jiva_controller_container_kill.yml
+    {% else %}
+      chaosutil: openebs/jiva_controller_pod_failure.yaml
+    {% endif %}
+  {% endif %}
+{% endif %}

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/run_litmus_test.yml
@@ -1,0 +1,78 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: nfs-openebs-target-failure-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: nfs-openebs-target-failure
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+            # Namespace where the NFS provisioner is deployed
+          - name: NFS_NAMESPACE
+            value: ""
+
+            # namespace where the OpenEBS components are deployed
+          - name: TARGET_NAMESPACE
+            value: openebs
+
+            # Label for the NFS provisioner deployment
+          - name: NFS_LABEL
+            value: ""
+
+            # PVC name for the NFS provisioner
+          - name: NFS_PVC
+            value: ""
+
+            # Application(s) namespace that are using NFS volume
+          - name: APP_NAMESPACE
+            value: ""
+
+            # Label for the Application that are using NFS volume
+          - name: APP_LABEL
+            value: ""
+         
+            # Liveness label for the applications that are using NFS volumes
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+            # Liveness namespace for the application that are using NFS volume
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
+       
+          # Specify the container runtime used , to pick the relevant chaos util
+          # Available Container runtimes are docker,condainerd,cri-o
+          - name: CONTAINER_RUNTIME
+            value: docker 
+
+            # CHAOS_TYPE values :  target-zrepl-kill , target-kill , target-delete , jiva-ctrl-kill
+            # For cstor-volume-istgt container kill Use : target-kill
+            # For Volume-mgmt-kill container Use  : target-zrepl-kill
+            # For cstor-target-failure Use    : target-delete
+            # For Jiva-Controller-container-kill Use : jiva-ctrl-kill
+
+          - name: CHAOS_TYPE
+            value: "target-zrepl-kill"
+            
+            # TARGET_CONTAINER values: cstor-volume-mgmt , cstor-istgt
+            # For cstor-volume-istgt container kill use : cstor-istgt
+            # For volume-mgmt-kill container use : cstor-volume-mgmt
+          - name: TARGET_CONTAINER
+            value: "cstor-volume-mgmt"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml
@@ -1,0 +1,109 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /utils/k8s/application_liveness_check.yml
+          when: liveness_label != ''
+
+        - include: test_prerequisites.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact:
+            chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "{{ chaosutil.split('.')[0] }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the NFS provisoner is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ app_namespace }}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        ## STORAGE FAULT INJECTION
+
+        - include: "{{ chaos_util_path }}"
+          app_ns: "{{ namespace }}"
+          target_ns: "{{ target_namespace }}"
+          app_pvc: "{{ pvc }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Wait (soak) for I/O on pools
+          wait_for:
+            timeout: "{{ chaos_duration }}"
+
+        - name: Verify that the NFS provisioner is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ app_namespace }}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /utils/k8s/application_liveness_check.yml
+          when: liveness_label != ''
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "{{ chaosutil.split('.')[0] }}"

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml
@@ -1,0 +1,51 @@
+---
+- name: Identify the storage class used by the PVC
+  shell: >
+    kubectl get pvc {{ pvc }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:spec.storageClassName
+  args:
+    executable: /bin/bash
+  register: storage_class
+
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }}
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
+- name: Record the storage class name
+  set_fact: 
+    sc: "{{ storage_class.stdout }}"
+
+- name: Record the storage provisioner name
+  set_fact:
+    stg_prov: "{{ provisioner.stdout }}"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
+        kubectl get pv {{ pv.stdout }} --no-headers
+        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "openebs.io/provisioner-iscsi"
+
+- name: Identify the chaos util to be invoked 
+  template:
+    src: chaosutil.j2
+    dest: chaosutil.yml

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_vars.yml
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_vars.yml
@@ -1,0 +1,25 @@
+test_name: openebs-target-failure
+
+target_namespace: "{{ lookup('env','TARGET_NAMESPACE') }}"
+
+namespace: "{{ lookup('env','NFS_NAMESPACE') }}"
+
+label: "{{ lookup('env','NFS_LABEL') }}"
+
+pvc: "{{ lookup('env','NFS_PVC') }}"
+
+app_namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+
+chaos_type: "{{ lookup('env','CHAOS_TYPE') }}"
+
+target_container: "{{ lookup('env','TARGET_CONTAINER') }}"
+
+chaos_duration: 120
+
+cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

- Perform the Openebs Target failure of the nfs provisioner

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Oct  7 2019, 17:39:04) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml

PLAY [localhost] ***************************************************************
2019-12-04T06:25:22.558297 (delta: 0.068404)         elapsed: 0.068404 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:2
2019-12-04T06:25:22.576018 (delta: 0.017682)         elapsed: 0.086125 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:12
2019-12-04T06:25:32.765117 (delta: 10.189063)         elapsed: 10.275224 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:2
2019-12-04T06:25:32.868263 (delta: 0.103078)         elapsed: 10.37837 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc nfs-pvc-claim -n app-nfsv4-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.279561", "end": "2019-12-04 06:25:34.678574", "rc": 0, "start": "2019-12-04 06:25:33.399013", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:10
2019-12-04T06:25:34.800384 (delta: 1.932046)         elapsed: 12.310491 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.228308", "end": "2019-12-04 06:25:36.325998", "rc": 0, "start": "2019-12-04 06:25:35.097690", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:18
2019-12-04T06:25:36.418259 (delta: 1.617762)         elapsed: 13.928366 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-disk"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:22
2019-12-04T06:25:36.526976 (delta: 0.10864)         elapsed: 14.037083 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:27
2019-12-04T06:25:36.618584 (delta: 0.091544)         elapsed: 14.128691 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc nfs-pvc-claim -n app-nfsv4-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.086745", "end": "2019-12-04 06:25:37.923476", "rc": 0, "start": "2019-12-04 06:25:36.836731", "stderr": "", "stderr_lines": [], "stdout": "pvc-a5aec6dd-1654-11ea-bf7d-005056985283", "stdout_lines": ["pvc-a5aec6dd-1654-11ea-bf7d-005056985283"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:35
2019-12-04T06:25:37.985703 (delta: 1.367057)         elapsed: 15.49581 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-a5aec6dd-1654-11ea-bf7d-005056985283 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.111516", "end": "2019-12-04 06:25:39.303582", "rc": 0, "start": "2019-12-04 06:25:38.192066", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:43
2019-12-04T06:25:39.422262 (delta: 1.436504)         elapsed: 16.932369 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test_prerequisites.yml:48
2019-12-04T06:25:39.586165 (delta: 0.163813)         elapsed: 17.096272 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d6bb5e73af7539d36671f040517e91ac88e3917f", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "bfe790917eb9487966fda4d055b50cc1", "mode": "0644", "owner": "root", "size": 66, "src": "/root/.ansible/tmp/ansible-tmp-1575440739.64-82931444434288/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:17
2019-12-04T06:25:40.503941 (delta: 0.917713)         elapsed: 18.014048 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_failure.yaml"}, "ansible_included_var_files": ["/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:20
2019-12-04T06:25:40.666985 (delta: 0.162952)         elapsed: 18.177092 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_failure.yaml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:25
2019-12-04T06:25:40.866569 (delta: 0.199499)         elapsed: 18.376676 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-12-04T06:25:41.062906 (delta: 0.196215)         elapsed: 18.573013 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-12-04T06:25:41.138388 (delta: 0.075429)         elapsed: 18.648495 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:27
2019-12-04T06:25:41.251246 (delta: 0.112733)         elapsed: 18.761353 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-04T06:25:41.485218 (delta: 0.233848)         elapsed: 18.995325 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "2e34900561c0eadb85d3373fb6f8476f1219fea1", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f248e61147c9d7f6a2032c947044c29", "mode": "0644", "owner": "root", "size": 451, "src": "/root/.ansible/tmp/ansible-tmp-1575440741.55-57574390037055/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-04T06:25:42.349281 (delta: 0.864011)         elapsed: 19.859388 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.950587", "end": "2019-12-04 06:25:43.677803", "rc": 0, "start": "2019-12-04 06:25:42.727216", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-04T06:25:43.752696 (delta: 1.403344)         elapsed: 21.262803 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-04T06:12:34Z", "generation": 3, "name": "openebs-target-failure", "resourceVersion": "963586", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-failure", "uid": "103207ea-165d-11ea-bf7d-005056985283"}, "spec": {"testMetadata": {"chaostype": "openebs/cstor_target_failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-04T06:25:45.260792 (delta: 1.508013)         elapsed: 22.770899 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-04T06:25:45.331916 (delta: 0.071055)         elapsed: 22.842023 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-04T06:25:45.434245 (delta: 0.102244)         elapsed: 22.944352 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the NFS provisoner is running] *******************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:34
2019-12-04T06:25:45.505949 (delta: 0.07164)         elapsed: 23.016056 ******** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-04T06:25:45.670178 (delta: 0.164174)         elapsed: 23.180285 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-nfsv4-ns -l app=\"nfs\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.194228", "end": "2019-12-04 06:25:47.110870", "rc": 0, "start": "2019-12-04 06:25:45.916642", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-04T05:14:09Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-04T05:14:09Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-04T06:25:47.178467 (delta: 1.508205)         elapsed: 24.688574 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-nfsv4-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"nfs\")].status.phase}'", "delta": "0:00:01.355629", "end": "2019-12-04 06:25:48.756262", "rc": 0, "start": "2019-12-04 06:25:47.400633", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:43
2019-12-04T06:25:48.871634 (delta: 1.693112)         elapsed: 26.381741 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-04T06:25:49.066054 (delta: 0.194331)         elapsed: 26.576161 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n minio -l app=\"minio3\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.251038", "end": "2019-12-04 06:25:50.551559", "rc": 0, "start": "2019-12-04 06:25:49.300521", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-04T06:15:35Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-04T06:15:35Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-04T06:25:50.707008 (delta: 1.640897)         elapsed: 28.217115 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n minio -o jsonpath='{.items[?(@.metadata.labels.app==\"minio3\")].status.phase}'", "delta": "0:00:01.164281", "end": "2019-12-04 06:25:52.354998", "rc": 0, "start": "2019-12-04 06:25:51.190717", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:52
2019-12-04T06:25:52.468649 (delta: 1.761542)         elapsed: 29.978756 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-nfsv4-ns -l app=nfs --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.985298", "end": "2019-12-04 06:25:53.909724", "rc": 0, "start": "2019-12-04 06:25:52.924426", "stderr": "", "stderr_lines": [], "stdout": "nfs-provisioner-5bf99b596c-wd7kk", "stdout_lines": ["nfs-provisioner-5bf99b596c-wd7kk"]}

TASK [include] *****************************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:62
2019-12-04T06:25:54.013358 (delta: 1.544614)         elapsed: 31.523465 ******* 
included: /chaoslib/openebs/cstor_target_failure.yaml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_failure.yaml:1
2019-12-04T06:25:54.230869 (delta: 0.217373)         elapsed: 31.740976 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc nfs-pvc-claim -o custom-columns=:spec.volumeName -n app-nfsv4-ns --no-headers", "delta": "0:00:01.222168", "end": "2019-12-04 06:25:55.704894", "rc": 0, "start": "2019-12-04 06:25:54.482726", "stderr": "", "stderr_lines": [], "stdout": "pvc-a5aec6dd-1654-11ea-bf7d-005056985283", "stdout_lines": ["pvc-a5aec6dd-1654-11ea-bf7d-005056985283"]}

TASK [Record the cstor target deployment of the PV] ****************************
task path: /chaoslib/openebs/cstor_target_failure.yaml:10
2019-12-04T06:25:55.769386 (delta: 1.538465)         elapsed: 33.279493 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_deploy": "pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target"}, "changed": false}

TASK [Get the resourceVersion of the target deploy before fault injection] *****
task path: /chaoslib/openebs/cstor_target_failure.yaml:15
2019-12-04T06:25:55.944625 (delta: 0.175192)         elapsed: 33.454732 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target -n openebs --no-headers -o custom-columns=:.metadata.resourceVersion", "delta": "0:00:01.298993", "end": "2019-12-04 06:25:57.723378", "rc": 0, "start": "2019-12-04 06:25:56.424385", "stderr": "", "stderr_lines": [], "stdout": "935105", "stdout_lines": ["935105"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_failure.yaml:23
2019-12-04T06:25:57.836080 (delta: 1.891333)         elapsed: 35.346187 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-a5aec6dd-1654-11ea-bf7d-005056985283 | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.191147", "end": "2019-12-04 06:25:59.430700", "rc": 0, "start": "2019-12-04 06:25:58.239553", "stderr": "", "stderr_lines": [], "stdout": "pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target-7c5bd5ffd7nwqmx", "stdout_lines": ["pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target-7c5bd5ffd7nwqmx"]}

TASK [Kill the cstor target pod] ***********************************************
task path: /chaoslib/openebs/cstor_target_failure.yaml:32
2019-12-04T06:25:59.501239 (delta: 1.665006)         elapsed: 37.011346 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target-7c5bd5ffd7nwqmx -n openebs --grace-period=0 --force", "delta": "0:00:01.234066", "end": "2019-12-04 06:26:01.014503", "rc": 0, "start": "2019-12-04 06:25:59.780437", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target-7c5bd5ffd7nwqmx\" force deleted", "stdout_lines": ["pod \"pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target-7c5bd5ffd7nwqmx\" force deleted"]}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_failure.yaml:35
2019-12-04T06:26:01.121912 (delta: 1.620597)         elapsed: 38.632019 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Get the resourceVersion of the target deploy after fault injection] ******
task path: /chaoslib/openebs/cstor_target_failure.yaml:39
2019-12-04T06:26:11.793273 (delta: 10.671254)         elapsed: 49.30338 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-a5aec6dd-1654-11ea-bf7d-005056985283-target -n openebs --no-headers -o custom-columns=:.metadata.resourceVersion", "delta": "0:00:01.262060", "end": "2019-12-04 06:26:13.380946", "rc": 0, "start": "2019-12-04 06:26:12.118886", "stderr": "", "stderr_lines": [], "stdout": "963804", "stdout_lines": ["963804"]}

TASK [Compare resourceVersions of target deployment] ***************************
task path: /chaoslib/openebs/cstor_target_failure.yaml:47
2019-12-04T06:26:13.477661 (delta: 1.684283)         elapsed: 50.987768 ******* 
ok: [127.0.0.1] => {
    "msg": "Verified target pods were restarted by fault injection"
}

TASK [Wait (soak) for I/O on pools] ********************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:69
2019-12-04T06:26:13.603373 (delta: 0.125621)         elapsed: 51.11348 ******** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 120, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Verify that the NFS provisioner is running] ******************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:73
2019-12-04T06:28:14.173238 (delta: 120.569775)         elapsed: 171.683345 **** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-04T06:28:14.283766 (delta: 0.110414)         elapsed: 171.793873 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-nfsv4-ns -l app=\"nfs\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.284363", "end": "2019-12-04 06:28:15.830348", "rc": 0, "start": "2019-12-04 06:28:14.545985", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-04T05:14:09Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-04T05:14:09Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-04T06:28:15.988596 (delta: 1.704775)         elapsed: 173.498703 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-nfsv4-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"nfs\")].status.phase}'", "delta": "0:00:01.171876", "end": "2019-12-04 06:28:17.496608", "rc": 0, "start": "2019-12-04 06:28:16.324732", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:82
2019-12-04T06:28:17.610738 (delta: 1.622048)         elapsed: 175.120845 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-04T06:28:17.825175 (delta: 0.214326)         elapsed: 175.335282 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n minio -l app=\"minio3\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.209797", "end": "2019-12-04 06:28:19.308695", "rc": 0, "start": "2019-12-04 06:28:18.098898", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-04T06:15:35Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-04T06:15:35Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-04T06:28:19.468970 (delta: 1.643738)         elapsed: 176.979077 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n minio -o jsonpath='{.items[?(@.metadata.labels.app==\"minio3\")].status.phase}'", "delta": "0:00:01.191814", "end": "2019-12-04 06:28:21.051911", "rc": 0, "start": "2019-12-04 06:28:19.860097", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:92
2019-12-04T06:28:21.215178 (delta: 1.746112)         elapsed: 178.725285 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:95
2019-12-04T06:28:21.388998 (delta: 0.173715)         elapsed: 178.899105 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml:106
2019-12-04T06:28:21.577592 (delta: 0.188422)         elapsed: 179.087699 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-04T06:28:21.809636 (delta: 0.231929)         elapsed: 179.319743 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-04T06:28:21.870310 (delta: 0.060569)         elapsed: 179.380417 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-04T06:28:21.941097 (delta: 0.070726)         elapsed: 179.451204 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-04T06:28:22.074412 (delta: 0.133162)         elapsed: 179.584519 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "7a38ab0cf60a334ab1f36da4aa6d29834d4606b4", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "09f6604346a7b11f14804b011e6fd6d7", "mode": "0644", "owner": "root", "size": 449, "src": "/root/.ansible/tmp/ansible-tmp-1575440902.2-30405838630791/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-04T06:28:25.034938 (delta: 2.960422)         elapsed: 182.545045 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.983098", "end": "2019-12-04 06:28:26.412389", "rc": 0, "start": "2019-12-04 06:28:25.429291", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-04T06:28:26.473995 (delta: 1.438959)         elapsed: 183.984102 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-04T06:12:34Z", "generation": 4, "name": "openebs-target-failure", "resourceVersion": "964698", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-failure", "uid": "103207ea-165d-11ea-bf7d-005056985283"}, "spec": {"testMetadata": {"chaostype": "openebs/cstor_target_failure"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=44   changed=25   unreachable=0    failed=0   

2019-12-04T06:28:27.752589 (delta: 1.27854)         elapsed: 185.262696 ******* 
===============================================================================
```