### PR TITLE
feat[yaml]: Included litmusbook for deployment of minio

### DIFF
--- a/apps/minio/deployers/minio-pvc.yml
+++ b/apps/minio/deployers/minio-pvc.yml
@@ -21,7 +21,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: testclaim
   labels:
-    app: minio-storage-claim
+    lkey: lvalue
 spec:
   storageClassName: testclass 
   accessModes:

--- a/apps/minio/deployers/minio-pvc.yml
+++ b/apps/minio/deployers/minio-pvc.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+  labels:
+    lkey: lvalue
+spec:
+  ports:
+    - port: 9000
+    #  nodePort: 32703
+      protocol: TCP
+  selector:
+    lkey: lvalue
+  sessionAffinity: None
+  type: NodePort
+  
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: testclaim
+  labels:
+    app: minio-storage-claim
+spec:
+  storageClassName: testclass 
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: volume-capacity

--- a/apps/minio/deployers/minio.yml
+++ b/apps/minio/deployers/minio.yml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-deployment
+spec:
+  selector:
+    matchLabels: 
+      lkey: lvalue
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        lkey: lvalue
+    spec:
+      # Refer to the PVC created earlier
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+                claimName: testclaim
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio
+        args:
+        - server
+        - /storage1
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: data-vol # must match the volume name, above
+          mountPath: "/storage1"

--- a/apps/minio/deployers/minio.yml
+++ b/apps/minio/deployers/minio.yml
@@ -28,6 +28,14 @@ spec:
         args:
         - server
         - /storage1
+        livenessProbe:
+          exec:
+            command: 
+            - /bin/sh
+            - -c
+            - touch /storage1/healthy; sleep 2; rm -rf /storage1/healthy;
+          initialDelaySeconds: 5
+          periodSeconds: 5
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY

--- a/apps/minio/deployers/minio_prerequisite.yml
+++ b/apps/minio/deployers/minio_prerequisite.yml
@@ -1,0 +1,70 @@
+---
+- name: copy the deployment spec to modify the specific values
+  shell: cp minio.yml minio-{{item}}.yml
+  args:
+    executable: /bin/bash
+
+- name: Get the application label values from env
+  set_fact:
+    app_lkey: "{{ app_label.split('=')[0] }}"
+    app_lvalue: "{{ app_label.split('=')[1] }}-{{item}}"
+
+- name: Replace the application label placeholder in deployment spec
+  replace:
+    path: minio-{{item}}.yml
+    regexp: "lkey: lvalue"
+    replace: "{{ app_lkey }}: {{ app_lvalue }}"
+
+- name: Replace the PVC name placeholder with PVC created earlier
+  replace:
+      path: minio-{{item}}.yml
+      regexp: "testclaim"
+      replace: "{{ lookup('env','APP_PVC') }}"
+
+- name: modify the Deployment name appended with number generated earlier
+  replace:
+      path: minio-{{item}}.yml
+      regexp: "minio-deployment"
+      replace: minio-deployment-{{item}}
+
+- name: print the specific spec
+  shell: cat minio-{{item}}.yml   
+
+
+- block:
+
+    - name: Applying the deployment spec
+      shell: kubectl apply -f minio-{{item}}.yml -n {{ app_ns }}
+
+    - name: Check the pod status
+      shell: >
+        kubectl get pods -n {{ app_ns }} -l "{{ app_lkey }}={{ app_lvalue }}" --no-headers
+        -o custom-columns=:status.phase
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'Running' in result.stdout"
+      delay: 30
+      retries: 15
+  when: lookup('env','ACTION') == 'provision'
+
+- block: 
+
+    - name: Deleting the deployment with spec
+      shell: kubectl delete -f minio-{{item}}.yml -n {{ app_ns }}
+      args:
+        executable: /bin/bash
+      register: status
+      failed_when: "status.rc != 0"
+    
+    ## verify if the pod is deleted
+    - name: Check if the pod is deleted successfully
+      shell: >
+        kubectl get po -n {{ app_ns }} -l "{{ app_lkey }}={{ app_lvalue }}" --no-headers 
+      args:
+        executable: /bin/bash
+      register: result
+      until: "result.stdout == ''"
+      delay: 30
+      retries: 15  
+  when: lookup('env','ACTION') == 'deprovision'

--- a/apps/minio/deployers/minio_prerequisites.yml
+++ b/apps/minio/deployers/minio_prerequisites.yml
@@ -15,12 +15,6 @@
     regexp: "lkey: lvalue"
     replace: "{{ app_lkey }}: {{ app_lvalue }}"
 
-- name: Replace the PVC name placeholder with PVC created earlier
-  replace:
-      path: minio-{{item}}.yml
-      regexp: "testclaim"
-      replace: "{{ lookup('env','APP_PVC') }}"
-
 - name: modify the Deployment name appended with number generated earlier
   replace:
       path: minio-{{item}}.yml
@@ -30,11 +24,14 @@
 - name: print the specific spec
   shell: cat minio-{{item}}.yml   
 
-
 - block:
 
     - name: Applying the deployment spec
       shell: kubectl apply -f minio-{{item}}.yml -n {{ app_ns }}
+      args:
+        executable: /bin/bash
+      register: status
+      failed_when: "status.rc != 0"
 
     - name: Check the pod status
       shell: >
@@ -60,7 +57,7 @@
     ## verify if the pod is deleted
     - name: Check if the pod is deleted successfully
       shell: >
-        kubectl get po -n {{ app_ns }} -l "{{ app_lkey }}={{ app_lvalue }}" --no-headers 
+        kubectl get pods -n {{ app_ns }} -l "{{ app_lkey }}={{ app_lvalue }}" --no-headers 
       args:
         executable: /bin/bash
       register: result

--- a/apps/minio/deployers/run_litmus_test.yml
+++ b/apps/minio/deployers/run_litmus_test.yml
@@ -55,7 +55,7 @@ spec:
            # Access mode for pvc
            # For RWM use 'ReadWriteMany'
           - name: ACCESS_MODE
-            value: 'ReadWriteOnce'  
+            value: 'ReadWriteMany'  
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/minio/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/minio/deployers/run_litmus_test.yml
+++ b/apps/minio/deployers/run_litmus_test.yml
@@ -48,8 +48,14 @@ spec:
           - name: CAPACITY
             value: 5Gi
 
+           # Number of minio deployments to be created
           - name: DEPLOY_COUNT
             value: '4'
+           
+           # Access mode for pvc
+           # For RWM use 'ReadWriteMany'
+          - name: ACCESS_MODE
+            value: 'ReadWriteOnce'  
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./apps/minio/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/minio/deployers/run_litmus_test.yml
+++ b/apps/minio/deployers/run_litmus_test.yml
@@ -53,7 +53,7 @@ spec:
             value: '4'
            
            # Access mode for pvc
