### PR TITLE
refactor[yaml]: Modified the csi provisioner to create storage class with fstype xfs

### DIFF
--- a/providers/csi-provisioner/csi-cstor-xfs-sc.j2
+++ b/providers/csi-provisioner/csi-cstor-xfs-sc.j2
@@ -1,0 +1,12 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ storage_class }}-xfs
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  cas-type: cstor
+  replicaCount: "{{ replica_count }}"
+  cstorPoolCluster: {{ cspc }}
+  fsType: xfs

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -111,7 +111,19 @@
             executable: /bin/bash
           register: sc_result
           failed_when: "sc_result.rc != 0"
+          
+        - name: Update the storage class template with the variables for FSType xfs.
+          template:
+            src: csi-cstor-xfs-sc.j2
+            dest: csi-cstor-xfs-sc.yml
 
+        - name: Create Storageclass for xfs FSType
+          shell: kubectl apply -f csi-cstor-xfs-sc.yml
+          args:
+            executable: /bin/bash
+          register: xfs_sc_result
+          failed_when: "xfs_sc_result.rc != 0"
+          
         - name: Update the volume snapshotclass template with the variables
           template:
             src: snapshot-class.j2


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified the csi provisioner to create one more storage class with fstype xfs

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2019-12-27T07:06:01.864597 (delta: 0.088844)         elapsed: 0.088844 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-12-27T07:06:01.879611 (delta: 0.014934)         elapsed: 0.103858 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-12-27T07:06:04.593847 (delta: 2.714196)         elapsed: 2.818094 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-12-27T07:06:04.752005 (delta: 0.15809)         elapsed: 2.976252 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-12-27T07:06:04.825012 (delta: 0.07294)         elapsed: 3.049259 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-27T07:06:04.895076 (delta: 0.070012)         elapsed: 3.119323 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-27T07:06:05.109018 (delta: 0.213882)         elapsed: 3.333265 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "af580fd43c60b8040cbac636c779b0cb4ebf449b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2d66fb549be9e3c9cae61b70ee95b9e0", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1577430365.19-79564244802654/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-27T07:06:06.025705 (delta: 0.916617)         elapsed: 4.249952 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.225092", "end": "2019-12-27 07:06:06.661363", "rc": 0, "start": "2019-12-27 07:06:06.436271", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-27T07:06:06.719744 (delta: 0.693955)         elapsed: 4.943991 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-24T10:49:57Z", "generation": 11, "name": "csi-provision", "resourceVersion": "1357835", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "332ebe5d-666b-4aab-ad19-2c796fcda94e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-27T07:06:08.243495 (delta: 1.523685)         elapsed: 6.467742 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-27T07:06:08.340457 (delta: 0.096906)         elapsed: 6.564704 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-27T07:06:08.452239 (delta: 0.11171)         elapsed: 6.676486 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy CSI Driver if OS is either centos or ubuntu-16.04] ****************
2019-12-27T07:06:08.536877 (delta: 0.084558)         elapsed: 6.761124 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator.yaml", "delta": "0:00:07.045237", "end": "2019-12-27 07:06:15.817958", "rc": 0, "start": "2019-12-27 07:06:08.772721", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged\nserviceaccount/openebs-cstor-csi-controller-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding unchanged\nstatefulset.apps/openebs-cstor-csi-controller configured\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding unchanged\nserviceaccount/openebs-cstor-csi-node-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding unchanged\ndaemonset.apps/openebs-cstor-csi-node configured", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/csivolumes.openebs.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged", "serviceaccount/openebs-cstor-csi-controller-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding unchanged", "statefulset.apps/openebs-cstor-csi-controller configured", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding unchanged", "serviceaccount/openebs-cstor-csi-node-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding unchanged", "daemonset.apps/openebs-cstor-csi-node configured"]}

TASK [Identify the patch to be invoked] ****************************************
2019-12-27T07:06:15.884413 (delta: 7.347478)         elapsed: 14.10866 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2bdd4471cdc6744b7b646cafd30905fba75ec9f7", "dest": "./patch.yml", "gid": 0, "group": "root", "md5sum": "b5644b52d2b84935254518e49be7c9f1", "mode": "0644", "owner": "root", "size": 240, "src": "/root/.ansible/tmp/ansible-tmp-1577430376.0-66802456388359/source", "state": "file", "uid": 0}

TASK [Patching openebs cstor csi-driver statefulset to allow volume remount] ***
2019-12-27T07:06:16.429595 (delta: 0.545126)         elapsed: 14.653842 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch \"$(cat patch.yml)\"", "delta": "0:00:00.365807", "end": "2019-12-27 07:06:17.033940", "failed_when_result": false, "rc": 0, "start": "2019-12-27 07:06:16.668133", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps/openebs-cstor-csi-controller patched (no change)", "stdout_lines": ["statefulset.apps/openebs-cstor-csi-controller patched (no change)"]}

TASK [Patching openebs cstor csi-driver daemonset to allow volume remount] *****
2019-12-27T07:06:17.126793 (delta: 0.697147)         elapsed: 15.35104 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch \"$(cat patch.yml)\"", "delta": "0:00:00.422697", "end": "2019-12-27 07:06:17.824140", "failed_when_result": false, "rc": 0, "start": "2019-12-27 07:06:17.401443", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/openebs-cstor-csi-node patched (no change)", "stdout_lines": ["daemonset.extensions/openebs-cstor-csi-node patched (no change)"]}

