### PR TITLE
feat(experiment): Included a litmus experiment to perform the disk replacement in CSPC pool

### DIFF
--- a/experiments/functional/disk_replacement/README.md
+++ b/experiments/functional/disk_replacement/README.md
@@ -1,0 +1,62 @@
+## Experiment Metadata
+
+Type  |     Description                                               | Storage    | K8s Platform | 
+------|---------------------------------------------------------------|------------|--------------|
+Chaos |Replace the blockdevice/disk in cspc Pool and check the status | OpenEBS    | Any          | 
+
+## Entry-Criteria
+
+- Application services are accessible & pods are healthy
+- Application writes are successful 
+- cStor pool instances are in healthy state.
+- Unclaimed BlockDevice should be available in the node to perform the disk replacement.
+
+## Exit-Criteria
+
+- Application services are accessible & pods are healthy
+- Data written prior to chaos is successfully retrieved/read
+- Database consistency is maintained as per db integrity check utils
+- Storage target pods are healthy.
+- cStor pool pods are should be Healthy.
+
+### Application
+
+Parameter     | Description
+--------------|------------
+APP_NAMESPACE | Namespace in which application pods are deployed
+APP_LABEL     | Unique Labels in `key=value` format of application deployment
+APP_PVC       | Name of persistent volume claim used for app's volume mounts 
+POOL_NAME     | Name of the CSPC to perform the disk replacement.
+OPERATOR_NS   | Namespace in Which OpenEBS components are deployed
+
+### Health Checks 
+
+Parameter             | Description
+----------------------|------------
+DATA_PERSISTENCY      | Data accessibility & integrity verification post recovery (enabled, disabled)
+
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of replace block device in the cStorPoolCluster  on OpenEBS data plane and control plane components.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after disk replacement is completed.
+

--- a/experiments/functional/disk_replacement/data_persistence.j2
+++ b/experiments/functional/disk_replacement/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/functional/disk_replacement/run_litmus_test.yml
+++ b/experiments/functional/disk_replacement/run_litmus_test.yml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: disk-replace
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-disk-replacement-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        app: disk-replacement
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Namespace for the application to check data persistence
+          - name: APP_NAMESPACE
+            value: ""
+
+            # Lable for the Application
+          - name: APP_LABEL
+            value: ""
+
+            # Namespace where the OpenEBS components are deployed
+          - name: OPERATOR_NS
+            value: ""
+
+            # Name of the Application PVC
+          - name: APP_PVC
+            value: ""
+
+            # Name of the Pool to perform the block device Replacement 
+          - name: POOL_NAME
+            value: ""
+
+            # Data accessibility & integrity verification. 
+            # To check against busybox set value: "busybox" and for percona, set value: "mysql"
+          - name: DATA_PERSISTENCE
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/disk_replacement/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: disk-replace

