### PR TITLE
refactor[yaml]: Modified target network loss to validate cstor csi remount

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/chaosutil.j2
+++ b/experiments/chaos/openebs_target_network_loss/chaosutil.j2
@@ -10,4 +10,10 @@
   {% endif %}
 {% endif %}
 
+{% if stg_prov is defined and stg_prov == 'cstor.csi.openebs.io' %}
+  {% if stg_engine is defined and stg_engine == 'cstor' and (cri == 'containerd' or cri == 'cri-o') %}
+    chaosutil: openebs/inject_packet_loss_tc.yml
+  {% endif %}
+{% endif %}
+
 

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -166,9 +166,10 @@
             - cri == 'containerd' or cri =='cri-o'  
             - stg_engine == 'jiva'
 
-        - name: Wait for 10s post fault injection 
+        - name: Wait for 240s post fault injection 
           wait_for:
-            timeout: 10
+            timeout: 240
+          when: cri == 'containerd' or cri =='cri-o'
 
         - include: "{{ chaos_util_path }}"
           vars:
@@ -192,35 +193,68 @@
           
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
-        - name: Kill the application pod
-          shell: >
-            kubectl delete pod {{ app_pod_name.stdout }} -n {{ namespace }}
-          args:
-            executable: /bin/bash
+        - block:
+            - name: Kill the application pod
+              shell: >
+                kubectl delete pod {{ app_pod_name.stdout }} -n {{ namespace }}
+              args:
+                executable: /bin/bash
 
-        - name: Verify if the application pod is deleted
-          shell: >
-            kubectl get pods -n {{ namespace }}
-          args:
-            executable: /bin/bash
-          register: podstatus
-          until: '"{{ app_pod_name.stdout }}" not in podstatus.stdout'
-          retries: 2
-          delay: 150
+            - name: Verify if the application pod is deleted
+              shell: >
+                kubectl get pods -n {{ namespace }}
+              args:
+                executable: /bin/bash
+              register: podstatus
+              until: '"{{ app_pod_name.stdout }}" not in podstatus.stdout'
+              retries: 2
+              delay: 150
 
-        - name: Obtain the newly created pod name for application
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} -o jsonpath='{.items[].metadata.name}'
-          args:
-            executable: /bin/bash
-          register: newpod_name
+            - name: Obtain the newly created pod name for application
+              shell: >
+                kubectl get pods -n {{ namespace }} -l {{ label }} -o jsonpath='{.items[].metadata.name}'
+              args:
+                executable: /bin/bash
+              register: newpod_name
 
-        - name: Checking application pod in running state
-          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[*].state}'
-          register: result
-          until: "'running' in result.stdout"
-          delay: 2
-          retries: 150
+            - name: Checking application pod in running state
+              shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[*].state}'
+              register: result
+              until: "'running' in result.stdout"
+              delay: 2
+              retries: 150
+          when: stg_prov == 'openebs.io/provisioner-iscsi'
+
+        - block:
+
+            - name: Verify that the volume is healthy
+              shell: >
+                kubectl get cstorvolume {{ pv.stdout }} -n {{ operator_ns }} 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: Status
+              until: "'Healthy' in Status.stdout"
+              delay: 5
+              retries: 60
+
+            - name: Verify that the AUT (Application Under Test) is running
+              include_tasks: "/utils/k8s/status_app_pod.yml"
+              vars:
+                app_ns: "{{namespace}}" 
+                app_lkey: "{{ label.split('=')[0] }}"
+                app_lvalue: "{{ label.split('=')[1] }}"       
+                delay: 5
+                retries: 60
+
+            - name: Verify test data
+              include: "{{ data_consistency_util_path }}"
+              vars:
+                status: 'VERIFY'
+                ns: "{{ namespace }}"
+                pod_name: "{{ app_pod_name.stdout }}"
+              when: data_persistence != '' 
+          when: stg_prov == 'cstor.csi.openebs.io'
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
+++ b/experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
@@ -35,6 +35,28 @@
     - name: Check for presence & value of cas type annotation
       shell: >
         kubectl get pv {{ pv.stdout }} --no-headers
+        -o jsonpath="{.spec.csi.volumeAttributes.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "cstor.csi.openebs.io"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
+        kubectl get pv {{ pv.stdout }} --no-headers
         -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
       args:
         executable: /bin/bash


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified target network loss to validate cstor csi remount

