### PR TITLE
refactor[yaml]: Added REMOUNT env variable to csi-operator

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -217,10 +217,10 @@
                 executable: /bin/bash
               register: newpod_name
 
-            - name: Checking application pod in running state
+            - name: Checking application pod not in running state
               shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.name=="{{ newpod_name.stdout }}")].status.containerStatuses[*].state}'
               register: result
-              until: "'running' in result.stdout"
+              until: "'running' not in result.stdout"
               delay: 2
               retries: 150
           when: stg_prov == 'openebs.io/provisioner-iscsi'

--- a/providers/csi-provisioner/patch.j2
+++ b/providers/csi-provisioner/patch.j2
@@ -1,0 +1,19 @@
+{
+ "spec": {
+  "template": {
+    "spec": {
+     "containers": [
+      {
+       "name": "openebs-csi-plugin",
+       "env": [
+        {
+           "name": "REMOUNT",
+           "value": "true"
+        }
+       ]
+      }
+     ]
+    }
+  }
+ }
+}

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -18,21 +18,55 @@
 
         - block:
 
-           - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04 
-             shell: >
-               kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml
-             args:
-               executable: /bin/bash
+            - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04 
+              shell: >
+                kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml
+              args:
+                executable: /bin/bash
+
+            - name: Identify the patch to be invoked
+              template:
+                src: patch.j2
+                dest: patch.yml
+
+            - name: Patching openebs cstor csi-driver statefulset to allow volume remount
+              shell: >
+                kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch "$(cat patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"
+
+            - name: Patching openebs cstor csi-driver daemonset to allow volume remount
+              shell: >
+                kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch "$(cat patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"
 
           when: node_os == "ubuntu-16.04" or node_os == "centos"
 
         - block:
 
-           - name: Deploy CSI Driver if os is ubuntu 18.04
-             shell: >
-               kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator-ubuntu-18.04.yaml
-             args:
-               executable: /bin/bash
+            - name: Deploy CSI Driver if os is ubuntu 18.04
+              shell: >
+                kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator-ubuntu-18.04.yaml
+              args:
+                executable: /bin/bash
+
+            - name: Identify the patch to be invoked
+              template:
+                src: patch.j2
+                dest: patch.yml
+
+            - name: Patching openebs cstor csi-driver statefulset to allow volume remount
+              shell: >
+                kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch "$(cat patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"
+              
+            - name: Patching openebs cstor csi-driver daemonset to allow volume remount
+              shell: >
+                kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch "$(cat patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"    
 
           when: node_os == "ubuntu-18.04"
 

--- a/utils/k8s/pre_create_app_deploy.yml
+++ b/utils/k8s/pre_create_app_deploy.yml
@@ -1,12 +1,12 @@
 ---
 - block:
     - name: Check whether the provider storageclass is applied
-      k8s_facts:
-        kind: StorageClass
-        name: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+      shell: kubectl get sc "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+      args:
+        executable: /bin/bash
       register: result