--- a/experiments/functional/disk_replacement/test.yml
+++ b/experiments/functional/disk_replacement/test.yml
@@ -1,0 +1,308 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml      
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
+
+        - include_vars:
+            file: data_persistence.yml
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ app_namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name           
+
+        - name: Create some test data
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ app_namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''          
+
+        - name: Check the status of CStorPoolInstance
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: cspi_status
+          until: "((cspi_status.stdout_lines|unique)|length) == 1 and 'ONLINE' in cspi_status.stdout"
+          retries: 30
+          delay: 10
+
+        - name: Get cStor Disk Pool names to verify the container statuses
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: cstor_pool_pod
+
+        - name: Verify if the Pool pod containers are running
+          shell: >
+            kubectl get pod {{ item }} -n {{ operator_ns }}
+            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+            cut -d "[" -f2 | cut -d ":" -f1
+          args:
+            executable: /bin/bash
+          register: pool_pod_status
+          with_items: "{{ cstor_pool_pod.stdout_lines }}"
+          until: "((pool_pod_status.stdout_lines|unique)|length) == 1 and 'running' in pool_pod_status.stdout"
+          delay: 30
+          retries: 10
+
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ app_namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Derive PV from application PVC
+          shell: >
+            kubectl get pvc {{ app_pvc }}
+            -o custom-columns=:spec.volumeName -n {{ app_namespace }}
+            --no-headers
+          args:
+            executable: /bin/bash
+          register: pv
+
+        - name: Check if the cStor target is in Running state
+          shell: >
+             kubectl get pods -n {{ operator_ns }} --no-headers -l openebs.io/persistent-volume={{ pv.stdout }}
+             -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: target_status
+          until: "'Running' in target_status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Obtain the cStorVolume status
+          shell: >
+            kubectl get cstorvolume -n {{ operator_ns }} --no-headers -l openebs.io/persistent-volume={{ pv.stdout }}
+            -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: cv_status
+          until: "'Healthy' in cv_status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Check the status of CVR
+          shell: >
+            kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+            --no-headers -o custom-columns=:.status.phase
+          register: cvr_status
+          until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Obtain the node names where the CVR's are scheduled
+          shell: >
+             kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+             -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpoolinstance\.openebs\.io\/hostname}{"\n"}'
+          args:
+            executable: /bin/bash
+          register: node_name
+
+        - name: Select random cvr node from the list of nodes as target node to perform disk replacement
+          set_fact:
+            target_node: "{{ item }}"
+          with_random_choice: "{{ node_name.stdout_lines }}"
+
+        - name: Obtain the Claimed block device from the targeted node
+          shell: >
+            kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ target_node }}
+            -o jsonpath='{.items[?(@.status.claimState=="Claimed")].metadata.name}' | tr " " "\n" | grep -v sparse
+          args:
+            executable: /bin/bash
+          register: claimed_bd
+          failed_when: 'claimed_bd.stdout == ""'
+
+        - name: Select random bd from the list of claimed block device as claimed target blockdevice to perform disk replacement
+          set_fact:
+            claimed_target_bd: "{{ item }}"
+          with_random_choice: "{{ claimed_bd.stdout_lines }}"
+
+        - name: Obtain the Unclaimed block device from the targeted node to perform disk replacement
+          shell: >
+            kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ target_node }}
+            -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse
+          args:
+            executable: /bin/bash
+          register: unclaimed_bd
+          failed_when: 'unclaimed_bd.stdout == ""'
+
+        - name: Select random bd from the list of unclaimed block device as claimed target blockdevice to perform disk replacement
+          set_fact:
+            unclaimed_target_bd: "{{ item }}"
+          with_random_choice: "{{ unclaimed_bd.stdout_lines }}"
+
+        - name: Obtain the cspc yaml
+          shell:
+            kubectl get cspc -n {{ operator_ns }} -o yaml > ./cspc_disk_replace.yml
+          args:
+            executable: /bin/bash
+
+        - name: Replacing the block device in the cspc yaml
+          replace:
+            path: ./cspc_disk_replace.yml
+            regexp: "{{ claimed_target_bd }}"
+            replace: "{{ unclaimed_target_bd }}"
+
+        - name: Display cspc.yml for verification
+          debug: var=item
+          with_file:
+          - "cspc_disk_replace.yml"
+
+        - name: Patch the CSPC to replace the blockdevice
+          shell: kubectl apply -f cspc_disk_replace.yml
+          args:
+            executable: /bin/bash
+
+        - name: Check if the replacing Blockdevice is in Claimed state
+          shell: >
+             kubectl get blockdevice -n {{ operator_ns }} {{ unclaimed_target_bd }}
+             --no-headers -o custom-columns=:.status.claimState
+          args:
+            executable: /bin/bash
+          register: bd_state
+          until: "'Claimed' in bd_state.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Check if the replaced Blockdevice is in Unclaimed state
+          shell: >
+             kubectl get blockdevice -n {{ operator_ns }} {{ claimed_target_bd }}
+             --no-headers -o custom-columns=:.status.claimState
+          args:
+            executable: /bin/bash
+          register: old_bd_state
+          until: "'Unclaimed' in old_bd_state.stdout"
+          delay: 10
+          retries: 120
+
+        - name: Verify if the Pool pod containers are running
+          shell: >
+            kubectl get pod {{ item }} -n {{ operator_ns }}
+            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+            cut -d "[" -f2 | cut -d ":" -f1
+          args:
+            executable: /bin/bash
+          register: pool_pod_status
+          with_items: "{{ cstor_pool_pod.stdout_lines }}"
+          until: "((pool_pod_status.stdout_lines|unique)|length) == 1 and 'running' in pool_pod_status.stdout"
+          delay: 30
+          retries: 10
+
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{ app_namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
+        - name: Check if the cStor target is in Running state
+          shell: >
+             kubectl get pods -n {{ operator_ns }} --no-headers -l openebs.io/persistent-volume={{ pv.stdout }}
+             -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: target_status
+          until: "'Running' in target_status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Obtain the cStorVolume status
+          shell: >
+            kubectl get cstorvolume -n {{ operator_ns }} --no-headers -l openebs.io/persistent-volume={{ pv.stdout }}
+            -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: cv_status
+          until: "'Healthy' in cv_status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Check the status of CVR
+          shell:
+            kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+            --no-headers -o custom-columns=:.status.phase
+          register: cvr_status
+          until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Check the status of CStorPoolInstance
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: cspi_status_aftr
+          until: "((cspi_status_aftr.stdout_lines|unique)|length) == 1 and 'ONLINE' in cspi_status_aftr.stdout"
+          retries: 60
+          delay: 5
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ app_namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod  
+
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ app_namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"                 
+          when: data_persistence != ''          
+
+        - name: Setting pass flag
+          set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/disk_replacement/test_vars.yml
+++ b/experiments/functional/disk_replacement/test_vars.yml
@@ -1,0 +1,10 @@
+---
+## TEST-SPECIFIC PARAMS
+test_name: blockdevice-replacement
+app_namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+

--- a/utils/scm/applications/mysql/mysql_data_persistence.yml
+++ b/utils/scm/applications/mysql/mysql_data_persistence.yml
@@ -58,6 +58,13 @@
      delay: 2
      retries: 150
 
+   - name: Check if db is ready for connections
+     shell: kubectl logs {{ newpod_name.stdout }} -n {{ ns }} | grep 'ready for connections'
+     register: initcheck
+     until: "'ready for connections' in initcheck.stdout"
+     delay: 5
+     retries: 180
+
    - name: Checking for the Corrupted tables
      shell: >
        kubectl exec {{ newpod_name.stdout }} -n {{ ns }}


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

Perform the Disk Replacement in Mirror,RAIDZ1 and RAIDZ2 CSPC pool
  - Verifying the CSPI ,CSPC  and Pool pod status before performing Disk replacement
  - Verify the Unclaimed BlockDevice is available in the node of targeted pool instance to perform the Blockdevice
  - Perform the Disk replacement and verify the CVR,CSPI and Pool pod status.
  - Verify the data consistency from the application

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [x] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [x] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-12-19T10:55:07.766601 (delta: 0.045674)         elapsed: 0.045674 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-12-19T10:55:07.777559 (delta: 0.010925)         elapsed: 0.056632 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-12-19T10:55:13.270994 (delta: 5.49341)         elapsed: 5.550067 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-12-19T10:55:13.333476 (delta: 0.06245)         elapsed: 5.612549 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-12-19T10:55:13.377184 (delta: 0.043674)         elapsed: 5.656257 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-19T10:55:13.420884 (delta: 0.043666)         elapsed: 5.699957 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-19T10:55:13.492750 (delta: 0.071831)         elapsed: 5.771823 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d98d0c6f0382f1a8a0460cdf463dc68785d6d01b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bd750ca6c8005753324fbdc6b679ab3a", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1576752913.53-220861492442987/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-19T10:55:14.065421 (delta: 0.572635)         elapsed: 6.344494 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.643794", "end": "2019-12-19 10:55:14.950496", "rc": 0, "start": "2019-12-19 10:55:14.306702", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: blockdevice-replacement \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: blockdevice-replacement ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-19T10:55:14.992228 (delta: 0.926771)         elapsed: 7.271301 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-19T09:05:16Z", "generation": 19, "name": "blockdevice-replacement", "resourceVersion": "49632", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/blockdevice-replacement", "uid": "8fbcb264-285b-41a0-8bea-d91278f2a6e3"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-19T10:55:16.095660 (delta: 1.103395)         elapsed: 8.374733 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-19T10:55:16.159960 (delta: 0.064265)         elapsed: 8.439033 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-19T10:55:16.198905 (delta: 0.038899)         elapsed: 8.477978 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the data consistency util to be invoked] ************************
2019-12-19T10:55:16.240727 (delta: 0.041769)         elapsed: 8.5198 ********** 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1576752916.28-21889441690048/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
2019-12-19T10:55:16.555114 (delta: 0.314351)         elapsed: 8.834187 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/functional/disk_replacement/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
2019-12-19T10:55:16.615245 (delta: 0.060096)         elapsed: 8.894318 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [Get application pod name] ************************************************
2019-12-19T10:55:16.779012 (delta: 0.163731)         elapsed: 9.058085 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-1 -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.196728", "end": "2019-12-19 10:55:18.229259", "rc": 0, "start": "2019-12-19 10:55:17.032531", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-k6zbd", "stdout_lines": ["percona-7c6969cf78-k6zbd"]}