**Special notes for your reviewer**:
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_loss/test.yml

PLAY [localhost] ***************************************************************
2019-12-23T09:20:54.305717 (delta: 0.104291)         elapsed: 0.104291 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:2
2019-12-23T09:20:54.328656 (delta: 0.022883)         elapsed: 0.12723 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:12
2019-12-23T09:20:57.281170 (delta: 2.952467)         elapsed: 3.079744 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:2
2019-12-23T09:20:57.423176 (delta: 0.141931)         elapsed: 3.22175 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n sam --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:00.529191", "end": "2019-12-23 09:20:58.560381", "rc": 0, "start": "2019-12-23 09:20:58.031190", "stderr": "", "stderr_lines": [], "stdout": "csi-sc", "stdout_lines": ["csi-sc"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:10
2019-12-23T09:20:58.718936 (delta: 1.295674)         elapsed: 4.51751 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc csi-sc --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.396787", "end": "2019-12-23 09:20:59.458635", "rc": 0, "start": "2019-12-23 09:20:59.061848", "stderr": "", "stderr_lines": [], "stdout": "cstor.csi.openebs.io", "stdout_lines": ["cstor.csi.openebs.io"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:18
2019-12-23T09:20:59.576876 (delta: 0.857855)         elapsed: 5.37545 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "csi-sc"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:22
2019-12-23T09:20:59.688281 (delta: 0.111337)         elapsed: 5.486855 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "cstor.csi.openebs.io"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:27
2019-12-23T09:20:59.813396 (delta: 0.125045)         elapsed: 5.61197 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n sam --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.380939", "end": "2019-12-23 09:21:00.482437", "rc": 0, "start": "2019-12-23 09:21:00.101498", "stderr": "", "stderr_lines": [], "stdout": "pvc-daff5bbd-579e-4b86-b112-d75d34a35c93", "stdout_lines": ["pvc-daff5bbd-579e-4b86-b112-d75d34a35c93"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:35
2019-12-23T09:21:00.576821 (delta: 0.76335)         elapsed: 6.375395 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-daff5bbd-579e-4b86-b112-d75d34a35c93 --no-headers -o jsonpath=\"{.spec.csi.volumeAttributes.openebs\\\\.io/cas-type}\"", "delta": "0:00:00.421214", "end": "2019-12-23 09:21:01.237325", "rc": 0, "start": "2019-12-23 09:21:00.816111", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:43
2019-12-23T09:21:01.344688 (delta: 0.767793)         elapsed: 7.143262 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:49
2019-12-23T09:21:01.524131 (delta: 0.179369)         elapsed: 7.322705 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:57
2019-12-23T09:21:01.616445 (delta: 0.092253)         elapsed: 7.415019 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:65
2019-12-23T09:21:01.691835 (delta: 0.07533)         elapsed: 7.490409 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:70
2019-12-23T09:21:01.771511 (delta: 0.079612)         elapsed: 7.570085 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4413a9fc2c62c209b922cb90819e91c2310ff040", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "25e7332e96e6fce71e8672f28745f618", "mode": "0644", "owner": "root", "size": 57, "src": "/root/.ansible/tmp/ansible-tmp-1577092861.85-10106885032798/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:75
2019-12-23T09:21:02.891659 (delta: 1.120064)         elapsed: 8.690233 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1577092862.95-105105588625608/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:19
2019-12-23T09:21:03.441917 (delta: 0.550195)         elapsed: 9.240491 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:22
2019-12-23T09:21:03.567608 (delta: 0.125627)         elapsed: 9.366182 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/inject_packet_loss_tc.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:25
2019-12-23T09:21:03.707946 (delta: 0.140262)         elapsed: 9.50652 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/inject_packet_loss_tc.yml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:29
2019-12-23T09:21:03.823221 (delta: 0.115196)         elapsed: 9.621795 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:36
2019-12-23T09:21:03.953704 (delta: 0.130413)         elapsed: 9.752278 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2019-12-23T09:21:04.120049 (delta: 0.166284)         elapsed: 9.918623 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2019-12-23T09:21:04.224427 (delta: 0.104305)         elapsed: 10.023001 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:38
2019-12-23T09:21:04.321449 (delta: 0.096965)         elapsed: 10.120023 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-23T09:21:04.475787 (delta: 0.154266)         elapsed: 10.274361 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b4a6399a25fbae045154f4a5fa4895e0315d7e06", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0a4d87a3064f79e6407f3c30711a53e4", "mode": "0644", "owner": "root", "size": 457, "src": "/root/.ansible/tmp/ansible-tmp-1577092864.56-214222105751957/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-23T09:21:05.035575 (delta: 0.559701)         elapsed: 10.834149 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.230800", "end": "2019-12-23 09:21:05.544181", "rc": 0, "start": "2019-12-23 09:21:05.313381", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/inject_packet_loss_tc \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/inject_packet_loss_tc ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-23T09:21:05.625789 (delta: 0.590118)         elapsed: 11.424363 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-23T06:35:09Z", "generation": 12, "name": "openebs-target-network-loss", "resourceVersion": "1173474", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-network-loss", "uid": "d1937024-8fba-4a8c-83bb-5cfd7c16727e"}, "spec": {"testMetadata": {"chaostype": "openebs/inject_packet_loss_tc"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-23T09:21:07.421042 (delta: 1.794778)         elapsed: 13.219616 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-23T09:21:07.515857 (delta: 0.094749)         elapsed: 13.314431 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-23T09:21:07.617729 (delta: 0.101807)         elapsed: 13.416303 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:45
2019-12-23T09:21:07.738102 (delta: 0.120282)         elapsed: 13.536676 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : sam", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : csi-sc"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:55
2019-12-23T09:21:07.959976 (delta: 0.221788)         elapsed: 13.75855 ******** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-23T09:21:08.128896 (delta: 0.168841)         elapsed: 13.92747 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n sam -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.420671", "end": "2019-12-23 09:21:08.840881", "rc": 0, "start": "2019-12-23 09:21:08.420210", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-23T09:17:16Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-23T09:17:16Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-23T09:21:08.974424 (delta: 0.845463)         elapsed: 14.772998 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.375684", "end": "2019-12-23 09:21:09.695282", "rc": 0, "start": "2019-12-23 09:21:09.319598", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:64
2019-12-23T09:21:09.811614 (delta: 0.837124)         elapsed: 15.610188 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.411506", "end": "2019-12-23 09:21:10.481138", "rc": 0, "start": "2019-12-23 09:21:10.069632", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-kzb7r", "stdout_lines": ["percona-7c6969cf78-kzb7r"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:72
2019-12-23T09:21:10.564214 (delta: 0.75102)         elapsed: 16.362788 ******** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-12-23T09:21:10.852866 (delta: 0.288591)         elapsed: 16.65144 ******** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb2;') => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-kzb7r -n sam -- mysql -uroot -pk8sDem0 -e 'create database tdb2;'", "delta": "0:00:01.128620", "end": "2019-12-23 09:21:12.241073", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb2;'", "rc": 0, "start": "2019-12-23 09:21:11.112453", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb2) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-kzb7r -n sam -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb2", "delta": "0:00:01.100974", "end": "2019-12-23 09:21:13.625730", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb2", "rc": 0, "start": "2019-12-23 09:21:12.524756", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb2) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-kzb7r -n sam -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb2", "delta": "0:00:01.112327", "end": "2019-12-23 09:21:15.176816", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb2", "rc": 0, "start": "2019-12-23 09:21:14.064489", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-12-23T09:21:15.258474 (delta: 4.405525)         elapsed: 21.057048 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-12-23T09:21:15.394403 (delta: 0.13587)         elapsed: 21.192977 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-12-23T09:21:15.556667 (delta: 0.162185)         elapsed: 21.355241 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-12-23T09:21:15.736971 (delta: 0.180194)         elapsed: 21.535545 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-12-23T09:21:15.895674 (delta: 0.158591)         elapsed: 21.694248 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-12-23T09:21:15.994871 (delta: 0.099126)         elapsed: 21.793445 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-12-23T09:21:16.100817 (delta: 0.105857)         elapsed: 21.899391 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-12-23T09:21:16.228372 (delta: 0.127489)         elapsed: 22.026946 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-12-23T09:21:16.317688 (delta: 0.089252)         elapsed: 22.116262 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV from application PVC] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:80
2019-12-23T09:21:16.420486 (delta: 0.10273)         elapsed: 22.21906 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n sam --no-headers", "delta": "0:00:00.526312", "end": "2019-12-23 09:21:17.210420", "rc": 0, "start": "2019-12-23 09:21:16.684108", "stderr": "", "stderr_lines": [], "stdout": "pvc-daff5bbd-579e-4b86-b112-d75d34a35c93", "stdout_lines": ["pvc-daff5bbd-579e-4b86-b112-d75d34a35c93"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:89
2019-12-23T09:21:17.349444 (delta: 0.928889)         elapsed: 23.148018 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-daff5bbd-579e-4b86-b112-d75d34a35c93 | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.476254", "end": "2019-12-23 09:21:18.168810", "rc": 0, "start": "2019-12-23 09:21:17.692556", "stderr": "", "stderr_lines": [], "stdout": "pvc-daff5bbd-579e-4b86-b112-d75d34a35c93-target-77574ddc6dbnjlx", "stdout_lines": ["pvc-daff5bbd-579e-4b86-b112-d75d34a35c93-target-77574ddc6dbnjlx"]}

TASK [Identify the patch to be invoked] ****************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:101
2019-12-23T09:21:18.254389 (delta: 0.904865)         elapsed: 24.052963 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching jiva controller deployment to allow security privileged] ********
task path: /experiments/chaos/openebs_target_network_loss/test.yml:106
2019-12-23T09:21:18.349543 (delta: 0.094837)         elapsed: 24.148117 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for 10s post fault injection] ***************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:113
2019-12-23T09:21:18.428343 (delta: 0.078741)         elapsed: 24.226917 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:117
2019-12-23T09:21:18.519239 (delta: 0.090836)         elapsed: 24.317813 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for the jiva controller container status] **************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:126
2019-12-23T09:21:18.624168 (delta: 0.104855)         elapsed: 24.422742 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:141
2019-12-23T09:21:18.721404 (delta: 0.097146)         elapsed: 24.519978 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:149
2019-12-23T09:21:18.917411 (delta: 0.195919)         elapsed: 24.715985 ******* 
included: /chaoslib/openebs/inject_packet_loss_tc.yml for 127.0.0.1

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:14
2019-12-23T09:21:19.154890 (delta: 0.2374)         elapsed: 24.953464 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-daff5bbd-579e-4b86-b112-d75d34a35c93-target-77574ddc6dbnjlx -n openebs --container cstor-istgt -- bash -c \"which tc\"", "delta": "0:00:01.037071", "end": "2019-12-23 09:21:20.500915", "rc": 0, "start": "2019-12-23 09:21:19.463844", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "/sbin/tc", "stdout_lines": ["/sbin/tc"]}