-           # For RWM use 'ReadWriteMany'
+           # For RWM use 'ReadWriteMany' and For RWO use 'ReadWriteOnce'
           - name: ACCESS_MODE
             value: 'ReadWriteMany'  
 

--- a/apps/minio/deployers/run_litmus_test.yml
+++ b/apps/minio/deployers/run_litmus_test.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-minio-deployment-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: minio-litmus
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+            # storage class to deploy wordpress
+          - name: PROVIDER_STORAGE_CLASS
+            value: ''
+     
+            # Application PVC name for minio deployment
+          - name: APP_PVC
+            value: minio-pv-claim
+
+            # Application label
+          - name: APP_LABEL
+            value: 'name=minio'
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-minio-ns 
+
+            # Use 'deprovision' for app-clean up
+          - name: ACTION
+            value: 'provision'
+
+           # PV capacity for minio  
+          - name: CAPACITY
+            value: 5Gi
+
+          - name: DEPLOY_COUNT
+            value: '4'
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./apps/minio/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/minio/deployers/test.yml
+++ b/apps/minio/deployers/test.yml
@@ -1,0 +1,142 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+         
+        - block: 
+            - name: Check whether the provider storageclass is applied
+              k8s_facts:
+                kind: StorageClass
+                name: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+              register: result
+              failed_when: result.resources | length < 1
+
+              # Creating namespace
+            - include_tasks: /utils/k8s/create_ns.yml
+
+            - name: Get the application label values from env
+              set_fact:
+                app_lkey: "{{ app_label.split('=')[0] }}"
+                app_lvalue: "{{ app_label.split('=')[1] }}"
+
+            - name: Replace the application label placeholder in service spec
+              replace:
+                path: "{{ pvc_deployment }}"
+                regexp: "lkey: lvalue"
+                replace: "{{ app_lkey }}: {{ app_lvalue }}"
+
+            - name: Replace the storage capacity placeholder
+              replace:
+                  path: "{{ pvc_deployment }}"
+                  regexp: "volume-capacity"
+                  replace: "{{ lookup('env','CAPACITY') }}" 
+
+            - name: Replace the storage class placeholder
+              replace:
+                  path: "{{ pvc_deployment }}"
+                  regexp: "testclass"
+                  replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}" 
+
+            - name: Replace the PVC name placeholder
+              replace:
+                  path: "{{ pvc_deployment }}"
+                  regexp: "testclaim"
+                  replace: "{{ lookup('env','APP_PVC') }}"
+
+            - name: Applying the pvc
+              shell: kubectl apply -f minio-pvc.yml -n {{ app_ns }}
+            
+            - name: Checking the status of PVC
+              shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.status.phase}'
+              register: pvc_status
+              until: "'Bound' in pvc_status.stdout"
+              delay: 30
+              retries: 15
+
+          when: lookup('env','ACTION') == 'provision'      
+      
+      ## create and delete the deployments according to action
+        - include_tasks: ./minio_prerequisite.yml
+          loop: "{{ range(0, deploy_count | int, 1)|list }}"
+
+        - block:
+            ## verify and delete the pvc 
+            - name: delete the pvc
+              shell: >
+                kubectl delete pvc {{ app_pvc }} -n {{ app_ns }} 
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            ## verify if the pvc is deleted
+            - name: check if the cloned pvc is deleted
+              shell: >
+                kubectl get pvc -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: pvc_name
+              until: "app_pvc not in pvc_name.stdout"
+              delay: 30
+              retries: 15   
+            
+            - name: Delete the service
+              shell: kubectl delete service minio-service -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - name: Check if the service is deleted successfully
+              shell: >
+                kubectl get service -n {{ app_ns }} -l "{{ app_lkey }}={{ app_lvalue }}" --no-headers 
+              args:
+                executable: /bin/bash
+              register: result
+              until: "result.stdout == ''"
+              delay: 30
+              retries: 15  
+
+            - name: Delete the namespace.
+              k8s:
+                state: absent
+                kind: Namespace
+                name: "{{ app_ns }}"
+
+            - name: Check if the namespace is deleted successfully
+              shell: kubectl get ns 
+              args:
+                executable: /bin/bash
+              register: result
+              until: "app_ns not in result.stdout"
+              delay: 30
+              retries: 15  
+                
+          when: lookup('env','ACTION') == 'deprovision'
+
+        - set_fact:
+                flag: "Pass"  
+         
+      rescue:
+        - set_fact:
+            flag: "Fail"     
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+              

--- a/apps/minio/deployers/test.yml
+++ b/apps/minio/deployers/test.yml
@@ -16,6 +16,47 @@
           vars:
             status: 'SOT'
          
+        - name: Get the application label values from env
+          set_fact:
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+
+        - name: Replace the application label placeholder in service spec
+          replace:
+            path: "{{ pvc_deployment }}"
+            regexp: "lkey: lvalue"
+            replace: "{{ app_lkey }}: {{ app_lvalue }}"
+
+        - name: Replace the storage capacity placeholder
+          replace:
+              path: "{{ pvc_deployment }}"
+              regexp: "volume-capacity"
+              replace: "{{ lookup('env','CAPACITY') }}" 
+
+        - name: Replace the storage class placeholder
+          replace:
+              path: "{{ pvc_deployment }}"
+              regexp: "testclass"
+              replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}" 
+
+        - name: Replace the PVC name placeholder
+          replace:
+              path: "{{ pvc_deployment }}"
+              regexp: "testclaim"
+              replace: "{{ lookup('env','APP_PVC') }}"
+
+        - name: Replace the PVC access method placeholder
+          replace:
+              path: "{{ pvc_deployment }}"
+              regexp: "ReadWriteOnce"
+              replace: "{{ lookup('env','ACCESS_MODE') }}"
+ 
+        - name: Replace the PVC name placeholder with PVC created earlier
+          replace:
+              path: "{{ application_deployment }}"
+              regexp: "testclaim"
+              replace: "{{ lookup('env','APP_PVC') }}"
+
         - block: 
             - name: Check whether the provider storageclass is applied
               k8s_facts:
@@ -26,39 +67,14 @@
 
               # Creating namespace
             - include_tasks: /utils/k8s/create_ns.yml