TASK [Create some test data] ***************************************************
2019-12-19T10:55:18.299701 (delta: 1.520647)         elapsed: 10.578774 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
2019-12-19T10:55:18.471513 (delta: 0.17177)         elapsed: 10.750586 ******** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database testdb16;') => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-k6zbd -n percona-1 -- mysql -uroot -pk8sDem0 -e 'create database testdb16;'", "delta": "0:00:00.990790", "end": "2019-12-19 10:55:19.641072", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database testdb16;'", "rc": 0, "start": "2019-12-19 10:55:18.650282", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' testdb16) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-k6zbd -n percona-1 -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' testdb16", "delta": "0:00:01.303690", "end": "2019-12-19 10:55:21.073175", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' testdb16", "rc": 0, "start": "2019-12-19 10:55:19.769485", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' testdb16) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-k6zbd -n percona-1 -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' testdb16", "delta": "0:00:01.837495", "end": "2019-12-19 10:55:23.048995", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' testdb16", "rc": 0, "start": "2019-12-19 10:55:21.211500", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
2019-12-19T10:55:23.101554 (delta: 4.629985)         elapsed: 15.380627 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
2019-12-19T10:55:23.145394 (delta: 0.043796)         elapsed: 15.424467 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
2019-12-19T10:55:23.185586 (delta: 0.040157)         elapsed: 15.464659 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
2019-12-19T10:55:23.225718 (delta: 0.040097)         elapsed: 15.504791 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
2019-12-19T10:55:23.266938 (delta: 0.041164)         elapsed: 15.546011 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
2019-12-19T10:55:23.310008 (delta: 0.043034)         elapsed: 15.589081 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
2019-12-19T10:55:23.349428 (delta: 0.039365)         elapsed: 15.628501 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
2019-12-19T10:55:23.388868 (delta: 0.039387)         elapsed: 15.667941 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
2019-12-19T10:55:23.430000 (delta: 0.041079)         elapsed: 15.709073 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
2019-12-19T10:55:23.476526 (delta: 0.046472)         elapsed: 15.755599 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the status of CStorPoolInstance] ***********************************
2019-12-19T10:55:23.518066 (delta: 0.041503)         elapsed: 15.797139 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.803883", "end": "2019-12-19 10:55:24.481818", "rc": 0, "start": "2019-12-19 10:55:23.677935", "stderr": "", "stderr_lines": [], "stdout": "ONLINE\nONLINE\nONLINE", "stdout_lines": ["ONLINE", "ONLINE", "ONLINE"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2019-12-19T10:55:24.528857 (delta: 1.010737)         elapsed: 16.80793 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.720958", "end": "2019-12-19 10:55:25.466775", "rc": 0, "start": "2019-12-19 10:55:24.745817", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7\ncstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6\ncstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx", "stdout_lines": ["cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7", "cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6", "cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx"]}