TASK [Deploy CSI Driver if os is ubuntu 18.04] *********************************
2019-12-27T07:06:17.974258 (delta: 0.847401)         elapsed: 16.198505 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the patch to be invoked] ****************************************
2019-12-27T07:06:18.131089 (delta: 0.156719)         elapsed: 16.355336 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching openebs cstor csi-driver statefulset to allow volume remount] ***
2019-12-27T07:06:18.292594 (delta: 0.161424)         elapsed: 16.516841 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching openebs cstor csi-driver daemonset to allow volume remount] *****
2019-12-27T07:06:18.441998 (delta: 0.149297)         elapsed: 16.666245 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if csi-controller pod is running] **********************************
2019-12-27T07:06:18.587290 (delta: 0.14521)         elapsed: 16.811537 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.442364", "end": "2019-12-27 07:06:19.451071", "rc": 0, "start": "2019-12-27 07:06:19.008707", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2019-12-27T07:06:19.584062 (delta: 0.996691)         elapsed: 17.808309 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:00.405432", "end": "2019-12-27 07:06:20.278323", "rc": 0, "start": "2019-12-27 07:06:19.872891", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Check if the desired count matches the ready pods] ***********************
2019-12-27T07:06:20.386610 (delta: 0.802473)         elapsed: 18.610857 ******* 
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": ["kubectl", "get", "ds", "-n", "kube-system", "openebs-cstor-csi-node", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:00.380191", "end": "2019-12-27 07:06:21.156127", "rc": 0, "start": "2019-12-27 07:06:20.775936", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Update the storage class template with the variables.] *******************
2019-12-27T07:06:21.304416 (delta: 0.917735)         elapsed: 19.528663 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9890c339373662e248bbea3e508ccdd851b3d17d", "dest": "./csi-cstor-sc.yml", "gid": 0, "group": "root", "md5sum": "cda468a84440d8ff0cec29780dbb6324", "mode": "0644", "owner": "root", "size": 287, "src": "/root/.ansible/tmp/ansible-tmp-1577430381.41-40618568640254/source", "state": "file", "uid": 0}

TASK [Create Storageclass] *****************************************************
2019-12-27T07:06:21.990319 (delta: 0.685815)         elapsed: 20.214566 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-sc.yml", "delta": "0:00:00.814850", "end": "2019-12-27 07:06:23.110149", "failed_when_result": false, "rc": 0, "start": "2019-12-27 07:06:22.295299", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-csi created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-csi created"]}

TASK [Update the storage class template with the variables for FSType xfs.] ****
2019-12-27T07:06:23.249679 (delta: 1.25931)         elapsed: 21.473926 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "7d1bbeda646833ca6db042ce79c9eab26a2ba168", "dest": "./csi-cstor-xfs-sc.yml", "gid": 0, "group": "root", "md5sum": "82da1fc73b660b13967ed2662402409b", "mode": "0644", "owner": "root", "size": 258, "src": "/root/.ansible/tmp/ansible-tmp-1577430383.35-212068609085291/source", "state": "file", "uid": 0}

TASK [Create Storageclass for xfs FSType] **************************************
2019-12-27T07:06:23.895439 (delta: 0.645464)         elapsed: 22.119686 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-xfs-sc.yml", "delta": "0:00:00.685202", "end": "2019-12-27 07:06:24.848224", "failed_when_result": false, "rc": 0, "start": "2019-12-27 07:06:24.163022", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-cstor-csi-xfs created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-cstor-csi-xfs created"]}

TASK [Update the volume snapshotclass template with the variables] *************
2019-12-27T07:06:24.971991 (delta: 1.076496)         elapsed: 23.196238 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "02e2271c90ce59569a49dc852ce824fa54224dab", "dest": "./snapshot-class.yml", "gid": 0, "group": "root", "md5sum": "75e3a11ddb301d34b68626be558ad9a1", "mode": "0644", "owner": "root", "size": 234, "src": "/root/.ansible/tmp/ansible-tmp-1577430385.08-199060194737552/source", "state": "file", "uid": 0}

TASK [Create volume snapshotclass] *********************************************
2019-12-27T07:06:25.716535 (delta: 0.744469)         elapsed: 23.940782 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-class.yml", "delta": "0:00:00.758413", "end": "2019-12-27 07:06:26.742509", "failed_when_result": false, "rc": 0, "start": "2019-12-27 07:06:25.984096", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor unchanged", "stdout_lines": ["volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor unchanged"]}

TASK [set_fact] ****************************************************************
2019-12-27T07:06:26.859378 (delta: 1.142753)         elapsed: 25.083625 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-12-27T07:06:27.009073 (delta: 0.149614)         elapsed: 25.23332 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-27T07:06:27.211649 (delta: 0.202507)         elapsed: 25.435896 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-27T07:06:27.308103 (delta: 0.096387)         elapsed: 25.53235 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-27T07:06:27.422412 (delta: 0.114237)         elapsed: 25.646659 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-27T07:06:27.564959 (delta: 0.142461)         elapsed: 25.789206 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8465df021b7326c95c9856682eb50700e84d8dc7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "685bbc60e191086cf7d2cf0f55be2022", "mode": "0644", "owner": "root", "size": 412, "src": "/root/.ansible/tmp/ansible-tmp-1577430387.7-85663671759169/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-27T07:06:28.515267 (delta: 0.950197)         elapsed: 26.739514 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.148542", "end": "2019-12-27 07:06:29.057953", "rc": 0, "start": "2019-12-27 07:06:28.909411", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-27T07:06:29.126158 (delta: 0.610812)         elapsed: 27.350405 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-24T10:49:57Z", "generation": 12, "name": "csi-provision", "resourceVersion": "1357952", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "332ebe5d-666b-4aab-ad19-2c796fcda94e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=19   unreachable=0    failed=0   

2019-12-27T07:06:30.332745 (delta: 1.206533)         elapsed: 28.556992 ******* 
```