-
-            - name: Get the application label values from env
-              set_fact:
-                app_lkey: "{{ app_label.split('=')[0] }}"
-                app_lvalue: "{{ app_label.split('=')[1] }}"
-
-            - name: Replace the application label placeholder in service spec
-              replace:
-                path: "{{ pvc_deployment }}"
-                regexp: "lkey: lvalue"
-                replace: "{{ app_lkey }}: {{ app_lvalue }}"
-
-            - name: Replace the storage capacity placeholder
-              replace:
-                  path: "{{ pvc_deployment }}"
-                  regexp: "volume-capacity"
-                  replace: "{{ lookup('env','CAPACITY') }}" 
-
-            - name: Replace the storage class placeholder
-              replace:
-                  path: "{{ pvc_deployment }}"
-                  regexp: "testclass"
-                  replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}" 
-
-            - name: Replace the PVC name placeholder
-              replace:
-                  path: "{{ pvc_deployment }}"
-                  regexp: "testclaim"
-                  replace: "{{ lookup('env','APP_PVC') }}"
-
+            
             - name: Applying the pvc
               shell: kubectl apply -f minio-pvc.yml -n {{ app_ns }}
-            
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
             - name: Checking the status of PVC
               shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.status.phase}'
               register: pvc_status
@@ -67,23 +83,22 @@
               retries: 15
 
           when: lookup('env','ACTION') == 'provision'      
-      
+              
       ## create and delete the deployments according to action
-        - include_tasks: ./minio_prerequisite.yml
+        - include_tasks: ./minio_prerequisites.yml
           loop: "{{ range(0, deploy_count | int, 1)|list }}"
 
         - block:
-            ## verify and delete the pvc 
-            - name: delete the pvc
-              shell: >
-                kubectl delete pvc {{ app_pvc }} -n {{ app_ns }} 
+            ## verify and delete the pvc and service
+            - name: Deleting the PVC and service
+              shell: kubectl delete -f minio-pvc.yml -n {{ app_ns }}
               args:
                 executable: /bin/bash
               register: status
               failed_when: "status.rc != 0"
 
             ## verify if the pvc is deleted
-            - name: check if the cloned pvc is deleted
+            - name: check if the pvc is deleted successfully
               shell: >
                 kubectl get pvc -n {{ app_ns }}
               args:
@@ -92,14 +107,7 @@
               until: "app_pvc not in pvc_name.stdout"
               delay: 30
               retries: 15   
-            
-            - name: Delete the service
-              shell: kubectl delete service minio-service -n {{ app_ns }}
-              args:
-                executable: /bin/bash
-              register: status
-              failed_when: "status.rc != 0"
-
+                        
             - name: Check if the service is deleted successfully
               shell: >
                 kubectl get service -n {{ app_ns }} -l "{{ app_lkey }}={{ app_lvalue }}" --no-headers 

--- a/apps/minio/deployers/test_vars.yml
+++ b/apps/minio/deployers/test_vars.yml
@@ -1,13 +1,12 @@
-# Test-specific parametres
-
+# Test-specific parameters
+application_deployment: minio.yml
 pvc_deployment: minio-pvc.yml
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
-operator_ns: 'openebs'
 app_label: "{{ lookup('env','APP_LABEL') }}"
 test_name: minio-deployment
-application_name: "minio"
 action: "{{ lookup('env','ACTION') }}"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 capacity: "{{ lookup('env','CAPACITY') }}"
 deploy_count: "{{ lookup('env','DEPLOY_COUNT') }}"
+access_mode: "{{ lookup('env','ACCESS_MODE') }}"