TASK [Verify if the Pool pod containers are running] ***************************
2019-12-19T10:55:25.508100 (delta: 0.979205)         elapsed: 17.787173 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | cut -d \"[\" -f2 | cut -d \":\" -f1", "delta": "0:00:00.736408", "end": "2019-12-19 10:55:26.392955", "item": "cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7", "rc": 0, "start": "2019-12-19 10:55:25.656547", "stderr": "", "stderr_lines": [], "stdout": "running\nrunning\nrunning", "stdout_lines": ["running", "running", "running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | cut -d \"[\" -f2 | cut -d \":\" -f1", "delta": "0:00:00.798428", "end": "2019-12-19 10:55:27.331453", "item": "cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6", "rc": 0, "start": "2019-12-19 10:55:26.533025", "stderr": "", "stderr_lines": [], "stdout": "running\nrunning\nrunning", "stdout_lines": ["running", "running", "running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | cut -d \"[\" -f2 | cut -d \":\" -f1", "delta": "0:00:01.098732", "end": "2019-12-19 10:55:28.670056", "item": "cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx", "rc": 0, "start": "2019-12-19 10:55:27.571324", "stderr": "", "stderr_lines": [], "stdout": "running\nrunning\nrunning", "stdout_lines": ["running", "running", "running"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
2019-12-19T10:55:28.755513 (delta: 3.247378)         elapsed: 21.034586 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2019-12-19T10:55:28.825281 (delta: 0.069732)         elapsed: 21.104354 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona-1 -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.707177", "end": "2019-12-19 10:55:29.716946", "rc": 0, "start": "2019-12-19 10:55:29.009769", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-19T10:52:23Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-19T10:52:23Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
2019-12-19T10:55:29.766811 (delta: 0.941496)         elapsed: 22.045884 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-1 -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.842497", "end": "2019-12-19 10:55:30.772039", "rc": 0, "start": "2019-12-19 10:55:29.929542", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
2019-12-19T10:55:30.819708 (delta: 1.052864)         elapsed: 23.098781 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n percona-1 --no-headers", "delta": "0:00:00.715463", "end": "2019-12-19 10:55:31.691167", "rc": 0, "start": "2019-12-19 10:55:30.975704", "stderr": "", "stderr_lines": [], "stdout": "pvc-8649b257-fd73-43dd-a2df-3b413f607f48", "stdout_lines": ["pvc-8649b257-fd73-43dd-a2df-3b413f607f48"]}

TASK [Check if the cStor target is in Running state] ***************************
2019-12-19T10:55:31.734779 (delta: 0.915034)         elapsed: 24.013852 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs --no-headers -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 -o custom-columns=:.status.phase", "delta": "0:00:00.736234", "end": "2019-12-19 10:55:32.624208", "rc": 0, "start": "2019-12-19 10:55:31.887974", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the cStorVolume status] *******************************************
2019-12-19T10:55:32.685027 (delta: 0.950194)         elapsed: 24.9641 ********* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume -n openebs --no-headers -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 -o custom-columns=:.status.phase", "delta": "0:00:00.889386", "end": "2019-12-19 10:55:33.837802", "rc": 0, "start": "2019-12-19 10:55:32.948416", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}

TASK [Check the status of CVR] *************************************************
2019-12-19T10:55:33.888683 (delta: 1.203616)         elapsed: 26.167756 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.792670", "end": "2019-12-19 10:55:34.877759", "rc": 0, "start": "2019-12-19 10:55:34.085089", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Obtain the node names where the CVR's are scheduled] *********************
2019-12-19T10:55:34.935528 (delta: 1.046799)         elapsed: 27.214601 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpoolinstance\\.openebs\\.io\\/hostname}{\"\\n\"}'", "delta": "0:00:00.695301", "end": "2019-12-19 10:55:35.774421", "rc": 0, "start": "2019-12-19 10:55:35.079120", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-disk-test-default-pool-490e7047-8h6g\ngke-e2e-disk-test-default-pool-490e7047-99w8\ngke-e2e-disk-test-default-pool-490e7047-tjfp", "stdout_lines": ["gke-e2e-disk-test-default-pool-490e7047-8h6g", "gke-e2e-disk-test-default-pool-490e7047-99w8", "gke-e2e-disk-test-default-pool-490e7047-tjfp"]}

TASK [Select random cvr node from the list of nodes as target node to perform disk replacement] ***
2019-12-19T10:55:35.816867 (delta: 0.881304)         elapsed: 28.09594 ******** 
ok: [127.0.0.1] => (item=gke-e2e-disk-test-default-pool-490e7047-tjfp) => {"ansible_facts": {"target_node": "gke-e2e-disk-test-default-pool-490e7047-tjfp"}, "changed": false, "item": "gke-e2e-disk-test-default-pool-490e7047-tjfp"}

TASK [Obtain the Claimed block device from the targeted node] ******************
2019-12-19T10:55:35.891963 (delta: 0.075058)         elapsed: 28.171036 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gke-e2e-disk-test-default-pool-490e7047-tjfp -o jsonpath='{.items[?(@.status.claimState==\"Claimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse", "delta": "0:00:00.729878", "end": "2019-12-19 10:55:36.828669", "failed_when_result": false, "rc": 0, "start": "2019-12-19 10:55:36.098791", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-5807d086025f777dcd82ae1236a3968f\nblockdevice-97b10611c8de8e9b2c541d4d07646782", "stdout_lines": ["blockdevice-5807d086025f777dcd82ae1236a3968f", "blockdevice-97b10611c8de8e9b2c541d4d07646782"]}

TASK [Select random bd from the list of claimed block device as claimed target blockdevice to perform disk replacement] ***
2019-12-19T10:55:36.873245 (delta: 0.981247)         elapsed: 29.152318 ******* 
ok: [127.0.0.1] => (item=blockdevice-5807d086025f777dcd82ae1236a3968f) => {"ansible_facts": {"claimed_target_bd": "blockdevice-5807d086025f777dcd82ae1236a3968f"}, "changed": false, "item": "blockdevice-5807d086025f777dcd82ae1236a3968f"}

TASK [Obtain the Unclaimed block device from the targeted node to perform disk replacement] ***
2019-12-19T10:55:36.942274 (delta: 0.068995)         elapsed: 29.221347 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gke-e2e-disk-test-default-pool-490e7047-tjfp -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse", "delta": "0:00:00.783416", "end": "2019-12-19 10:55:37.868487", "failed_when_result": false, "rc": 0, "start": "2019-12-19 10:55:37.085071", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-ae29b5f20686fe823a0f447ecb708a1f", "stdout_lines": ["blockdevice-ae29b5f20686fe823a0f447ecb708a1f"]}

TASK [Select random bd from the list of unclaimed block device as claimed target blockdevice to perform disk replacement] ***
2019-12-19T10:55:37.915063 (delta: 0.972752)         elapsed: 30.194136 ******* 
ok: [127.0.0.1] => (item=blockdevice-ae29b5f20686fe823a0f447ecb708a1f) => {"ansible_facts": {"unclaimed_target_bd": "blockdevice-ae29b5f20686fe823a0f447ecb708a1f"}, "changed": false, "item": "blockdevice-ae29b5f20686fe823a0f447ecb708a1f"}

TASK [Obtain the cspc yaml] ****************************************************
2019-12-19T10:55:38.044142 (delta: 0.129044)         elapsed: 30.323215 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspc -n openebs -o yaml > ./cspc_disk_replace.yml", "delta": "0:00:00.779769", "end": "2019-12-19 10:55:39.084413", "rc": 0, "start": "2019-12-19 10:55:38.304644", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Replacing the block device in the cspc yaml] *****************************
2019-12-19T10:55:39.125894 (delta: 1.081696)         elapsed: 31.404967 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2019-12-19T10:55:39.464843 (delta: 0.338914)         elapsed: 31.743916 ******* 
ok: [127.0.0.1] => (item=apiVersion: v1
items:
- apiVersion: openebs.io/v1alpha1
  kind: CStorPoolCluster
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"openebs.io/v1alpha1","kind":"CStorPoolCluster","metadata":{"annotations":{"openebs.io/cspc-lease":"{\"holder\":\"openebs/cspc-operator-b565b6dd6-mvjrd\",\"leaderTransition\":1}"},"creationTimestamp":"2019-12-19T08:51:29Z","finalizers":["cstorpoolcluster.openebs.io/finalizer"],"generation":5,"name":"cstor-cspc-disk-pool","namespace":"openebs","resourceVersion":"39405","selfLink":"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorpoolclusters/cstor-cspc-disk-pool","uid":"07a3e5db-829b-46c9-9801-1b81ab22d880"},"spec":{"auxResources":{},"pools":[{"nodeSelector":{"kubernetes.io/hostname":"gke-e2e-disk-test-default-pool-490e7047-tjfp"},"poolConfig":{"cacheFile":"","compression":"off","defaultRaidGroupType":"mirror","overProvisioning":false},"raidGroups":[{"blockDevices":[{"blockDeviceName":"blockdevice-97b10611c8de8e9b2c541d4d07646782","capacity":"","devLink":""},{"blockDeviceName":"blockdevice-ae29b5f20686fe823a0f447ecb708a1f","capacity":"","devLink":""}],"isReadCache":false,"isSpare":false,"isWriteCache":false,"type":"mirror"}]},{"nodeSelector":{"kubernetes.io/hostname":"gke-e2e-disk-test-default-pool-490e7047-99w8"},"poolConfig":{"cacheFile":"","compression":"off","defaultRaidGroupType":"mirror","overProvisioning":false},"raidGroups":[{"blockDevices":[{"blockDeviceName":"blockdevice-60414d7edc9505035b572bf86f20c8ec","capacity":"","devLink":""},{"blockDeviceName":"blockdevice-2272bf855734632d0fda0c8bcc744328","capacity":"","devLink":""}],"isReadCache":false,"isSpare":false,"isWriteCache":false,"type":"mirror"}]},{"nodeSelector":{"kubernetes.io/hostname":"gke-e2e-disk-test-default-pool-490e7047-8h6g"},"poolConfig":{"cacheFile":"","compression":"off","defaultRaidGroupType":"mirror","overProvisioning":false},"raidGroups":[{"blockDevices":[{"blockDeviceName":"blockdevice-5c4d7515318dafe7807674fd05d5376d","capacity":"","devLink":""},{"blockDeviceName":"blockdevice-8e558129cb8346055b7741342227910b","capacity":"","devLink":""}],"isReadCache":false,"isSpare":false,"isWriteCache":false,"type":"mirror"}]}]},"status":{"capacity":{"free":"","total":"","used":""},"phase":""},"versionDetails":{"autoUpgrade":false,"desired":"1.5.0","status":{"current":"1.5.0","dependentsUpgraded":true,"state":""}}}
      openebs.io/cspc-lease: '{"holder":"openebs/cspc-operator-b565b6dd6-mvjrd","leaderTransition":1}'
    creationTimestamp: 2019-12-19T08:51:29Z
    finalizers:
    - cstorpoolcluster.openebs.io/finalizer
    generation: 6
    name: cstor-cspc-disk-pool
    namespace: openebs
    resourceVersion: "46304"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorpoolclusters/cstor-cspc-disk-pool
    uid: 07a3e5db-829b-46c9-9801-1b81ab22d880
  spec:
    auxResources: {}
    pools:
    - nodeSelector:
        kubernetes.io/hostname: gke-e2e-disk-test-default-pool-490e7047-tjfp
      poolConfig:
        cacheFile: ""
        compression: "off"
        defaultRaidGroupType: mirror
        overProvisioning: false
      raidGroups:
      - blockDevices:
        - blockDeviceName: blockdevice-97b10611c8de8e9b2c541d4d07646782
          capacity: ""
          devLink: ""
        - blockDeviceName: blockdevice-ae29b5f20686fe823a0f447ecb708a1f
          capacity: ""
          devLink: ""
        isReadCache: false
        isSpare: false
        isWriteCache: false
        type: mirror
    - nodeSelector:
        kubernetes.io/hostname: gke-e2e-disk-test-default-pool-490e7047-99w8
      poolConfig:
        cacheFile: ""
        compression: "off"
        defaultRaidGroupType: mirror
        overProvisioning: false
      raidGroups:
      - blockDevices:
        - blockDeviceName: blockdevice-60414d7edc9505035b572bf86f20c8ec
          capacity: ""
          devLink: ""
        - blockDeviceName: blockdevice-2272bf855734632d0fda0c8bcc744328
          capacity: ""
          devLink: ""
        isReadCache: false
        isSpare: false
        isWriteCache: false
        type: mirror
    - nodeSelector:
        kubernetes.io/hostname: gke-e2e-disk-test-default-pool-490e7047-8h6g
      poolConfig:
        cacheFile: ""
        compression: "off"
        defaultRaidGroupType: mirror
        overProvisioning: false
      raidGroups:
      - blockDevices:
        - blockDeviceName: blockdevice-5c4d7515318dafe7807674fd05d5376d
          capacity: ""
          devLink: ""
        - blockDeviceName: blockdevice-8e558129cb8346055b7741342227910b
          capacity: ""
          devLink: ""
        isReadCache: false
        isSpare: false
        isWriteCache: false
        type: mirror
  status:
    capacity:
      free: ""
      total: ""
      used: ""
    phase: ""
  versionDetails:
    autoUpgrade: false
    desired: 1.5.0
    status:
      current: 1.5.0
      dependentsUpgraded: true
      state: ""
kind: List
metadata:
  resourceVersion: ""
  selfLink: "") => {
    "item": "apiVersion: v1\nitems:\n- apiVersion: openebs.io/v1alpha1\n  kind: CStorPoolCluster\n  metadata:\n    annotations:\n      kubectl.kubernetes.io/last-applied-configuration: |\n        {\"apiVersion\":\"openebs.io/v1alpha1\",\"kind\":\"CStorPoolCluster\",\"metadata\":{\"annotations\":{\"openebs.io/cspc-lease\":\"{\\\"holder\\\":\\\"openebs/cspc-operator-b565b6dd6-mvjrd\\\",\\\"leaderTransition\\\":1}\"},\"creationTimestamp\":\"2019-12-19T08:51:29Z\",\"finalizers\":[\"cstorpoolcluster.openebs.io/finalizer\"],\"generation\":5,\"name\":\"cstor-cspc-disk-pool\",\"namespace\":\"openebs\",\"resourceVersion\":\"39405\",\"selfLink\":\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorpoolclusters/cstor-cspc-disk-pool\",\"uid\":\"07a3e5db-829b-46c9-9801-1b81ab22d880\"},\"spec\":{\"auxResources\":{},\"pools\":[{\"nodeSelector\":{\"kubernetes.io/hostname\":\"gke-e2e-disk-test-default-pool-490e7047-tjfp\"},\"poolConfig\":{\"cacheFile\":\"\",\"compression\":\"off\",\"defaultRaidGroupType\":\"mirror\",\"overProvisioning\":false},\"raidGroups\":[{\"blockDevices\":[{\"blockDeviceName\":\"blockdevice-97b10611c8de8e9b2c541d4d07646782\",\"capacity\":\"\",\"devLink\":\"\"},{\"blockDeviceName\":\"blockdevice-ae29b5f20686fe823a0f447ecb708a1f\",\"capacity\":\"\",\"devLink\":\"\"}],\"isReadCache\":false,\"isSpare\":false,\"isWriteCache\":false,\"type\":\"mirror\"}]},{\"nodeSelector\":{\"kubernetes.io/hostname\":\"gke-e2e-disk-test-default-pool-490e7047-99w8\"},\"poolConfig\":{\"cacheFile\":\"\",\"compression\":\"off\",\"defaultRaidGroupType\":\"mirror\",\"overProvisioning\":false},\"raidGroups\":[{\"blockDevices\":[{\"blockDeviceName\":\"blockdevice-60414d7edc9505035b572bf86f20c8ec\",\"capacity\":\"\",\"devLink\":\"\"},{\"blockDeviceName\":\"blockdevice-2272bf855734632d0fda0c8bcc744328\",\"capacity\":\"\",\"devLink\":\"\"}],\"isReadCache\":false,\"isSpare\":false,\"isWriteCache\":false,\"type\":\"mirror\"}]},{\"nodeSelector\":{\"kubernetes.io/hostname\":\"gke-e2e-disk-test-default-pool-490e7047-8h6g\"},\"poolConfig\":{\"cacheFile\":\"\",\"compression\":\"off\",\"defaultRaidGroupType\":\"mirror\",\"overProvisioning\":false},\"raidGroups\":[{\"blockDevices\":[{\"blockDeviceName\":\"blockdevice-5c4d7515318dafe7807674fd05d5376d\",\"capacity\":\"\",\"devLink\":\"\"},{\"blockDeviceName\":\"blockdevice-8e558129cb8346055b7741342227910b\",\"capacity\":\"\",\"devLink\":\"\"}],\"isReadCache\":false,\"isSpare\":false,\"isWriteCache\":false,\"type\":\"mirror\"}]}]},\"status\":{\"capacity\":{\"free\":\"\",\"total\":\"\",\"used\":\"\"},\"phase\":\"\"},\"versionDetails\":{\"autoUpgrade\":false,\"desired\":\"1.5.0\",\"status\":{\"current\":\"1.5.0\",\"dependentsUpgraded\":true,\"state\":\"\"}}}\n      openebs.io/cspc-lease: '{\"holder\":\"openebs/cspc-operator-b565b6dd6-mvjrd\",\"leaderTransition\":1}'\n    creationTimestamp: 2019-12-19T08:51:29Z\n    finalizers:\n    - cstorpoolcluster.openebs.io/finalizer\n    generation: 6\n    name: cstor-cspc-disk-pool\n    namespace: openebs\n    resourceVersion: \"46304\"\n    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorpoolclusters/cstor-cspc-disk-pool\n    uid: 07a3e5db-829b-46c9-9801-1b81ab22d880\n  spec:\n    auxResources: {}\n    pools:\n    - nodeSelector:\n        kubernetes.io/hostname: gke-e2e-disk-test-default-pool-490e7047-tjfp\n      poolConfig:\n        cacheFile: \"\"\n        compression: \"off\"\n        defaultRaidGroupType: mirror\n        overProvisioning: false\n      raidGroups:\n      - blockDevices:\n        - blockDeviceName: blockdevice-97b10611c8de8e9b2c541d4d07646782\n          capacity: \"\"\n          devLink: \"\"\n        - blockDeviceName: blockdevice-ae29b5f20686fe823a0f447ecb708a1f\n          capacity: \"\"\n          devLink: \"\"\n        isReadCache: false\n        isSpare: false\n        isWriteCache: false\n        type: mirror\n    - nodeSelector:\n        kubernetes.io/hostname: gke-e2e-disk-test-default-pool-490e7047-99w8\n      poolConfig:\n        cacheFile: \"\"\n        compression: \"off\"\n        defaultRaidGroupType: mirror\n        overProvisioning: false\n      raidGroups:\n      - blockDevices:\n        - blockDeviceName: blockdevice-60414d7edc9505035b572bf86f20c8ec\n          capacity: \"\"\n          devLink: \"\"\n        - blockDeviceName: blockdevice-2272bf855734632d0fda0c8bcc744328\n          capacity: \"\"\n          devLink: \"\"\n        isReadCache: false\n        isSpare: false\n        isWriteCache: false\n        type: mirror\n    - nodeSelector:\n        kubernetes.io/hostname: gke-e2e-disk-test-default-pool-490e7047-8h6g\n      poolConfig:\n        cacheFile: \"\"\n        compression: \"off\"\n        defaultRaidGroupType: mirror\n        overProvisioning: false\n      raidGroups:\n      - blockDevices:\n        - blockDeviceName: blockdevice-5c4d7515318dafe7807674fd05d5376d\n          capacity: \"\"\n          devLink: \"\"\n        - blockDeviceName: blockdevice-8e558129cb8346055b7741342227910b\n          capacity: \"\"\n          devLink: \"\"\n        isReadCache: false\n        isSpare: false\n        isWriteCache: false\n        type: mirror\n  status:\n    capacity:\n      free: \"\"\n      total: \"\"\n      used: \"\"\n    phase: \"\"\n  versionDetails:\n    autoUpgrade: false\n    desired: 1.5.0\n    status:\n      current: 1.5.0\n      dependentsUpgraded: true\n      state: \"\"\nkind: List\nmetadata:\n  resourceVersion: \"\"\n  selfLink: \"\""
}

TASK [Patch the CSPC to replace the blockdevice] *******************************
2019-12-19T10:55:39.566266 (delta: 0.101388)         elapsed: 31.845339 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc_disk_replace.yml", "delta": "0:00:01.323144", "end": "2019-12-19 10:55:41.040590", "rc": 0, "start": "2019-12-19 10:55:39.717446", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.openebs.io/cstor-cspc-disk-pool configured", "stdout_lines": ["cstorpoolcluster.openebs.io/cstor-cspc-disk-pool configured"]}