TASK [Install tc command on targeted pod] **************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:20
2019-12-23T09:21:20.611027 (delta: 1.456072)         elapsed: 26.409601 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on target] ********************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:27
2019-12-23T09:21:20.732372 (delta: 0.121279)         elapsed: 26.530946 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-daff5bbd-579e-4b86-b112-d75d34a35c93-target-77574ddc6dbnjlx -n openebs --container cstor-istgt -- bash -c \"tc qdisc add dev eth0 root netem loss 100.00\"", "delta": "0:00:00.990030", "end": "2019-12-23 09:21:22.135398", "rc": 0, "start": "2019-12-23 09:21:21.145368", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove packet loss rule from targeted pod] *******************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:37
2019-12-23T09:21:22.217191 (delta: 1.48475)         elapsed: 28.015765 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:159
2019-12-23T09:21:22.299011 (delta: 0.081758)         elapsed: 28.097585 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for 240s post fault injection] **************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:169
2019-12-23T09:21:22.426233 (delta: 0.127157)         elapsed: 28.224807 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 240, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:174
2019-12-23T09:25:23.131992 (delta: 240.705678)         elapsed: 268.930566 **** 
included: /chaoslib/openebs/inject_packet_loss_tc.yml for 127.0.0.1

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:14
2019-12-23T09:25:23.294016 (delta: 0.161974)         elapsed: 269.09259 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install tc command on targeted pod] **************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:20
2019-12-23T09:25:23.360589 (delta: 0.066516)         elapsed: 269.159163 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on target] ********************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:27
2019-12-23T09:25:23.426181 (delta: 0.065542)         elapsed: 269.224755 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove packet loss rule from targeted pod] *******************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:37
2019-12-23T09:25:23.499922 (delta: 0.07368)         elapsed: 269.298496 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-daff5bbd-579e-4b86-b112-d75d34a35c93-target-77574ddc6dbnjlx -n openebs --container cstor-istgt -- bash -c \"tc qdisc del dev eth0 root netem loss 100.00\"", "delta": "0:00:00.796812", "end": "2019-12-23 09:25:24.518595", "rc": 0, "start": "2019-12-23 09:25:23.721783", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:184
2019-12-23T09:25:24.588604 (delta: 1.088616)         elapsed: 270.387178 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:197
2019-12-23T09:25:24.668498 (delta: 0.079846)         elapsed: 270.467072 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:203
2019-12-23T09:25:24.728419 (delta: 0.059873)         elapsed: 270.526993 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:213
2019-12-23T09:25:24.790377 (delta: 0.061911)         elapsed: 270.588951 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod in running state] *******************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:220
2019-12-23T09:25:24.864785 (delta: 0.074357)         elapsed: 270.663359 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the volume is healthy] ***************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:230
2019-12-23T09:25:24.958404 (delta: 0.093542)         elapsed: 270.756978 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume pvc-daff5bbd-579e-4b86-b112-d75d34a35c93 -n openebs --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.293581", "end": "2019-12-23 09:25:25.477932", "rc": 0, "start": "2019-12-23 09:25:25.184351", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:241
2019-12-23T09:25:25.568265 (delta: 0.609795)         elapsed: 271.366839 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2019-12-23T09:25:25.684579 (delta: 0.116258)         elapsed: 271.483153 ****** 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
FAILED - RETRYING: Get the container status of application. (134 retries left).
FAILED - RETRYING: Get the container status of application. (133 retries left).
FAILED - RETRYING: Get the container status of application. (132 retries left).
FAILED - RETRYING: Get the container status of application. (131 retries left).
FAILED - RETRYING: Get the container status of application. (130 retries left).
FAILED - RETRYING: Get the container status of application. (129 retries left).
FAILED - RETRYING: Get the container status of application. (128 retries left).
FAILED - RETRYING: Get the container status of application. (127 retries left).
FAILED - RETRYING: Get the container status of application. (126 retries left).
FAILED - RETRYING: Get the container status of application. (125 retries left).
FAILED - RETRYING: Get the container status of application. (124 retries left).
FAILED - RETRYING: Get the container status of application. (123 retries left).
FAILED - RETRYING: Get the container status of application. (122 retries left).
FAILED - RETRYING: Get the container status of application. (121 retries left).
FAILED - RETRYING: Get the container status of application. (120 retries left).
FAILED - RETRYING: Get the container status of application. (119 retries left).
changed: [127.0.0.1] => {"attempts": 33, "changed": true, "cmd": "kubectl get pod -n sam -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.345823", "end": "2019-12-23 09:26:50.379931", "rc": 0, "start": "2019-12-23 09:26:50.034108", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-23T09:26:50Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-23T09:26:50Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2019-12-23T09:26:50.502713 (delta: 84.81808)         elapsed: 356.301287 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.424138", "end": "2019-12-23 09:26:51.226755", "rc": 0, "start": "2019-12-23 09:26:50.802617", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify test data] ********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:250
2019-12-23T09:26:51.327062 (delta: 0.824296)         elapsed: 357.125636 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2019-12-23T09:26:51.551815 (delta: 0.224685)         elapsed: 357.350389 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb2;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb2;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb2)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb2)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb2", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2019-12-23T09:26:51.681130 (delta: 0.129239)         elapsed: 357.479704 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7c6969cf78-kzb7r -n sam", "delta": "0:00:03.306894", "end": "2019-12-23 09:26:55.252589", "rc": 0, "start": "2019-12-23 09:26:51.945695", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7c6969cf78-kzb7r\" deleted", "stdout_lines": ["pod \"percona-7c6969cf78-kzb7r\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2019-12-23T09:26:55.462285 (delta: 3.781082)         elapsed: 361.260859 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam", "delta": "0:00:00.373077", "end": "2019-12-23 09:26:56.274329", "rc": 0, "start": "2019-12-23 09:26:55.901252", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS              RESTARTS   AGE\npercona-7c6969cf78-lgk5k   0/1     ContainerCreating   0          4s", "stdout_lines": ["NAME                       READY   STATUS              RESTARTS   AGE", "percona-7c6969cf78-lgk5k   0/1     ContainerCreating   0          4s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2019-12-23T09:26:56.385485 (delta: 0.923063)         elapsed: 362.184059 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.382125", "end": "2019-12-23 09:26:58.047103", "rc": 0, "start": "2019-12-23 09:26:56.664978", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-lgk5k", "stdout_lines": ["percona-7c6969cf78-lgk5k"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2019-12-23T09:26:58.125751 (delta: 1.740201)         elapsed: 363.924325 ****** 
FAILED - RETRYING: Checking application pod is in running state (150 retries left).
FAILED - RETRYING: Checking application pod is in running state (149 retries left).
FAILED - RETRYING: Checking application pod is in running state (148 retries left).
FAILED - RETRYING: Checking application pod is in running state (147 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n sam -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-lgk5k\")].status.phase}'", "delta": "0:00:00.356447", "end": "2019-12-23 09:27:09.451210", "rc": 0, "start": "2019-12-23 09:27:09.094763", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2019-12-23T09:27:09.550511 (delta: 11.424689)         elapsed: 375.349085 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-lgk5k\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.446250", "end": "2019-12-23 09:27:10.409701", "rc": 0, "start": "2019-12-23 09:27:09.963451", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-12-23T09:27:07Z]]", "stdout_lines": ["map[running:map[startedAt:2019-12-23T09:27:07Z]]"]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2019-12-23T09:27:10.504727 (delta: 0.954146)         elapsed: 376.303301 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-lgk5k -n sam -- mysqlcheck -c tdb2 -uroot -pk8sDem0", "delta": "0:00:00.960443", "end": "2019-12-23 09:27:11.686578", "failed_when_result": false, "rc": 0, "start": "2019-12-23 09:27:10.726135", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb2.ttbl                                          OK", "stdout_lines": ["tdb2.ttbl                                          OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:70
2019-12-23T09:27:11.772107 (delta: 1.26732)         elapsed: 377.570681 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-lgk5k -n sam -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb2;", "delta": "0:00:01.030285", "end": "2019-12-23 09:27:13.117987", "failed_when_result": false, "rc": 0, "start": "2019-12-23 09:27:12.087702", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:83
2019-12-23T09:27:13.194489 (delta: 1.422303)         elapsed: 378.993063 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:91
2019-12-23T09:27:13.293943 (delta: 0.099393)         elapsed: 379.092517 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:259
2019-12-23T09:27:13.368946 (delta: 0.074942)         elapsed: 379.16752 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:270
2019-12-23T09:27:13.460539 (delta: 0.091532)         elapsed: 379.259113 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2019-12-23T09:27:13.590231 (delta: 0.129632)         elapsed: 379.388805 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2019-12-23T09:27:13.656833 (delta: 0.06655)         elapsed: 379.455407 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2019-12-23T09:27:13.734396 (delta: 0.077486)         elapsed: 379.53297 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2019-12-23T09:27:13.827833 (delta: 0.093379)         elapsed: 379.626407 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "758d3b8e4d8f9b67957aa16b7f592dc929872911", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4468d8d3a7d480bbec78a3546de12401", "mode": "0644", "owner": "root", "size": 455, "src": "/root/.ansible/tmp/ansible-tmp-1577093233.94-265463937482684/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2019-12-23T09:27:14.898920 (delta: 1.071018)         elapsed: 380.697494 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.176683", "end": "2019-12-23 09:27:15.319679", "rc": 0, "start": "2019-12-23 09:27:15.142996", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/inject_packet_loss_tc \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/inject_packet_loss_tc ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2019-12-23T09:27:15.389022 (delta: 0.490022)         elapsed: 381.187596 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-23T06:35:09Z", "generation": 13, "name": "openebs-target-network-loss", "resourceVersion": "1175515", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-network-loss", "uid": "d1937024-8fba-4a8c-83bb-5cfd7c16727e"}, "spec": {"testMetadata": {"chaostype": "openebs/inject_packet_loss_tc"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=51   changed=31   unreachable=0    failed=0   

2019-12-23T09:27:16.602908 (delta: 1.213816)         elapsed: 382.401482 ****** 
=============================================================================== 
```