--- a/apps/minio/deployers/test_vars.yml
+++ b/apps/minio/deployers/test_vars.yml
@@ -1,0 +1,13 @@
+# Test-specific parametres
+
+pvc_deployment: minio-pvc.yml
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+operator_ns: 'openebs'
+app_label: "{{ lookup('env','APP_LABEL') }}"
+test_name: minio-deployment
+application_name: "minio"
+action: "{{ lookup('env','ACTION') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+capacity: "{{ lookup('env','CAPACITY') }}"
+deploy_count: "{{ lookup('env','DEPLOY_COUNT') }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Included litmusbook for provisioning and deprovisioning of minio
**Special notes for your reviewer**:
logs for minio deployment with deploy_count=4
```
PLAY [localhost] ***************************************************************
2019-12-05T07:19:18.694434 (delta: 0.119082)         elapsed: 0.119082 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-12-05T07:19:18.718845 (delta: 0.024321)         elapsed: 0.143493 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-12-05T07:19:34.785171 (delta: 16.06627)         elapsed: 16.209819 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-12-05T07:19:34.958857 (delta: 0.173602)         elapsed: 16.383505 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-12-05T07:19:35.110386 (delta: 0.151456)         elapsed: 16.535034 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-05T07:19:35.269427 (delta: 0.158952)         elapsed: 16.694075 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-05T07:19:35.495120 (delta: 0.225586)         elapsed: 16.919768 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "2bf332f35fd0895e0cf297de6da4decc3aec5d86", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a887782fae455881048e40d3063c9155", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1575530375.61-24187228883096/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:19:36.746435 (delta: 1.251181)         elapsed: 18.171083 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.492344", "end": "2019-12-05 07:19:38.820693", "rc": 0, "start": "2019-12-05 07:19:37.328349", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: minio-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: minio-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:19:38.912032 (delta: 2.165524)         elapsed: 20.33668 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-05T05:15:27Z", "generation": 15, "name": "minio-deployment", "resourceVersion": "847701", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/minio-deployment", "uid": "4170eb24-d231-4628-8fe1-cd13fcf286bd"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-05T07:19:40.730077 (delta: 1.817972)         elapsed: 22.154725 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:19:40.863333 (delta: 0.133175)         elapsed: 22.287981 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:19:40.959403 (delta: 0.095989)         elapsed: 22.384051 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2019-12-05T07:19:41.068271 (delta: 0.108781)         elapsed: 22.492919 ******* 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "resources": [{"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass", "metadata": {"creationTimestamp": "2019-12-05T05:08:57Z", "name": "openebs-nfs", "resourceVersion": "754822", "selfLink": "/apis/storage.k8s.io/v1/storageclasses/openebs-nfs", "uid": "f2e33118-6227-45d8-a681-31d8f319bcdb"}, "parameters": {"mountOptions": "vers=4.1"}, "provisioner": "openebs.io/nfs", "reclaimPolicy": "Delete", "volumeBindingMode": "Immediate"}]}

TASK [include_tasks] ***********************************************************
2019-12-05T07:19:42.899577 (delta: 1.831229)         elapsed: 24.324225 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-12-05T07:19:43.144355 (delta: 0.244697)         elapsed: 24.569003 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.932685", "end": "2019-12-05 07:19:45.460596", "rc": 0, "start": "2019-12-05 07:19:43.527911", "stderr": "", "stderr_lines": [], "stdout": "app-nfs-ns\napp-nfsv4-ns\napp-scale\napp-scale-jiva\napp-wordpress-ns\nbusybox\nbusybox-csi\nbusybox-jiva-snap\nbusybox-snap\ncas-performance\ncert-manager\ndefault\ne2e\nfio\nfio-jiva\njiva-openebs-ns\njiva-replica-scaleup\nkommander\nkube-node-lease\nkube-public\nkube-system\nkubeaddons\nlitmus\nlogging\nmemleak-jiva\nopenebs\npost-rebuild\ntarget-delay\ntarget-loss", "stdout_lines": ["app-nfs-ns", "app-nfsv4-ns", "app-scale", "app-scale-jiva", "app-wordpress-ns", "busybox", "busybox-csi", "busybox-jiva-snap", "busybox-snap", "cas-performance", "cert-manager", "default", "e2e", "fio", "fio-jiva", "jiva-openebs-ns", "jiva-replica-scaleup", "kommander", "kube-node-lease", "kube-public", "kube-system", "kubeaddons", "litmus", "logging", "memleak-jiva", "openebs", "post-rebuild", "target-delay", "target-loss"]}

TASK [Create test specific namespace.] *****************************************
2019-12-05T07:19:45.618333 (delta: 2.473891)         elapsed: 27.042981 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-minio-ns", "delta": "0:00:01.748662", "end": "2019-12-05 07:19:47.747641", "rc": 0, "start": "2019-12-05 07:19:45.998979", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-minio-ns created", "stdout_lines": ["namespace/app-minio-ns created"]}

TASK [include_tasks] ***********************************************************
2019-12-05T07:19:47.923912 (delta: 2.30548)         elapsed: 29.34856 ********* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-12-05T07:19:48.235519 (delta: 0.31148)         elapsed: 29.660167 ******** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2019-12-05T07:19:47Z", "name": "app-minio-ns", "resourceVersion": "847794", "selfLink": "/api/v1/namespaces/app-minio-ns", "uid": "abd3e2d8-dd74-42d7-bea3-02163b1e9462"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [Get the application label values from env] *******************************
2019-12-05T07:19:49.882690 (delta: 1.647042)         elapsed: 31.307338 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio"}, "changed": false}

TASK [Replace the application label placeholder in service spec] ***************
2019-12-05T07:19:50.283785 (delta: 0.401004)         elapsed: 31.708433 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storage capacity placeholder] ********************************
2019-12-05T07:19:50.977800 (delta: 0.693924)         elapsed: 32.402448 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the storage class placeholder] ***********************************
2019-12-05T07:19:51.413853 (delta: 0.435973)         elapsed: 32.838501 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the PVC name placeholder] ****************************************
2019-12-05T07:19:51.933350 (delta: 0.51942)         elapsed: 33.357998 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Applying the pvc] ********************************************************
2019-12-05T07:19:52.408542 (delta: 0.475095)         elapsed: 33.83319 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f minio-pvc.yml -n app-minio-ns", "delta": "0:00:02.227588", "end": "2019-12-05 07:19:54.959748", "rc": 0, "start": "2019-12-05 07:19:52.732160", "stderr": "", "stderr_lines": [], "stdout": "service/minio-service created\npersistentvolumeclaim/minio-pv-claim created", "stdout_lines": ["service/minio-service created", "persistentvolumeclaim/minio-pv-claim created"]}

TASK [Checking the status of PVC] **********************************************
2019-12-05T07:19:55.113839 (delta: 2.705193)         elapsed: 36.538487 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc minio-pv-claim -n app-minio-ns -o jsonpath='{.status.phase}'", "delta": "0:00:01.839732", "end": "2019-12-05 07:19:57.415007", "rc": 0, "start": "2019-12-05 07:19:55.575275", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [include_tasks] ***********************************************************
2019-12-05T07:19:57.545795 (delta: 2.431837)         elapsed: 38.970443 ******* 
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=0)
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=1)
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=2)
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=3)

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:19:57.929524 (delta: 0.383644)         elapsed: 39.354172 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-0.yml", "delta": "0:00:01.268912", "end": "2019-12-05 07:19:59.505507", "rc": 0, "start": "2019-12-05 07:19:58.236595", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:19:59.601269 (delta: 1.671624)         elapsed: 41.025917 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-0"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:19:59.788394 (delta: 0.18703)         elapsed: 41.213042 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:20:00.249897 (delta: 0.461414)         elapsed: 41.674545 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:20:00.681461 (delta: 0.431488)         elapsed: 42.106109 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:20:01.141168 (delta: 0.459629)         elapsed: 42.565816 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-0.yml", "delta": "0:00:01.339439", "end": "2019-12-05 07:20:02.794549", "rc": 0, "start": "2019-12-05 07:20:01.455110", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-0\nspec:\n  selector:\n    matchLabels: \n      name: minio-0\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-0\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-0", "spec:", "  selector:", "    matchLabels: ", "      name: minio-0", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-0", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:20:02.911161 (delta: 1.76979)         elapsed: 44.335809 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f minio-0.yml -n app-minio-ns", "delta": "0:00:02.159533", "end": "2019-12-05 07:20:05.378770", "rc": 0, "start": "2019-12-05 07:20:03.219237", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/minio-deployment-0 created", "stdout_lines": ["deployment.apps/minio-deployment-0 created"]}

TASK [Check the pod status] ****************************************************
2019-12-05T07:20:05.501513 (delta: 2.590223)         elapsed: 46.926161 ******* 
FAILED - RETRYING: Check the pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n app-minio-ns -l \"name=minio-0\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.566337", "end": "2019-12-05 07:20:39.469972", "rc": 0, "start": "2019-12-05 07:20:37.903635", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:20:39.625360 (delta: 34.123769)         elapsed: 81.050008 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:20:39.813665 (delta: 0.188208)         elapsed: 81.238313 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:20:39.995951 (delta: 0.182183)         elapsed: 81.420599 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-1.yml", "delta": "0:00:01.352474", "end": "2019-12-05 07:20:41.799003", "rc": 0, "start": "2019-12-05 07:20:40.446529", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:20:41.913435 (delta: 1.917381)         elapsed: 83.338083 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-1"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:20:42.120285 (delta: 0.206778)         elapsed: 83.544933 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:20:42.569731 (delta: 0.449364)         elapsed: 83.994379 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:20:43.130954 (delta: 0.561127)         elapsed: 84.555602 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:20:43.615030 (delta: 0.483977)         elapsed: 85.039678 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-1.yml", "delta": "0:00:01.428345", "end": "2019-12-05 07:20:45.371498", "rc": 0, "start": "2019-12-05 07:20:43.943153", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-1\nspec:\n  selector:\n    matchLabels: \n      name: minio-1\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-1\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-1", "spec:", "  selector:", "    matchLabels: ", "      name: minio-1", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-1", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:20:45.499219 (delta: 1.884089)         elapsed: 86.923867 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f minio-1.yml -n app-minio-ns", "delta": "0:00:01.973289", "end": "2019-12-05 07:20:47.838882", "rc": 0, "start": "2019-12-05 07:20:45.865593", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/minio-deployment-1 created", "stdout_lines": ["deployment.apps/minio-deployment-1 created"]}

TASK [Check the pod status] ****************************************************
2019-12-05T07:20:47.988697 (delta: 2.489376)         elapsed: 89.413345 ******* 
FAILED - RETRYING: Check the pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n app-minio-ns -l \"name=minio-1\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.639314", "end": "2019-12-05 07:21:21.981930", "rc": 0, "start": "2019-12-05 07:21:20.342616", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:21:22.108318 (delta: 34.11952)         elapsed: 123.532966 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:21:22.257855 (delta: 0.149462)         elapsed: 123.682503 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:21:22.393722 (delta: 0.135786)         elapsed: 123.81837 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-2.yml", "delta": "0:00:01.396857", "end": "2019-12-05 07:21:24.106830", "rc": 0, "start": "2019-12-05 07:21:22.709973", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:21:24.215253 (delta: 1.821453)         elapsed: 125.639901 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-2"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:21:24.443133 (delta: 0.22777)         elapsed: 125.867781 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:21:24.959397 (delta: 0.516126)         elapsed: 126.384045 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:21:25.493121 (delta: 0.533625)         elapsed: 126.917769 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:21:26.072121 (delta: 0.578867)         elapsed: 127.496769 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-2.yml", "delta": "0:00:01.464642", "end": "2019-12-05 07:21:27.889363", "rc": 0, "start": "2019-12-05 07:21:26.424721", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-2\nspec:\n  selector:\n    matchLabels: \n      name: minio-2\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-2\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-2", "spec:", "  selector:", "    matchLabels: ", "      name: minio-2", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-2", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:21:28.008611 (delta: 1.936382)         elapsed: 129.433259 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f minio-2.yml -n app-minio-ns", "delta": "0:00:01.788734", "end": "2019-12-05 07:21:30.138875", "rc": 0, "start": "2019-12-05 07:21:28.350141", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/minio-deployment-2 created", "stdout_lines": ["deployment.apps/minio-deployment-2 created"]}

TASK [Check the pod status] ****************************************************
2019-12-05T07:21:30.246934 (delta: 2.23823)         elapsed: 131.671582 ******* 
FAILED - RETRYING: Check the pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n app-minio-ns -l \"name=minio-2\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.687670", "end": "2019-12-05 07:22:04.244981", "rc": 0, "start": "2019-12-05 07:22:02.557311", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:22:04.346996 (delta: 34.099983)         elapsed: 165.771644 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:22:04.482551 (delta: 0.135481)         elapsed: 165.907199 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:22:04.634569 (delta: 0.151939)         elapsed: 166.059217 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-3.yml", "delta": "0:00:01.474653", "end": "2019-12-05 07:22:06.475673", "rc": 0, "start": "2019-12-05 07:22:05.001020", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:22:06.593055 (delta: 1.958389)         elapsed: 168.017703 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-3"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:22:06.765347 (delta: 0.172194)         elapsed: 168.189995 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:22:07.227547 (delta: 0.462125)         elapsed: 168.652195 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:22:07.705284 (delta: 0.477652)         elapsed: 169.129932 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:22:08.388246 (delta: 0.682878)         elapsed: 169.812894 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-3.yml", "delta": "0:00:01.393325", "end": "2019-12-05 07:22:10.143641", "rc": 0, "start": "2019-12-05 07:22:08.750316", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-3\nspec:\n  selector:\n    matchLabels: \n      name: minio-3\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-3\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-3", "spec:", "  selector:", "    matchLabels: ", "      name: minio-3", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-3", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:22:10.241914 (delta: 1.853575)         elapsed: 171.666562 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f minio-3.yml -n app-minio-ns", "delta": "0:00:01.881074", "end": "2019-12-05 07:22:12.469865", "rc": 0, "start": "2019-12-05 07:22:10.588791", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/minio-deployment-3 created", "stdout_lines": ["deployment.apps/minio-deployment-3 created"]}

TASK [Check the pod status] ****************************************************
2019-12-05T07:22:12.598248 (delta: 2.356255)         elapsed: 174.022896 ****** 
FAILED - RETRYING: Check the pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n app-minio-ns -l \"name=minio-3\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.750143", "end": "2019-12-05 07:22:47.630530", "rc": 0, "start": "2019-12-05 07:22:45.880387", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:22:47.771944 (delta: 35.173611)         elapsed: 209.196592 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:22:47.918430 (delta: 0.146404)         elapsed: 209.343078 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [delete the pvc] **********************************************************
2019-12-05T07:22:48.102214 (delta: 0.183665)         elapsed: 209.526862 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if the cloned pvc is deleted] **************************************
2019-12-05T07:22:48.250880 (delta: 0.148568)         elapsed: 209.675528 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the service] ******************************************************
2019-12-05T07:22:48.401200 (delta: 0.150239)         elapsed: 209.825848 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the service is deleted successfully] ****************************
2019-12-05T07:22:48.528696 (delta: 0.127418)         elapsed: 209.953344 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the namespace.] ***************************************************
2019-12-05T07:22:48.655386 (delta: 0.126607)         elapsed: 210.080034 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the namespace is deleted successfully] **************************
2019-12-05T07:22:48.775141 (delta: 0.119668)         elapsed: 210.199789 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-12-05T07:22:48.917943 (delta: 0.142663)         elapsed: 210.342591 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-12-05T07:22:49.110782 (delta: 0.192749)         elapsed: 210.53543 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-05T07:22:49.428734 (delta: 0.317784)         elapsed: 210.853382 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:22:49.608870 (delta: 0.180007)         elapsed: 211.033518 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:22:49.765449 (delta: 0.156452)         elapsed: 211.190097 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-05T07:22:49.916408 (delta: 0.150834)         elapsed: 211.341056 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4cbb1ca916b83e2015659a0b63f04bf25e478212", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a7d337d3c8093afc0c2c2ed82f6f5f21", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1575530570.04-176622525198374/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:22:53.699671 (delta: 3.783162)         elapsed: 215.124319 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.397950", "end": "2019-12-05 07:22:55.411108", "rc": 0, "start": "2019-12-05 07:22:54.013158", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: minio-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: minio-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:22:55.561079 (delta: 1.861326)         elapsed: 216.985727 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-05T05:15:27Z", "generation": 16, "name": "minio-deployment", "resourceVersion": "850136", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/minio-deployment", "uid": "4170eb24-d231-4628-8fe1-cd13fcf286bd"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=60   changed=42   unreachable=0    failed=0   

2019-12-05T07:22:57.219953 (delta: 1.658783)         elapsed: 218.644601 ****** 
=============================================================================== 
```