-      failed_when: result.resources | length < 1
-
+      failed_when: "result.rc != 0"
+      
     - name: Replace the pvc placeholder with provider
       replace:
         path: "{{ application_deployment }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Added REMOUNT env variable to csi-operator

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2019-12-26T05:08:00.035816 (delta: 0.081853)         elapsed: 0.081853 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-12-26T05:08:00.056320 (delta: 0.020375)         elapsed: 0.102357 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-12-26T05:08:02.820548 (delta: 2.764176)         elapsed: 2.866585 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-12-26T05:08:02.934491 (delta: 0.113895)         elapsed: 2.980528 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-12-26T05:08:03.033594 (delta: 0.099026)         elapsed: 3.079631 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-26T05:08:03.145776 (delta: 0.112105)         elapsed: 3.191813 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-26T05:08:03.347854 (delta: 0.201972)         elapsed: 3.393891 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "af580fd43c60b8040cbac636c779b0cb4ebf449b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2d66fb549be9e3c9cae61b70ee95b9e0", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1577336883.41-51977644863389/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-26T05:08:04.283365 (delta: 0.935439)         elapsed: 4.329402 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.146625", "end": "2019-12-26 05:08:04.871249", "rc": 0, "start": "2019-12-26 05:08:04.724624", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-26T05:08:04.943896 (delta: 0.660469)         elapsed: 4.989933 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-24T10:49:57Z", "generation": 9, "name": "csi-provision", "resourceVersion": "805727", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "332ebe5d-666b-4aab-ad19-2c796fcda94e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-26T05:08:06.625232 (delta: 1.681274)         elapsed: 6.671269 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-26T05:08:06.712529 (delta: 0.086892)         elapsed: 6.758566 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-26T05:08:06.793958 (delta: 0.081339)         elapsed: 6.839995 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy CSI Driver if OS is either centos or ubuntu-16.04] ****************
2019-12-26T05:08:06.861088 (delta: 0.067066)         elapsed: 6.907125 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml", "delta": "0:00:06.727414", "end": "2019-12-26 05:08:13.828111", "rc": 0, "start": "2019-12-26 05:08:07.100697", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged\nserviceaccount/openebs-cstor-csi-controller-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding unchanged\nstatefulset.apps/openebs-cstor-csi-controller created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding unchanged\nserviceaccount/openebs-cstor-csi-node-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding unchanged\ndaemonset.apps/openebs-cstor-csi-node created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged", "serviceaccount/openebs-cstor-csi-controller-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding unchanged", "statefulset.apps/openebs-cstor-csi-controller created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding unchanged", "serviceaccount/openebs-cstor-csi-node-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding unchanged", "daemonset.apps/openebs-cstor-csi-node created"]}

TASK [Identify the patch to be invoked] ****************************************
2019-12-26T05:08:13.944477 (delta: 7.08333)         elapsed: 13.990514 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2bdd4471cdc6744b7b646cafd30905fba75ec9f7", "dest": "./patch.yml", "gid": 0, "group": "root", "md5sum": "b5644b52d2b84935254518e49be7c9f1", "mode": "0644", "owner": "root", "size": 240, "src": "/root/.ansible/tmp/ansible-tmp-1577336894.02-11211461812878/source", "state": "file", "uid": 0}

TASK [Patching openebs cstor csi-driver statefulset to allow volume remount] ***
2019-12-26T05:08:14.551697 (delta: 0.607157)         elapsed: 14.597734 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch \"$(cat patch.yml)\"", "delta": "0:00:00.414796", "end": "2019-12-26 05:08:15.261754", "failed_when_result": false, "rc": 0, "start": "2019-12-26 05:08:14.846958", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps/openebs-cstor-csi-controller patched", "stdout_lines": ["statefulset.apps/openebs-cstor-csi-controller patched"]}

TASK [Patching openebs cstor csi-driver daemonset to allow volume remount] *****
2019-12-26T05:08:15.381111 (delta: 0.829351)         elapsed: 15.427148 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch \"$(cat patch.yml)\"", "delta": "0:00:00.403529", "end": "2019-12-26 05:08:16.076975", "failed_when_result": false, "rc": 0, "start": "2019-12-26 05:08:15.673446", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/openebs-cstor-csi-node patched", "stdout_lines": ["daemonset.extensions/openebs-cstor-csi-node patched"]}