TASK [Check if the replacing Blockdevice is in Claimed state] ******************
2019-12-19T10:55:41.080247 (delta: 1.513942)         elapsed: 33.35932 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-ae29b5f20686fe823a0f447ecb708a1f --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.995186", "end": "2019-12-19 10:55:42.271320", "rc": 0, "start": "2019-12-19 10:55:41.276134", "stderr": "", "stderr_lines": [], "stdout": "Claimed", "stdout_lines": ["Claimed"]}

TASK [Check if the replaced Blockdevice is in Unclaimed state] *****************
2019-12-19T10:55:42.320334 (delta: 1.240053)         elapsed: 34.599407 ******* 
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (120 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (119 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (118 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (117 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (116 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (115 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (114 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (113 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (112 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (111 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (110 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (109 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (108 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (107 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (106 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (105 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (104 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (103 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (102 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (101 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (100 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (99 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (98 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (97 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (96 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (95 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (94 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (93 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (92 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (91 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (90 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (89 retries left).
FAILED - RETRYING: Check if the replaced Blockdevice is in Unclaimed state (88 retries left).
changed: [127.0.0.1] => {"attempts": 34, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-5807d086025f777dcd82ae1236a3968f --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.695597", "end": "2019-12-19 11:01:44.540816", "rc": 0, "start": "2019-12-19 11:01:43.845219", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}

TASK [Verify if the Pool pod containers are running] ***************************
2019-12-19T11:01:44.583843 (delta: 362.26347)         elapsed: 396.862916 ***** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | cut -d \"[\" -f2 | cut -d \":\" -f1", "delta": "0:00:00.700021", "end": "2019-12-19 11:01:45.461753", "item": "cstor-cspc-disk-pool-bpvk-845bdff8f-5blf7", "rc": 0, "start": "2019-12-19 11:01:44.761732", "stderr": "", "stderr_lines": [], "stdout": "running\nrunning\nrunning", "stdout_lines": ["running", "running", "running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | cut -d \"[\" -f2 | cut -d \":\" -f1", "delta": "0:00:00.727302", "end": "2019-12-19 11:01:46.347420", "item": "cstor-cspc-disk-pool-j4qs-78788d94cb-7qhf6", "rc": 0, "start": "2019-12-19 11:01:45.620118", "stderr": "", "stderr_lines": [], "stdout": "running\nrunning\nrunning", "stdout_lines": ["running", "running", "running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | cut -d \"[\" -f2 | cut -d \":\" -f1", "delta": "0:00:00.759714", "end": "2019-12-19 11:01:47.239689", "item": "cstor-cspc-disk-pool-t7wt-55754bc7f-9qrxx", "rc": 0, "start": "2019-12-19 11:01:46.479975", "stderr": "", "stderr_lines": [], "stdout": "running\nrunning\nrunning", "stdout_lines": ["running", "running", "running"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
2019-12-19T11:01:47.296940 (delta: 2.713063)         elapsed: 399.576013 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2019-12-19T11:01:47.365996 (delta: 0.069007)         elapsed: 399.645069 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona-1 -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.816120", "end": "2019-12-19 11:01:48.334737", "rc": 0, "start": "2019-12-19 11:01:47.518617", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-19T10:52:23Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-19T10:52:23Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
2019-12-19T11:01:48.382873 (delta: 1.016777)         elapsed: 400.661946 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-1 -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.956317", "end": "2019-12-19 11:01:49.508764", "rc": 0, "start": "2019-12-19 11:01:48.552447", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Check if the cStor target is in Running state] ***************************
2019-12-19T11:01:49.556413 (delta: 1.173508)         elapsed: 401.835486 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs --no-headers -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 -o custom-columns=:.status.phase", "delta": "0:00:00.709630", "end": "2019-12-19 11:01:50.421384", "rc": 0, "start": "2019-12-19 11:01:49.711754", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the cStorVolume status] *******************************************
2019-12-19T11:01:50.476391 (delta: 0.919941)         elapsed: 402.755464 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume -n openebs --no-headers -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 -o custom-columns=:.status.phase", "delta": "0:00:00.798917", "end": "2019-12-19 11:01:51.467765", "rc": 0, "start": "2019-12-19 11:01:50.668848", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}

TASK [Check the status of CVR] *************************************************
2019-12-19T11:01:51.511872 (delta: 1.035442)         elapsed: 403.790945 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-8649b257-fd73-43dd-a2df-3b413f607f48 --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.697261", "end": "2019-12-19 11:01:52.366815", "rc": 0, "start": "2019-12-19 11:01:51.669554", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Check the status of CStorPoolInstance] ***********************************
2019-12-19T11:01:52.417123 (delta: 0.905214)         elapsed: 404.696196 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.780045", "end": "2019-12-19 11:01:53.352999", "rc": 0, "start": "2019-12-19 11:01:52.572954", "stderr": "", "stderr_lines": [], "stdout": "ONLINE\nONLINE\nONLINE", "stdout_lines": ["ONLINE", "ONLINE", "ONLINE"]}

TASK [Get application pod name] ************************************************
2019-12-19T11:01:53.397036 (delta: 0.979876)         elapsed: 405.676109 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-1 -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.702291", "end": "2019-12-19 11:01:54.246908", "rc": 0, "start": "2019-12-19 11:01:53.544617", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-k6zbd", "stdout_lines": ["percona-7c6969cf78-k6zbd"]}

TASK [Verify application data persistence] *************************************
2019-12-19T11:01:54.291938 (delta: 0.894868)         elapsed: 406.571011 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
2019-12-19T11:01:54.383333 (delta: 0.091356)         elapsed: 406.662406 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database testdb16;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database testdb16;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' testdb16)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' testdb16", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' testdb16)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' testdb16", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
2019-12-19T11:01:54.459382 (delta: 0.076013)         elapsed: 406.738455 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7c6969cf78-k6zbd -n percona-1", "delta": "0:00:09.945708", "end": "2019-12-19 11:02:04.572706", "rc": 0, "start": "2019-12-19 11:01:54.626998", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7c6969cf78-k6zbd\" deleted", "stdout_lines": ["pod \"percona-7c6969cf78-k6zbd\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
2019-12-19T11:02:04.611779 (delta: 10.152303)         elapsed: 416.890852 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-1", "delta": "0:00:00.687701", "end": "2019-12-19 11:02:05.468526", "rc": 0, "start": "2019-12-19 11:02:04.780825", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS              RESTARTS   AGE\npercona-7c6969cf78-v9ms7   0/1     ContainerCreating   0          10s", "stdout_lines": ["NAME                       READY   STATUS              RESTARTS   AGE", "percona-7c6969cf78-v9ms7   0/1     ContainerCreating   0          10s"]}

TASK [Obtain the newly created pod name for application] ***********************
2019-12-19T11:02:05.534004 (delta: 0.922188)         elapsed: 417.813077 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-1 -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:00.674459", "end": "2019-12-19 11:02:06.372826", "rc": 0, "start": "2019-12-19 11:02:05.698367", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-v9ms7", "stdout_lines": ["percona-7c6969cf78-v9ms7"]}

TASK [Checking application pod is in running state] ****************************
2019-12-19T11:02:06.411983 (delta: 0.877945)         elapsed: 418.691056 ****** 
FAILED - RETRYING: Checking application pod is in running state (150 retries left).
FAILED - RETRYING: Checking application pod is in running state (149 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pods -n percona-1 -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-v9ms7\")].status.phase}'", "delta": "0:00:00.921792", "end": "2019-12-19 11:02:13.229925", "rc": 0, "start": "2019-12-19 11:02:12.308133", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
2019-12-19T11:02:13.322510 (delta: 6.910473)         elapsed: 425.601583 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-1 -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-v9ms7\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.727568", "end": "2019-12-19 11:02:14.202977", "rc": 0, "start": "2019-12-19 11:02:13.475409", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-19T11:02:11Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-19T11:02:11Z]]"]}

TASK [Check if db is ready for connections] ************************************
2019-12-19T11:02:14.269038 (delta: 0.94649)         elapsed: 426.548111 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-7c6969cf78-v9ms7 -n percona-1 | grep 'ready for connections'", "delta": "0:00:00.799643", "end": "2019-12-19 11:02:15.230405", "rc": 0, "start": "2019-12-19 11:02:14.430762", "stderr": "", "stderr_lines": [], "stdout": "2019-12-19T11:02:14.921291Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2019-12-19T11:02:14.921291Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
2019-12-19T11:02:15.276603 (delta: 1.007525)         elapsed: 427.555676 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-v9ms7 -n percona-1 -- mysqlcheck -c testdb16 -uroot -pk8sDem0", "delta": "0:00:01.456549", "end": "2019-12-19 11:02:16.882316", "failed_when_result": false, "rc": 0, "start": "2019-12-19 11:02:15.425767", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "testdb16.ttbl                                      OK", "stdout_lines": ["testdb16.ttbl                                      OK"]}

TASK [Verify mysql data persistence] *******************************************
2019-12-19T11:02:16.927838 (delta: 1.651197)         elapsed: 429.206911 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-v9ms7 -n percona-1 -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' testdb16;", "delta": "0:00:00.990534", "end": "2019-12-19 11:02:18.072042", "failed_when_result": false, "rc": 0, "start": "2019-12-19 11:02:17.081508", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
2019-12-19T11:02:18.135160 (delta: 1.207287)         elapsed: 430.414233 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
2019-12-19T11:02:18.191182 (delta: 0.055971)         elapsed: 430.470255 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Setting pass flag] *******************************************************
2019-12-19T11:02:18.234637 (delta: 0.043415)         elapsed: 430.51371 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-12-19T11:02:18.302955 (delta: 0.06828)         elapsed: 430.582028 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-19T11:02:18.373636 (delta: 0.070641)         elapsed: 430.652709 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-19T11:02:18.414660 (delta: 0.040986)         elapsed: 430.693733 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-19T11:02:18.455281 (delta: 0.040579)         elapsed: 430.734354 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-19T11:02:18.495834 (delta: 0.040518)         elapsed: 430.774907 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "1d817d449757d52d413e983e6dc78fff2d7d2367", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c0bf841d4a0a7837a7f826c524746747", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1576753338.54-129315962231008/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-19T11:02:20.029429 (delta: 1.533559)         elapsed: 432.308502 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.563634", "end": "2019-12-19 11:02:20.734669", "rc": 0, "start": "2019-12-19 11:02:20.171035", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: blockdevice-replacement \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: blockdevice-replacement ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-19T11:02:20.775524 (delta: 0.746064)         elapsed: 433.054597 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-19T09:05:16Z", "generation": 20, "name": "blockdevice-replacement", "resourceVersion": "52076", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/blockdevice-replacement", "uid": "8fbcb264-285b-41a0-8bea-d91278f2a6e3"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=57   changed=42   unreachable=0    failed=0   

2019-12-19T11:02:21.605257 (delta: 0.829694)         elapsed: 433.88433 ******* 
=============================================================================== 
```