logs for deprovision of minio with deploy_count=4
```
PLAY [localhost] ***************************************************************
2019-12-05T07:25:15.422442 (delta: 0.091397)         elapsed: 0.091397 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-12-05T07:25:15.442602 (delta: 0.020079)         elapsed: 0.111557 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-12-05T07:25:30.758221 (delta: 15.315572)         elapsed: 15.427176 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-12-05T07:25:30.924391 (delta: 0.166108)         elapsed: 15.593346 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-12-05T07:25:31.047417 (delta: 0.122936)         elapsed: 15.716372 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-05T07:25:31.204219 (delta: 0.156711)         elapsed: 15.873174 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-05T07:25:31.416757 (delta: 0.212448)         elapsed: 16.085712 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "2bf332f35fd0895e0cf297de6da4decc3aec5d86", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a887782fae455881048e40d3063c9155", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1575530731.49-247611715982090/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:25:32.556740 (delta: 1.139907)         elapsed: 17.225695 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.430467", "end": "2019-12-05 07:25:34.600860", "rc": 0, "start": "2019-12-05 07:25:33.170393", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: minio-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: minio-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:25:34.699656 (delta: 2.142837)         elapsed: 19.368611 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-05T05:15:27Z", "generation": 17, "name": "minio-deployment", "resourceVersion": "852025", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/minio-deployment", "uid": "4170eb24-d231-4628-8fe1-cd13fcf286bd"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-05T07:25:36.648270 (delta: 1.948539)         elapsed: 21.317225 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:25:36.811363 (delta: 0.162995)         elapsed: 21.480318 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:25:36.918147 (delta: 0.106682)         elapsed: 21.587102 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2019-12-05T07:25:37.022967 (delta: 0.104719)         elapsed: 21.691922 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-05T07:25:37.160922 (delta: 0.137868)         elapsed: 21.829877 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2019-12-05T07:25:37.281207 (delta: 0.120181)         elapsed: 21.950162 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the application label placeholder in service spec] ***************
2019-12-05T07:25:37.426347 (delta: 0.145048)         elapsed: 22.095302 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the storage capacity placeholder] ********************************
2019-12-05T07:25:37.591359 (delta: 0.164898)         elapsed: 22.260314 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the storage class placeholder] ***********************************
2019-12-05T07:25:37.759773 (delta: 0.16829)         elapsed: 22.428728 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the PVC name placeholder] ****************************************
2019-12-05T07:25:37.924236 (delta: 0.164347)         elapsed: 22.593191 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Applying the pvc] ********************************************************
2019-12-05T07:25:38.108995 (delta: 0.184644)         elapsed: 22.77795 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status of PVC] **********************************************
2019-12-05T07:25:38.271021 (delta: 0.161923)         elapsed: 22.939976 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-05T07:25:38.425304 (delta: 0.154169)         elapsed: 23.094259 ******* 
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=0)
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=1)
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=2)
included: /apps/minio/deployers/minio_prerequisite.yml for 127.0.0.1 => (item=3)

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:25:38.831674 (delta: 0.406228)         elapsed: 23.500629 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-0.yml", "delta": "0:00:01.330259", "end": "2019-12-05 07:25:40.542914", "rc": 0, "start": "2019-12-05 07:25:39.212655", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:25:40.660897 (delta: 1.829139)         elapsed: 25.329852 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-0"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:25:40.878780 (delta: 0.217816)         elapsed: 25.547735 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:25:41.543468 (delta: 0.66458)         elapsed: 26.212423 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:25:42.029896 (delta: 0.486318)         elapsed: 26.698851 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:25:42.525513 (delta: 0.495536)         elapsed: 27.194468 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-0.yml", "delta": "0:00:01.484029", "end": "2019-12-05 07:25:44.333721", "rc": 0, "start": "2019-12-05 07:25:42.849692", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-0\nspec:\n  selector:\n    matchLabels: \n      name: minio-0\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-0\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-0", "spec:", "  selector:", "    matchLabels: ", "      name: minio-0", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-0", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:25:44.438976 (delta: 1.913278)         elapsed: 29.107931 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the pod status] ****************************************************
2019-12-05T07:25:44.570321 (delta: 0.131272)         elapsed: 29.239276 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:25:44.734127 (delta: 0.163707)         elapsed: 29.403082 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f minio-0.yml -n app-minio-ns", "delta": "0:00:01.977494", "end": "2019-12-05 07:25:47.215270", "failed_when_result": false, "rc": 0, "start": "2019-12-05 07:25:45.237776", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"minio-deployment-0\" deleted", "stdout_lines": ["deployment.apps \"minio-deployment-0\" deleted"]}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:25:47.454920 (delta: 2.720637)         elapsed: 32.123875 ******* 
FAILED - RETRYING: Check if the pod is deleted successfully (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n app-minio-ns -l \"name=minio-0\" --no-headers", "delta": "0:00:01.543046", "end": "2019-12-05 07:26:21.381727", "rc": 0, "start": "2019-12-05 07:26:19.838681", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:26:21.497151 (delta: 34.042159)         elapsed: 66.166106 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-1.yml", "delta": "0:00:01.345410", "end": "2019-12-05 07:26:23.166851", "rc": 0, "start": "2019-12-05 07:26:21.821441", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:26:23.270843 (delta: 1.773615)         elapsed: 67.939798 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-1"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:26:23.454181 (delta: 0.183243)         elapsed: 68.123136 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:26:23.888006 (delta: 0.433728)         elapsed: 68.556961 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:26:24.401499 (delta: 0.513384)         elapsed: 69.070454 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:26:24.784506 (delta: 0.382877)         elapsed: 69.453461 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-1.yml", "delta": "0:00:01.373954", "end": "2019-12-05 07:26:26.508699", "rc": 0, "start": "2019-12-05 07:26:25.134745", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-1\nspec:\n  selector:\n    matchLabels: \n      name: minio-1\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-1\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-1", "spec:", "  selector:", "    matchLabels: ", "      name: minio-1", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-1", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:26:26.615213 (delta: 1.830593)         elapsed: 71.284168 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the pod status] ****************************************************
2019-12-05T07:26:26.755967 (delta: 0.140676)         elapsed: 71.424922 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:26:26.901804 (delta: 0.145734)         elapsed: 71.570759 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f minio-1.yml -n app-minio-ns", "delta": "0:00:01.637557", "end": "2019-12-05 07:26:28.901035", "failed_when_result": false, "rc": 0, "start": "2019-12-05 07:26:27.263478", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"minio-deployment-1\" deleted", "stdout_lines": ["deployment.apps \"minio-deployment-1\" deleted"]}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:26:29.034658 (delta: 2.132765)         elapsed: 73.703613 ******* 
FAILED - RETRYING: Check if the pod is deleted successfully (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n app-minio-ns -l \"name=minio-1\" --no-headers", "delta": "0:00:01.556564", "end": "2019-12-05 07:27:02.880890", "rc": 0, "start": "2019-12-05 07:27:01.324326", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:27:03.081918 (delta: 34.047161)         elapsed: 107.750873 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-2.yml", "delta": "0:00:01.463018", "end": "2019-12-05 07:27:04.885751", "rc": 0, "start": "2019-12-05 07:27:03.422733", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:27:04.990938 (delta: 1.908942)         elapsed: 109.659893 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-2"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:27:05.188241 (delta: 0.197215)         elapsed: 109.857196 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:27:05.633141 (delta: 0.444815)         elapsed: 110.302096 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:27:06.082067 (delta: 0.448841)         elapsed: 110.751022 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:27:06.520793 (delta: 0.438633)         elapsed: 111.189748 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-2.yml", "delta": "0:00:01.328742", "end": "2019-12-05 07:27:08.246308", "rc": 0, "start": "2019-12-05 07:27:06.917566", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-2\nspec:\n  selector:\n    matchLabels: \n      name: minio-2\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-2\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-2", "spec:", "  selector:", "    matchLabels: ", "      name: minio-2", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-2", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:27:08.346311 (delta: 1.825407)         elapsed: 113.015266 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the pod status] ****************************************************
2019-12-05T07:27:08.517136 (delta: 0.170736)         elapsed: 113.186091 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:27:08.701962 (delta: 0.184745)         elapsed: 113.370917 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f minio-2.yml -n app-minio-ns", "delta": "0:00:01.606053", "end": "2019-12-05 07:27:10.677184", "failed_when_result": false, "rc": 0, "start": "2019-12-05 07:27:09.071131", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"minio-deployment-2\" deleted", "stdout_lines": ["deployment.apps \"minio-deployment-2\" deleted"]}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:27:10.784191 (delta: 2.082156)         elapsed: 115.453146 ****** 
FAILED - RETRYING: Check if the pod is deleted successfully (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n app-minio-ns -l \"name=minio-2\" --no-headers", "delta": "0:00:01.587549", "end": "2019-12-05 07:27:44.684449", "rc": 0, "start": "2019-12-05 07:27:43.096900", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [copy the deployment spec to modify the specific values] ******************
2019-12-05T07:27:44.850866 (delta: 34.066604)         elapsed: 149.519821 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cp minio.yml minio-3.yml", "delta": "0:00:01.378094", "end": "2019-12-05 07:27:46.609414", "rc": 0, "start": "2019-12-05 07:27:45.231320", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get the application label values from env] *******************************
2019-12-05T07:27:46.716304 (delta: 1.865303)         elapsed: 151.385259 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "minio-3"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-12-05T07:27:46.902898 (delta: 0.186505)         elapsed: 151.571853 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the PVC name placeholder with PVC created earlier] ***************
2019-12-05T07:27:47.392898 (delta: 0.489923)         elapsed: 152.061853 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [modify the Deployment name appended with number generated earlier] *******
2019-12-05T07:27:47.978013 (delta: 0.585017)         elapsed: 152.646968 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [print the specific spec] *************************************************
2019-12-05T07:27:48.410613 (delta: 0.432513)         elapsed: 153.079568 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat minio-3.yml", "delta": "0:00:01.503853", "end": "2019-12-05 07:27:50.298108", "rc": 0, "start": "2019-12-05 07:27:48.794255", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minio-deployment-3\nspec:\n  selector:\n    matchLabels: \n      name: minio-3\n  strategy:\n    type: Recreate\n  template:\n    metadata:\n      labels:\n        # Label is used as selector in the service.\n        name: minio-3\n    spec:\n      # Refer to the PVC created earlier\n      volumes:\n      - name: data-vol\n        persistentVolumeClaim:\n          # Name of the PVC created earlier\n                claimName: minio-pv-claim\n      containers:\n      - name: minio\n        # Pulls the default Minio image from Docker Hub\n        image: minio/minio\n        args:\n        - server\n        - /storage1\n        env:\n        # Minio access key and secret key\n        - name: MINIO_ACCESS_KEY\n          value: \"minio\"\n        - name: MINIO_SECRET_KEY\n          value: \"minio123\"\n        ports:\n        - containerPort: 9000\n        # Mount the volume into the pod\n        volumeMounts:\n        - name: data-vol # must match the volume name, above\n          mountPath: \"/storage1\"", "stdout_lines": ["---", "apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: minio-deployment-3", "spec:", "  selector:", "    matchLabels: ", "      name: minio-3", "  strategy:", "    type: Recreate", "  template:", "    metadata:", "      labels:", "        # Label is used as selector in the service.", "        name: minio-3", "    spec:", "      # Refer to the PVC created earlier", "      volumes:", "      - name: data-vol", "        persistentVolumeClaim:", "          # Name of the PVC created earlier", "                claimName: minio-pv-claim", "      containers:", "      - name: minio", "        # Pulls the default Minio image from Docker Hub", "        image: minio/minio", "        args:", "        - server", "        - /storage1", "        env:", "        # Minio access key and secret key", "        - name: MINIO_ACCESS_KEY", "          value: \"minio\"", "        - name: MINIO_SECRET_KEY", "          value: \"minio123\"", "        ports:", "        - containerPort: 9000", "        # Mount the volume into the pod", "        volumeMounts:", "        - name: data-vol # must match the volume name, above", "          mountPath: \"/storage1\""]}

TASK [Applying the deployment spec] ********************************************
2019-12-05T07:27:50.421891 (delta: 2.011202)         elapsed: 155.090846 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the pod status] ****************************************************
2019-12-05T07:27:50.541454 (delta: 0.119458)         elapsed: 155.210409 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting the deployment with spec] ***************************************
2019-12-05T07:27:50.675683 (delta: 0.13411)         elapsed: 155.344638 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f minio-3.yml -n app-minio-ns", "delta": "0:00:01.630541", "end": "2019-12-05 07:27:52.670107", "failed_when_result": false, "rc": 0, "start": "2019-12-05 07:27:51.039566", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"minio-deployment-3\" deleted", "stdout_lines": ["deployment.apps \"minio-deployment-3\" deleted"]}

TASK [Check if the pod is deleted successfully] ********************************
2019-12-05T07:27:52.801056 (delta: 2.125259)         elapsed: 157.470011 ****** 
FAILED - RETRYING: Check if the pod is deleted successfully (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get po -n app-minio-ns -l \"name=minio-3\" --no-headers", "delta": "0:00:01.571917", "end": "2019-12-05 07:28:26.713607", "rc": 0, "start": "2019-12-05 07:28:25.141690", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [delete the pvc] **********************************************************
2019-12-05T07:28:26.829045 (delta: 34.027904)         elapsed: 191.498 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc minio-pv-claim -n app-minio-ns", "delta": "0:00:01.578639", "end": "2019-12-05 07:28:28.722684", "failed_when_result": false, "rc": 0, "start": "2019-12-05 07:28:27.144045", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"minio-pv-claim\" deleted", "stdout_lines": ["persistentvolumeclaim \"minio-pv-claim\" deleted"]}

TASK [check if the cloned pvc is deleted] **************************************
2019-12-05T07:28:28.878819 (delta: 2.049673)         elapsed: 193.547774 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n app-minio-ns", "delta": "0:00:02.570539", "end": "2019-12-05 07:28:31.935359", "rc": 0, "start": "2019-12-05 07:28:29.364820", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete the service] ******************************************************
2019-12-05T07:28:32.082527 (delta: 3.203583)         elapsed: 196.751482 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete service minio-service -n app-minio-ns", "delta": "0:00:01.610303", "end": "2019-12-05 07:28:34.150744", "failed_when_result": false, "rc": 0, "start": "2019-12-05 07:28:32.540441", "stderr": "", "stderr_lines": [], "stdout": "service \"minio-service\" deleted", "stdout_lines": ["service \"minio-service\" deleted"]}

TASK [Check if the service is deleted successfully] ****************************
2019-12-05T07:28:34.278774 (delta: 2.196092)         elapsed: 198.947729 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get service -n app-minio-ns -l \"name=minio-3\" --no-headers", "delta": "0:00:01.561230", "end": "2019-12-05 07:28:36.200877", "rc": 0, "start": "2019-12-05 07:28:34.639647", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete the namespace.] ***************************************************
2019-12-05T07:28:36.304858 (delta: 2.026)         elapsed: 200.973813 ********* 
changed: [127.0.0.1] => {"changed": true, "method": "delete", "result": {"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2019-12-05T07:19:47Z", "deletionTimestamp": "2019-12-05T07:28:37Z", "name": "app-minio-ns", "resourceVersion": "854203", "selfLink": "/api/v1/namespaces/app-minio-ns", "uid": "abd3e2d8-dd74-42d7-bea3-02163b1e9462"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Terminating"}}}

TASK [Check if the namespace is deleted successfully] **************************
2019-12-05T07:28:37.835473 (delta: 1.530539)         elapsed: 202.504428 ****** 
FAILED - RETRYING: Check if the namespace is deleted successfully (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get ns", "delta": "0:00:01.691407", "end": "2019-12-05 07:29:11.911477", "rc": 0, "start": "2019-12-05 07:29:10.220070", "stderr": "", "stderr_lines": [], "stdout": "NAME                   STATUS   AGE\napp-nfs-ns             Active   140m\napp-nfsv4-ns           Active   21h\napp-scale              Active   4h18m\napp-scale-jiva         Active   7h22m\napp-wordpress-ns       Active   20h\nbusybox                Active   20h\nbusybox-csi            Active   20h\nbusybox-jiva-snap      Active   20h\nbusybox-snap           Active   20h\ncas-performance        Active   7h20m\ncert-manager           Active   16d\ndefault                Active   16d\ne2e                    Active   21h\nfio                    Active   20h\nfio-jiva               Active   20h\njiva-openebs-ns        Active   7h22m\njiva-replica-scaleup   Active   7h22m\nkommander              Active   16d\nkube-node-lease        Active   16d\nkube-public            Active   16d\nkube-system            Active   16d\nkubeaddons             Active   16d\nlitmus                 Active   21h\nlogging                Active   21h\nmemleak-jiva           Active   20h\nopenebs                Active   21h\npost-rebuild           Active   20h\ntarget-delay           Active   20h\ntarget-loss            Active   20h", "stdout_lines": ["NAME                   STATUS   AGE", "app-nfs-ns             Active   140m", "app-nfsv4-ns           Active   21h", "app-scale              Active   4h18m", "app-scale-jiva         Active   7h22m", "app-wordpress-ns       Active   20h", "busybox                Active   20h", "busybox-csi            Active   20h", "busybox-jiva-snap      Active   20h", "busybox-snap           Active   20h", "cas-performance        Active   7h20m", "cert-manager           Active   16d", "default                Active   16d", "e2e                    Active   21h", "fio                    Active   20h", "fio-jiva               Active   20h", "jiva-openebs-ns        Active   7h22m", "jiva-replica-scaleup   Active   7h22m", "kommander              Active   16d", "kube-node-lease        Active   16d", "kube-public            Active   16d", "kube-system            Active   16d", "kubeaddons             Active   16d", "litmus                 Active   21h", "logging                Active   21h", "memleak-jiva           Active   20h", "openebs                Active   21h", "post-rebuild           Active   20h", "target-delay           Active   20h", "target-loss            Active   20h"]}

TASK [set_fact] ****************************************************************
2019-12-05T07:29:12.055902 (delta: 34.220298)         elapsed: 236.724857 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-12-05T07:29:12.267140 (delta: 0.211166)         elapsed: 236.936095 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-05T07:29:12.558183 (delta: 0.290949)         elapsed: 237.227138 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:29:12.664467 (delta: 0.106184)         elapsed: 237.333422 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:29:12.765660 (delta: 0.10091)         elapsed: 237.434615 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-05T07:29:12.870307 (delta: 0.104555)         elapsed: 237.539262 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4cbb1ca916b83e2015659a0b63f04bf25e478212", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a7d337d3c8093afc0c2c2ed82f6f5f21", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1575530952.95-70762590584999/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-05T07:29:16.449289 (delta: 3.578911)         elapsed: 241.118244 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.326556", "end": "2019-12-05 07:29:18.109902", "rc": 0, "start": "2019-12-05 07:29:16.783346", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: minio-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: minio-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-05T07:29:18.207319 (delta: 1.757936)         elapsed: 242.876274 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-05T05:15:27Z", "generation": 18, "name": "minio-deployment", "resourceVersion": "854744", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/minio-deployment", "uid": "4170eb24-d231-4628-8fe1-cd13fcf286bd"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=53   changed=40   unreachable=0    failed=0   

2019-12-05T07:29:19.663917 (delta: 1.456518)         elapsed: 244.332872 ****** 
=============================================================================== 