TASK [Deploy CSI Driver if os is ubuntu 18.04] *********************************
2019-12-26T05:08:16.221410 (delta: 0.840205)         elapsed: 16.267447 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the patch to be invoked] ****************************************
2019-12-26T05:08:16.323002 (delta: 0.10151)         elapsed: 16.369039 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching openebs cstor csi-driver statefulset to allow volume remount] ***
2019-12-26T05:08:16.439494 (delta: 0.116403)         elapsed: 16.485531 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching openebs cstor csi-driver daemonset to allow volume remount] *****
2019-12-26T05:08:16.546438 (delta: 0.106861)         elapsed: 16.592475 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if csi-controller pod is running] **********************************
2019-12-26T05:08:16.648311 (delta: 0.10165)         elapsed: 16.694348 ******** 
FAILED - RETRYING: check if csi-controller pod is running (30 retries left).
FAILED - RETRYING: check if csi-controller pod is running (29 retries left).
FAILED - RETRYING: check if csi-controller pod is running (28 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.368751", "end": "2019-12-26 05:08:49.163665", "rc": 0, "start": "2019-12-26 05:08:48.794914", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2019-12-26T05:08:49.247356 (delta: 32.598929)         elapsed: 49.293393 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:00.358384", "end": "2019-12-26 05:08:49.880380", "rc": 0, "start": "2019-12-26 05:08:49.521996", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Check if the desired count matches the ready pods] ***********************
2019-12-26T05:08:49.984534 (delta: 0.737089)         elapsed: 50.030571 ******* 
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": ["kubectl", "get", "ds", "-n", "kube-system", "openebs-cstor-csi-node", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:00.323637", "end": "2019-12-26 05:08:50.573209", "rc": 0, "start": "2019-12-26 05:08:50.249572", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Update the storage class template with the variables.] *******************
2019-12-26T05:08:50.693905 (delta: 0.709305)         elapsed: 50.739942 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "2e1cd14ff4c680a82f60423c2e8d64c4478ec859", "dest": "./csi-cstor-sc.yml", "gid": 0, "group": "root", "md5sum": "79a8cafd2b514a365fc135d49566143f", "mode": "0644", "owner": "root", "size": 294, "src": "/root/.ansible/tmp/ansible-tmp-1577336930.78-30148386742586/source", "state": "file", "uid": 0}

TASK [Create Storageclass] *****************************************************
2019-12-26T05:08:51.357369 (delta: 0.663381)         elapsed: 51.403406 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-sc.yml", "delta": "0:00:01.092959", "end": "2019-12-26 05:08:52.787047", "failed_when_result": false, "rc": 0, "start": "2019-12-26 05:08:51.694088", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-csi-cstor-sparse created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-csi-cstor-sparse created"]}

TASK [Update the volume snapshotclass template with the variables] *************
2019-12-26T05:08:52.875043 (delta: 1.51761)         elapsed: 52.92108 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "02e2271c90ce59569a49dc852ce824fa54224dab", "dest": "./snapshot-class.yml", "gid": 0, "group": "root", "md5sum": "75e3a11ddb301d34b68626be558ad9a1", "mode": "0644", "owner": "root", "size": 234, "src": "/root/.ansible/tmp/ansible-tmp-1577336932.95-232338813467660/source", "state": "file", "uid": 0}

TASK [Create volume snapshotclass] *********************************************
2019-12-26T05:08:53.462723 (delta: 0.587604)         elapsed: 53.50876 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-class.yml", "delta": "0:00:00.851123", "end": "2019-12-26 05:08:54.590581", "failed_when_result": false, "rc": 0, "start": "2019-12-26 05:08:53.739458", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor unchanged", "stdout_lines": ["volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor unchanged"]}

TASK [set_fact] ****************************************************************
2019-12-26T05:08:54.678051 (delta: 1.21523)         elapsed: 54.724088 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-12-26T05:08:54.785460 (delta: 0.107326)         elapsed: 54.831497 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-26T05:08:54.931335 (delta: 0.145811)         elapsed: 54.977372 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-26T05:08:55.035997 (delta: 0.104585)         elapsed: 55.082034 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-26T05:08:55.141495 (delta: 0.105412)         elapsed: 55.187532 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-26T05:08:55.237525 (delta: 0.095962)         elapsed: 55.283562 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8465df021b7326c95c9856682eb50700e84d8dc7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "685bbc60e191086cf7d2cf0f55be2022", "mode": "0644", "owner": "root", "size": 412, "src": "/root/.ansible/tmp/ansible-tmp-1577336935.34-248570633927788/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-26T05:08:56.424654 (delta: 1.187052)         elapsed: 56.470691 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.251700", "end": "2019-12-26 05:08:57.090405", "rc": 0, "start": "2019-12-26 05:08:56.838705", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-26T05:08:57.194974 (delta: 0.770257)         elapsed: 57.241011 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-24T10:49:57Z", "generation": 10, "name": "csi-provision", "resourceVersion": "806240", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "332ebe5d-666b-4aab-ad19-2c796fcda94e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=22   changed=17   unreachable=0    failed=0   

2019-12-26T05:08:58.326962 (delta: 1.131901)         elapsed: 58.372999 ******* 
```