### PR TITLE
Induce target failure while Replica rebuild

### DIFF
--- a/experiments/functional/cvr-scaleup/run_litmus_test.yml
+++ b/experiments/functional/cvr-scaleup/run_litmus_test.yml
@@ -55,6 +55,9 @@ spec:
           - name: DATA_PERSISTENCE
             value: ""
 
+          - name: INDUCE_TARGET_FAILURE
+            value: enable
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/cvr-scaleup/test.yml -i /etc/ansible/hosts -v; exit 0"]
         

--- a/experiments/functional/cvr-scaleup/test.yml
+++ b/experiments/functional/cvr-scaleup/test.yml
@@ -41,6 +41,19 @@
           shell: kubectl get pod -n {{ app_ns }} -l {{ label }} -o jsonpath='{.items[0].metadata.name}'
           register: app_pod_name
 
+        - block:
+
+            - name: Getting the application mount point
+              shell: kubectl get pod {{ app_pod_name.stdout }} -n {{ app_ns }} -o jsonpath='{.spec.containers[0].volumeMounts[0].mountPath}'
+              register: app_mount_path
+              
+              #Writing approx 782M of data at mount point
+            - name: Writing data on application mount point
+              shell: kubectl exec -it {{ app_pod_name.stdout }} -n {{ app_ns }} -- sh -c "cd {{ app_mount_path.stdout }} && dd if=/dev/urandom of=test.txt bs=4k count=200024"
+
+          when: lookup('env','INDUCE_TARGET_FAILURE') == 'enable'
+         
+
         - name: Geting the PV name
           shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
           register: pv
@@ -224,6 +237,40 @@
           until: "'Running' in pod_status.stdout"
           delay: 10
           retries: 50
+
+        - block: 
+
+            - name: Getting the target name 
+              shell:  kubectl get pod -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} -o jsonpath='{.items[0].metadata.name}' 
+              register: target_name
+
+            - name: Checking for reconstructing state of newly created cvr 
+              shell: kubectl get cvr {{ pv.stdout }}-{{ csp_name.stdout_lines[0] }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
+              register: new_cvr_state
+              until: "'ReconstructingNewReplica' in new_cvr_state.stdout"
+              delay: 10
+              retries: 100
+
+            - name: Restarting target
+              shell: kubectl delete pod {{ target_name.stdout }} -n {{ operator_ns }}
+              register: target_delete_status
+              failed_when: "'deleted' not in target_delete_status.stdout"
+
+            - name: Verifying successful deletion of target
+              shell: kubectl get pod -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} -o jsonpath='{.items[0].metadata.name}'
+              register: target_del
+              until: "'{{ target_name.stdout }}' not in target_del.stdout"
+              delay: 10
+              retries: 100
+
+            - name: Waiting for new target to be in running state
+              shell: kubectl get pod -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} -o jsonpath='{.items[0].status.phase}'
+              register: new_target_state
+              until: "'Running' in new_target_state.stdout"
+              delay: 10
+              retries: 100
+               
+          when: lookup('env','INDUCE_TARGET_FAILURE') == 'enable'
 
         - name: Verify newly Created replicaID exists in cstorVolume or not
           shell: kubectl get cstorvolume {{ pv.stdout }} -n {{ operator_ns }} -o jsonpath='{.status.replicaDetails.knownReplicas.{{ md5sum.stdout }}}'


### PR DESCRIPTION
**What this PR does / why we need it**:

- Induce target failure when newly created replica is in sync.

**Following is the log of ansible test container**
```
PLAY [localhost] ***************************************************************
2019-12-31T09:04:55.020096 (delta: 0.093743)         elapsed: 0.093743 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-12-31T09:04:55.039620 (delta: 0.019478)         elapsed: 0.113267 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-12-31T09:05:04.729326 (delta: 9.689672)         elapsed: 9.802973 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-12-31T09:05:04.943611 (delta: 0.214214)         elapsed: 10.017258 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-12-31T09:05:05.023421 (delta: 0.079743)         elapsed: 10.097068 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-12-31T09:05:05.110700 (delta: 0.087226)         elapsed: 10.184347 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-31T09:05:05.293365 (delta: 0.182581)         elapsed: 10.367012 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "1f5327c5dde8d1e2c091ff2a03e17f9c47c51a34", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3b94830ec2c7ec52ee939db0aac74b6a", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1577783105.36-18695514870288/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-31T09:05:06.301292 (delta: 1.007858)         elapsed: 11.374939 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.237095", "end": "2019-12-31 09:05:07.957454", "rc": 0, "start": "2019-12-31 09:05:06.720359", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-cvr-scaleup \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-cvr-scaleup ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-31T09:05:08.031449 (delta: 1.730073)         elapsed: 13.105096 ******* 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-31T08:15:00Z", "generation": 7, "name": "openebs-cvr-scaleup", "resourceVersion": "744557", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-cvr-scaleup", "uid": "a3e54920-2ba5-11ea-81e1-005056982131"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-31T09:05:09.448293 (delta: 1.416782)         elapsed: 14.52194 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-31T09:05:09.525772 (delta: 0.077419)         elapsed: 14.599419 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-31T09:05:09.602936 (delta: 0.077097)         elapsed: 14.676583 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the data consistency util to be invoked] ************************
2019-12-31T09:05:09.687210 (delta: 0.0842)         elapsed: 14.760857 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "68b329da9893e34099c7d8ad5cb9c940", "mode": "0644", "owner": "root", "size": 1, "src": "/root/.ansible/tmp/ansible-tmp-1577783109.74-9465904911386/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
2019-12-31T09:05:10.229883 (delta: 0.542607)         elapsed: 15.30353 ******** 
ok: [127.0.0.1] => {"ansible_facts": {}, "ansible_included_var_files": ["/experiments/functional/cvr-scaleup/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
2019-12-31T09:05:10.354019 (delta: 0.124065)         elapsed: 15.427666 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status of application pod] **********************************
2019-12-31T09:05:10.523060 (delta: 0.168954)         elapsed: 15.596707 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-cvr3 -l name=percona -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.531898", "end": "2019-12-31 09:05:12.357490", "rc": 0, "start": "2019-12-31 09:05:10.825592", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Getting the pod name of Application] *************************************
2019-12-31T09:05:12.551313 (delta: 2.02814)         elapsed: 17.62496 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-percona-cvr3 -l name=percona -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.149587", "end": "2019-12-31 09:05:13.907651", "rc": 0, "start": "2019-12-31 09:05:12.758064", "stderr": "", "stderr_lines": [], "stdout": "percona-755f6678bf-jwsfg", "stdout_lines": ["percona-755f6678bf-jwsfg"]}

TASK [Getting the application mount point] *************************************
2019-12-31T09:05:14.034887 (delta: 1.483437)         elapsed: 19.108534 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-755f6678bf-jwsfg -n app-percona-cvr3 -o jsonpath='{.spec.containers[0].volumeMounts[0].mountPath}'", "delta": "0:00:01.241366", "end": "2019-12-31 09:05:15.501278", "rc": 0, "start": "2019-12-31 09:05:14.259912", "stderr": "", "stderr_lines": [], "stdout": "/var/lib/mysql", "stdout_lines": ["/var/lib/mysql"]}

TASK [Writing data on application mount point] *********************************
2019-12-31T09:05:15.588606 (delta: 1.553602)         elapsed: 20.662253 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it percona-755f6678bf-jwsfg -n app-percona-cvr3 -- sh -c \"cd /var/lib/mysql && dd if=/dev/urandom of=test.txt bs=4k count=200024\"", "delta": "0:00:31.555664", "end": "2019-12-31 09:05:47.355299", "rc": 0, "start": "2019-12-31 09:05:15.799635", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n200024+0 records in\n200024+0 records out\n819298304 bytes (819 MB, 781 MiB) copied, 29.9752 s, 27.3 MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "200024+0 records in", "200024+0 records out", "819298304 bytes (819 MB, 781 MiB) copied, 29.9752 s, 27.3 MB/s"], "stdout": "", "stdout_lines": []}

TASK [Geting the PV name] ******************************************************
2019-12-31T09:05:47.441435 (delta: 31.852773)         elapsed: 52.515082 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-cvr3 -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.274081", "end": "2019-12-31 09:05:48.930022", "rc": 0, "start": "2019-12-31 09:05:47.655941", "stderr": "", "stderr_lines": [], "stdout": "pvc-67410e10-2bac-11ea-81e1-005056982131", "stdout_lines": ["pvc-67410e10-2bac-11ea-81e1-005056982131"]}

TASK [Checking the cstorvolume status] *****************************************
2019-12-31T09:05:49.079545 (delta: 1.638049)         elapsed: 54.153192 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume -n openebs pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.status.phase}'", "delta": "0:00:01.281021", "end": "2019-12-31 09:05:50.624902", "rc": 0, "start": "2019-12-31 09:05:49.343881", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}

TASK [Verify cvr health status] ************************************************
2019-12-31T09:05:50.735940 (delta: 1.65631)         elapsed: 55.809587 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[*].status.phase}'", "delta": "0:00:01.268953", "end": "2019-12-31 09:05:52.381276", "rc": 0, "start": "2019-12-31 09:05:51.112323", "stderr": "", "stderr_lines": [], "stdout": "Healthy Healthy", "stdout_lines": ["Healthy Healthy"]}

TASK [Create some test data] ***************************************************
2019-12-31T09:05:52.489184 (delta: 1.753171)         elapsed: 57.562831 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the storage class name] **********************************************
2019-12-31T09:05:52.627849 (delta: 0.138598)         elapsed: 57.701496 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-cvr3 --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:01.233307", "end": "2019-12-31 09:05:54.318544", "rc": 0, "start": "2019-12-31 09:05:53.085237", "stderr": "", "stderr_lines": [], "stdout": "cvr-sc", "stdout_lines": ["cvr-sc"]}

TASK [Get the storage pool claim (spc) name] ***********************************
2019-12-31T09:05:54.411529 (delta: 1.78358)         elapsed: 59.485176 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc cvr-sc -o jsonpath=\"{.metadata.annotations.cas\\.openebs\\.io\\/config}\" | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g' | sed 's/ //g'", "delta": "0:00:01.239318", "end": "2019-12-31 09:05:55.853508", "rc": 0, "start": "2019-12-31 09:05:54.614190", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe", "stdout_lines": ["cstor-block-disk-pool-stripe"]}

TASK [Getting the list of csp name correspond to provided spc] *****************
2019-12-31T09:05:55.946816 (delta: 1.535209)         elapsed: 61.020463 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o jsonpath='{.items[*].metadata.name}'", "delta": "0:00:01.523443", "end": "2019-12-31 09:05:57.815993", "rc": 0, "start": "2019-12-31 09:05:56.292550", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew cstor-block-disk-pool-stripe-a4qg cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o cstor-block-disk-pool-stripe-k0nc", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew cstor-block-disk-pool-stripe-a4qg cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o cstor-block-disk-pool-stripe-k0nc"]}

TASK [Create a file to store CSP name] *****************************************
2019-12-31T09:05:57.889138 (delta: 1.94224)         elapsed: 62.962785 ******** 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u"kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o jsonpath='{.items[*].metadata.name}'", u'end': u'2019-12-31 09:05:57.815993', u'stdout': u'cstor-block-disk-pool-stripe-8hew cstor-block-disk-pool-stripe-a4qg cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o cstor-block-disk-pool-stripe-k0nc', u'changed': True, 'failed': False, u'delta': u'0:00:01.523443', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'cstor-block-disk-pool-stripe-8hew cstor-block-disk-pool-stripe-a4qg cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o cstor-block-disk-pool-stripe-k0nc'], u'start': u'2019-12-31 09:05:56.292550'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-block-disk-pool-stripe -o jsonpath='{.items[*].metadata.name}'", "delta": "0:00:01.523443", "end": "2019-12-31 09:05:57.815993", "failed": false, "rc": 0, "start": "2019-12-31 09:05:56.292550", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew cstor-block-disk-pool-stripe-a4qg cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o cstor-block-disk-pool-stripe-k0nc", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew cstor-block-disk-pool-stripe-a4qg cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o cstor-block-disk-pool-stripe-k0nc"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the list of csp on which cvr is created] *************************
2019-12-31T09:05:58.412515 (delta: 0.523322)         elapsed: 63.486162 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", "delta": "0:00:01.271819", "end": "2019-12-31 09:05:59.891394", "rc": 0, "start": "2019-12-31 09:05:58.619575", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o", "stdout_lines": ["cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o"]}

TASK [Create a file to store CSP name] *****************************************
2019-12-31T09:05:59.969467 (delta: 1.556888)         elapsed: 65.043114 ******* 
changed: [127.0.0.1] => (item={'stderr_lines': [], u'cmd': u"kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", u'end': u'2019-12-31 09:05:59.891394', u'stdout': u'cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o', u'changed': True, 'failed': False, u'delta': u'0:00:01.271819', u'stderr': u'', u'rc': 0, 'stdout_lines': [u'cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o'], u'start': u'2019-12-31 09:05:58.619575'}) => {"backup": "", "changed": true, "item": {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[*].metadata.labels.cstorpool\\.openebs\\.io/name}'", "delta": "0:00:01.271819", "end": "2019-12-31 09:05:59.891394", "failed": false, "rc": 0, "start": "2019-12-31 09:05:58.619575", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o", "stdout_lines": ["cstor-block-disk-pool-stripe-b8oh cstor-block-disk-pool-stripe-fw2o"]}, "msg": "line added and ownership, perms or SE linux context changed"}

TASK [Getting the csp where no cvr is created] *********************************
2019-12-31T09:06:00.287374 (delta: 0.31784)         elapsed: 65.361021 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat csp_all.tmp | tr \" \" \"\\n\" > csp_all\n cat csp_cvr.tmp | tr \" \" \"\\n\" > csp_cvr\n comm -3 <(sort csp_all) <(sort csp_cvr)", "delta": "0:00:01.036359", "end": "2019-12-31 09:06:01.531844", "rc": 0, "start": "2019-12-31 09:06:00.495485", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew\ncstor-block-disk-pool-stripe-a4qg\ncstor-block-disk-pool-stripe-k0nc", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew", "cstor-block-disk-pool-stripe-a4qg", "cstor-block-disk-pool-stripe-k0nc"]}

TASK [Getting the target IP from cvr] ******************************************
2019-12-31T09:06:01.625072 (delta: 1.337626)         elapsed: 66.698719 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorvolume.openebs.io/name=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[0].spec.targetIP}'", "delta": "0:00:01.322711", "end": "2019-12-31 09:06:03.200642", "rc": 0, "start": "2019-12-31 09:06:01.877931", "stderr": "", "stderr_lines": [], "stdout": "172.22.197.187", "stdout_lines": ["172.22.197.187"]}

TASK [Getting the Node name from CSP where CVR need to create] *****************
2019-12-31T09:06:03.274622 (delta: 1.649486)         elapsed: 68.348269 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-stripe-8hew -o jsonpath='{.metadata.labels.kubernetes\\.io/hostname}'", "delta": "0:00:01.168624", "end": "2019-12-31 09:06:04.679623", "rc": 0, "start": "2019-12-31 09:06:03.510999", "stderr": "", "stderr_lines": [], "stdout": "worker1.pipeline.mayalabs.io", "stdout_lines": ["worker1.pipeline.mayalabs.io"]}

TASK [Getting csp uid] *********************************************************
2019-12-31T09:06:04.757894 (delta: 1.483213)         elapsed: 69.831541 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-stripe-8hew -o jsonpath='{.metadata.uid}'", "delta": "0:00:01.267017", "end": "2019-12-31 09:06:06.278178", "rc": 0, "start": "2019-12-31 09:06:05.011161", "stderr": "", "stderr_lines": [], "stdout": "2272317b-2ba2-11ea-81e1-005056982131", "stdout_lines": ["2272317b-2ba2-11ea-81e1-005056982131"]}

TASK [Replacing the storage class in cvr yml] **********************************
2019-12-31T09:06:06.380204 (delta: 1.62225)         elapsed: 71.453851 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the Node name in cvr yml] **************************************
2019-12-31T09:06:06.941202 (delta: 0.560937)         elapsed: 72.014849 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the CSP name in cvr yml] ***************************************
2019-12-31T09:06:07.286384 (delta: 0.345104)         elapsed: 72.360031 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replacing the uid in cvr yml] ********************************************
2019-12-31T09:06:07.659797 (delta: 0.373345)         elapsed: 72.733444 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the volume name in cvr yml] ************************************
2019-12-31T09:06:07.951748 (delta: 0.291889)         elapsed: 73.025395 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the volume capacity in cvr yml] ********************************
2019-12-31T09:06:08.335185 (delta: 0.383374)         elapsed: 73.408832 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing OpenEBS version in cvr yml] ************************************
2019-12-31T09:06:08.671749 (delta: 0.3365)         elapsed: 73.745396 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replacing the target IP in cvr yml] **************************************
2019-12-31T09:06:09.002897 (delta: 0.331067)         elapsed: 74.076544 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the DRF in patch_cstorvolume yml] ******************************
2019-12-31T09:06:09.329864 (delta: 0.326906)         elapsed: 74.403511 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Patching the cstorvolume's desired rep count] ****************************
2019-12-31T09:06:09.648978 (delta: 0.319053)         elapsed: 74.722625 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cstorvolume pvc-67410e10-2bac-11ea-81e1-005056982131 -n openebs --type merge --patch \"$(cat patch_cstorvolume.yml)\"", "delta": "0:00:01.633059", "end": "2019-12-31 09:06:11.590532", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:06:09.957473", "stderr": "", "stderr_lines": [], "stdout": "cstorvolume.openebs.io/pvc-67410e10-2bac-11ea-81e1-005056982131 patched", "stdout_lines": ["cstorvolume.openebs.io/pvc-67410e10-2bac-11ea-81e1-005056982131 patched"]}

TASK [Creating new cvr] ********************************************************
2019-12-31T09:06:11.668053 (delta: 2.019007)         elapsed: 76.7417 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cvr.yml", "delta": "0:00:01.808189", "end": "2019-12-31 09:06:13.689124", "rc": 0, "start": "2019-12-31 09:06:11.880935", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io/pvc-67410e10-2bac-11ea-81e1-005056982131-cstor-block-disk-pool-stripe-8hew created", "stdout_lines": ["cstorvolumereplica.openebs.io/pvc-67410e10-2bac-11ea-81e1-005056982131-cstor-block-disk-pool-stripe-8hew created"]}

TASK [Getting the uid of newly created cvr] ************************************
2019-12-31T09:06:13.770440 (delta: 2.102329)         elapsed: 78.844087 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l cstorpool.openebs.io/name=cstor-block-disk-pool-stripe-8hew,cstorvolume.openebs.io/name=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[0].metadata.uid}'", "delta": "0:00:01.290674", "end": "2019-12-31 09:06:15.355690", "rc": 0, "start": "2019-12-31 09:06:14.065016", "stderr": "", "stderr_lines": [], "stdout": "cb7fc836-2bac-11ea-81e1-005056982131", "stdout_lines": ["cb7fc836-2bac-11ea-81e1-005056982131"]}

TASK [Creating MD5SUM of new-uid] **********************************************
2019-12-31T09:06:15.477350 (delta: 1.706847)         elapsed: 80.550997 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo cb7fc836-2bac-11ea-81e1-005056982131 | md5sum | awk '{print toupper($1)}'", "delta": "0:00:01.064633", "end": "2019-12-31 09:06:16.757555", "rc": 0, "start": "2019-12-31 09:06:15.692922", "stderr": "", "stderr_lines": [], "stdout": "BFE06F1249106169EC5A153AFDA78C1D", "stdout_lines": ["BFE06F1249106169EC5A153AFDA78C1D"]}

TASK [Replacing the md5sum value in patch yml] *********************************
2019-12-31T09:06:16.837086 (delta: 1.359657)         elapsed: 81.910733 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Patching the cvr's replica id with md5sum] *******************************
2019-12-31T09:06:17.236041 (delta: 0.398878)         elapsed: 82.309688 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cvr pvc-67410e10-2bac-11ea-81e1-005056982131-cstor-block-disk-pool-stripe-8hew -n openebs --type merge --patch \"$(cat patch_cvr.yml)\"", "delta": "0:00:01.384093", "end": "2019-12-31 09:06:18.901524", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:06:17.517431", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumereplica.openebs.io/pvc-67410e10-2bac-11ea-81e1-005056982131-cstor-block-disk-pool-stripe-8hew patched", "stdout_lines": ["cstorvolumereplica.openebs.io/pvc-67410e10-2bac-11ea-81e1-005056982131-cstor-block-disk-pool-stripe-8hew patched"]}

TASK [Getting the cstor pool pod name] *****************************************
2019-12-31T09:06:19.004932 (delta: 1.768816)         elapsed: 84.078579 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.203593", "end": "2019-12-31 09:06:20.521568", "rc": 0, "start": "2019-12-31 09:06:19.317975", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26"]}

TASK [Restarting the cstor-pool-mgmt container] ********************************
2019-12-31T09:06:20.625404 (delta: 1.620397)         elapsed: 85.699051 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs -c cstor-pool-mgmt -- pkill -f /usr/local/bin/", "delta": "0:00:01.576000", "end": "2019-12-31 09:06:22.565178", "rc": 0, "start": "2019-12-31 09:06:20.989178", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Checking for the pool pod to be in running state] ************************
2019-12-31T09:06:22.711369 (delta: 2.085897)         elapsed: 87.785016 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n openebs -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.305697", "end": "2019-12-31 09:06:24.300292", "rc": 0, "start": "2019-12-31 09:06:22.994595", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Getting the taget name] **************************************************
2019-12-31T09:06:24.415000 (delta: 1.70355)         elapsed: 89.488647 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.357334", "end": "2019-12-31 09:06:26.148992", "rc": 0, "start": "2019-12-31 09:06:24.791658", "stderr": "", "stderr_lines": [], "stdout": "pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb589496478tj2", "stdout_lines": ["pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb589496478tj2"]}

TASK [Checking for reconstructing state of newely created cvr] *****************
2019-12-31T09:06:26.266971 (delta: 1.851894)         elapsed: 91.340618 ******* 
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (100 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (99 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (98 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (97 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (96 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (95 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (94 retries left).
FAILED - RETRYING: Checking for reconstructing state of newely created cvr (93 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get cvr pvc-67410e10-2bac-11ea-81e1-005056982131-cstor-block-disk-pool-stripe-8hew -n openebs -o jsonpath='{.status.phase}'", "delta": "0:00:01.256407", "end": "2019-12-31 09:08:00.279008", "rc": 0, "start": "2019-12-31 09:07:59.022601", "stderr": "", "stderr_lines": [], "stdout": "ReconstructingNewReplica", "stdout_lines": ["ReconstructingNewReplica"]}

TASK [Restarting target] *******************************************************
2019-12-31T09:08:00.390249 (delta: 94.123194)         elapsed: 185.463896 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb589496478tj2 -n openebs", "delta": "0:00:33.956004", "end": "2019-12-31 09:08:34.591652", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:08:00.635648", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb589496478tj2\" deleted", "stdout_lines": ["pod \"pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb589496478tj2\" deleted"]}

TASK [Verify newly Created replicaID exists in cstorVolume or not] *************
2019-12-31T09:08:34.726131 (delta: 34.335809)         elapsed: 219.799778 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume pvc-67410e10-2bac-11ea-81e1-005056982131 -n openebs -o jsonpath='{.status.replicaDetails.knownReplicas.BFE06F1249106169EC5A153AFDA78C1D}'", "delta": "0:00:01.152432", "end": "2019-12-31 09:08:36.176933", "rc": 0, "start": "2019-12-31 09:08:35.024501", "stderr": "", "stderr_lines": [], "stdout": "11011622226459528689", "stdout_lines": ["11011622226459528689"]}

TASK [Checking for the desired replication factor in cstorvolume] **************
2019-12-31T09:08:36.298212 (delta: 1.571988)         elapsed: 221.371859 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-67410e10-2bac-11ea-81e1-005056982131 -n openebs -o jsonpath='{.spec.replicationFactor}'", "delta": "0:00:01.319843", "end": "2019-12-31 09:08:37.870911", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:08:36.551068", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Checking for the consistancy factor in cstorvolume] **********************
2019-12-31T09:08:37.946367 (delta: 1.648085)         elapsed: 223.020014 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cstorvolume pvc-67410e10-2bac-11ea-81e1-005056982131 -n openebs -o jsonpath='{.spec.consistencyFactor}'", "delta": "0:00:01.225844", "end": "2019-12-31 09:08:39.403709", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:08:38.177865", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Verify cvr health status] ************************************************
2019-12-31T09:08:39.485936 (delta: 1.539514)         elapsed: 224.559583 ****** 
FAILED - RETRYING: Verify cvr health status (100 retries left).
FAILED - RETRYING: Verify cvr health status (99 retries left).
FAILED - RETRYING: Verify cvr health status (98 retries left).
FAILED - RETRYING: Verify cvr health status (97 retries left).
FAILED - RETRYING: Verify cvr health status (96 retries left).
FAILED - RETRYING: Verify cvr health status (95 retries left).
FAILED - RETRYING: Verify cvr health status (94 retries left).
FAILED - RETRYING: Verify cvr health status (93 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-67410e10-2bac-11ea-81e1-005056982131 -o jsonpath='{.items[*].status.phase}'", "delta": "0:00:01.273749", "end": "2019-12-31 09:10:13.629204", "rc": 0, "start": "2019-12-31 09:10:12.355455", "stderr": "", "stderr_lines": [], "stdout": "Healthy Healthy Healthy", "stdout_lines": ["Healthy Healthy Healthy"]}

TASK [Get istgt target pod details] ********************************************
2019-12-31T09:10:13.774639 (delta: 94.288642)         elapsed: 318.848286 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/persistent-volume=pvc-67410e10-2bac-11ea-81e1-005056982131 -n openebs -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.318744", "end": "2019-12-31 09:10:15.496766", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:10:14.178022", "stderr": "", "stderr_lines": [], "stdout": "pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb5894964grw9w", "stdout_lines": ["pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb5894964grw9w"]}

TASK [Create an empty list of replica pods.] ***********************************
2019-12-31T09:10:15.576177 (delta: 1.801419)         elapsed: 320.649824 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_replicas_pod": []}, "changed": false}

TASK [Obtaining the pool deployments from cvr] *********************************
2019-12-31T09:10:15.680223 (delta: 0.103989)         elapsed: 320.75387 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-67410e10-2bac-11ea-81e1-005056982131 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.320543", "end": "2019-12-31 09:10:17.372153", "failed_when_result": false, "rc": 0, "start": "2019-12-31 09:10:16.051610", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew\ncstor-block-disk-pool-stripe-b8oh\ncstor-block-disk-pool-stripe-fw2o", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew", "cstor-block-disk-pool-stripe-b8oh", "cstor-block-disk-pool-stripe-fw2o"]}

TASK [Obtaining the pool pods] *************************************************
2019-12-31T09:10:17.456913 (delta: 1.776637)         elapsed: 322.53056 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-8hew) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.256894", "end": "2019-12-31 09:10:18.975771", "failed_when_result": false, "item": "cstor-block-disk-pool-stripe-8hew", "rc": 0, "start": "2019-12-31 09:10:17.718877", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-b8oh) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-b8oh -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.544063", "end": "2019-12-31 09:10:21.024648", "failed_when_result": false, "item": "cstor-block-disk-pool-stripe-b8oh", "rc": 0, "start": "2019-12-31 09:10:19.480585", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj", "stdout_lines": ["cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-fw2o) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-fw2o -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.380340", "end": "2019-12-31 09:10:22.602660", "failed_when_result": false, "item": "cstor-block-disk-pool-stripe-fw2o", "rc": 0, "start": "2019-12-31 09:10:21.222320", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58", "stdout_lines": ["cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58"]}

TASK [Build a list of replica pods] ********************************************
2019-12-31T09:10:22.838310 (delta: 5.381338)         elapsed: 327.911957 ****** 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26', '_ansible_item_result': True, u'delta': u'0:00:01.256894', 'stdout_lines': [u'cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26'], 'failed_when_result': False, '_ansible_item_label': u'cstor-block-disk-pool-stripe-8hew', u'end': u'2019-12-31 09:10:18.975771', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -n openebs --no-headers -o custom-columns=:.metadata.name', 'item': u'cstor-block-disk-pool-stripe-8hew', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -n openebs --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-12-31 09:10:17.718877', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.256894", "end": "2019-12-31 09:10:18.975771", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-8hew -n openebs --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-8hew", "rc": 0, "start": "2019-12-31 09:10:17.718877", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "stdout_lines": ["cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj', '_ansible_item_result': True, u'delta': u'0:00:01.544063', 'stdout_lines': [u'cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj'], 'failed_when_result': False, '_ansible_item_label': u'cstor-block-disk-pool-stripe-b8oh', u'end': u'2019-12-31 09:10:21.024648', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-b8oh -n openebs --no-headers -o custom-columns=:.metadata.name', 'item': u'cstor-block-disk-pool-stripe-b8oh', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-b8oh -n openebs --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-12-31 09:10:19.480585', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-b8oh -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.544063", "end": "2019-12-31 09:10:21.024648", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-b8oh -n openebs --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-b8oh", "rc": 0, "start": "2019-12-31 09:10:19.480585", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj", "stdout_lines": ["cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58', '_ansible_item_result': True, u'delta': u'0:00:01.380340', 'stdout_lines': [u'cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58'], 'failed_when_result': False, '_ansible_item_label': u'cstor-block-disk-pool-stripe-fw2o', u'end': u'2019-12-31 09:10:22.602660', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-fw2o -n openebs --no-headers -o custom-columns=:.metadata.name', 'item': u'cstor-block-disk-pool-stripe-fw2o', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-fw2o -n openebs --no-headers -o custom-columns=:.metadata.name', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-12-31 09:10:21.222320', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj", "cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-fw2o -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.380340", "end": "2019-12-31 09:10:22.602660", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool,openebs.io/cstor-pool=cstor-block-disk-pool-stripe-fw2o -n openebs --no-headers -o custom-columns=:.metadata.name", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-fw2o", "rc": 0, "start": "2019-12-31 09:10:21.222320", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58", "stdout_lines": ["cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58"]}}

TASK [Generate snapshot name] **************************************************
2019-12-31T09:10:22.993541 (delta: 0.155168)         elapsed: 328.067188 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1", "delta": "0:00:01.063445", "end": "2019-12-31 09:10:24.289087", "rc": 0, "start": "2019-12-31 09:10:23.225642", "stderr": "", "stderr_lines": [], "stdout": "mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc", "stdout_lines": ["mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc"]}

TASK [set_fact] ****************************************************************
2019-12-31T09:10:24.407152 (delta: 1.413553)         elapsed: 329.480799 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"snap_name": "mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc"}, "changed": false}

TASK [Take snapshot for data verification] *************************************
2019-12-31T09:10:24.538710 (delta: 0.131494)         elapsed: 329.612357 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb5894964grw9w -n openebs --container cstor-istgt -- istgtcontrol snapcreate pvc-67410e10-2bac-11ea-81e1-005056982131 mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc 30 30", "delta": "0:00:03.512727", "end": "2019-12-31 09:10:28.471566", "rc": 0, "start": "2019-12-31 09:10:24.958839", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPCREATE command", "stdout_lines": ["DONE SNAPCREATE command"]}

TASK [Install netcat on current host] ******************************************
2019-12-31T09:10:28.602322 (delta: 4.063518)         elapsed: 333.675969 ****** 
 [WARNING]: Consider using the apt module rather than running apt-get.  If you
need to use command because apt is insufficient you can add warn=False to this
command task or set command_warnings=False in ansible.cfg to get rid of this
message.
changed: [127.0.0.1] => {"changed": true, "cmd": "apt-get update && apt-get -y install netcat iproute2", "delta": "0:00:06.919654", "end": "2019-12-31 09:10:35.859102", "rc": 0, "start": "2019-12-31 09:10:28.939448", "stderr": "", "stderr_lines": [], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease\nGet:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]\nGet:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]\nGet:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]\nFetched 252 kB in 2s (150 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\niproute2 is already the newest version (4.15.0-2ubuntu1).\nnetcat is already the newest version (1.10-41.1).\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease", "Get:2 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]", "Get:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]", "Get:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]", "Fetched 252 kB in 2s (150 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "iproute2 is already the newest version (4.15.0-2ubuntu1).", "netcat is already the newest version (1.10-41.1).", "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded."]}

TASK [include] *****************************************************************
2019-12-31T09:10:35.935979 (delta: 7.333539)         elapsed: 341.009626 ****** 
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1

TASK [Get replica id] **********************************************************
2019-12-31T09:10:36.338333 (delta: 0.4023)         elapsed: 341.41198 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.445156", "end": "2019-12-31 09:10:38.041483", "rc": 0, "start": "2019-12-31 09:10:36.596327", "stderr": "", "stderr_lines": [], "stdout": "2272317b-2ba2-11ea-81e1-005056982131", "stdout_lines": ["2272317b-2ba2-11ea-81e1-005056982131"]}

TASK [Check for dataset name] **************************************************
2019-12-31T09:10:38.121986 (delta: 1.783596)         elapsed: 343.195633 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- zfs list cstor-2272317b-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131", "delta": "0:00:01.482230", "end": "2019-12-31 09:10:39.818939", "rc": 0, "start": "2019-12-31 09:10:38.336709", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-2272317b-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131   810M  23.3G   809M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-2272317b-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131   810M  23.3G   809M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
2019-12-31T09:10:39.901882 (delta: 1.779834)         elapsed: 344.975529 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-2272317b-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc > /snap.data\"", "delta": "0:00:11.681255", "end": "2019-12-31 09:10:51.805269", "rc": 0, "start": "2019-12-31 09:10:40.124014", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
2019-12-31T09:10:51.887028 (delta: 11.985093)         elapsed: 356.960675 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.608030", "end": "2019-12-31 09:10:53.717682", "rc": 0, "start": "2019-12-31 09:10:52.109652", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
2019-12-31T09:10:53.914373 (delta: 2.027276)         elapsed: 358.98802 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:05.927577", "end": "2019-12-31 09:11:00.111754", "rc": 0, "start": "2019-12-31 09:10:54.184177", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5e0b1083\n\ttype = 3\n\tflags = 0x4\n\ttoguid = cfc7590de850ea62\n\tfromguid = 0\n\ttoname = cstor-2272317b-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc\nEND checksum = 675c10c2d4f7500/e780216f99f3c7e4/aadd897b14d83f92/185cd38bffe7196b\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 230800\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 1281\n\tTotal DRR_SPILL records = 0\n\tTotal records = 232090\n\tTotal write size = 945353216 (0x3858f200)\n\tTotal stream length = 1017765296 (0x3ca9ddb0)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5e0b1083", "\ttype = 3", "\tflags = 0x4", "\ttoguid = cfc7590de850ea62", "\tfromguid = 0", "\ttoname = cstor-2272317b-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc", "END checksum = 675c10c2d4f7500/e780216f99f3c7e4/aadd897b14d83f92/185cd38bffe7196b", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 230800", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 1281", "\tTotal DRR_SPILL records = 0", "\tTotal records = 232090", "\tTotal write size = 945353216 (0x3858f200)", "\tTotal stream length = 1017765296 (0x3ca9ddb0)"]}

TASK [Install netcat on replica pod] *******************************************
2019-12-31T09:11:00.228428 (delta: 6.313923)         elapsed: 365.302075 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:07.226287", "end": "2019-12-31 09:11:07.704124", "rc": 0, "start": "2019-12-31 09:11:00.477837", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead."], "stdout": "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:2 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:1 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (223 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nnetcat is already the newest version (1.10-41).\n0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.", "stdout_lines": ["Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:1 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (223 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "netcat is already the newest version (1.10-41).", "0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded."]}

TASK [Start receiver to receive data object from replica pod] ******************
2019-12-31T09:11:07.781615 (delta: 7.553111)         elapsed: 372.855262 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "640528426098.2727", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/640528426098.2727", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
2019-12-31T09:11:09.005610 (delta: 1.223935)         elapsed: 374.079257 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.093427", "end": "2019-12-31 09:11:15.438259", "rc": 0, "start": "2019-12-31 09:11:09.344832", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
2019-12-31T09:11:15.513816 (delta: 6.508138)         elapsed: 380.587463 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.6.94 9090 < /1.dump\"", "delta": "0:00:15.513557", "end": "2019-12-31 09:11:31.233634", "rc": 0, "start": "2019-12-31 09:11:15.720077", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-12-31T09:11:31.327293 (delta: 15.813417)         elapsed: 396.40094 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.177464", "end": "2019-12-31 09:11:32.751845", "rc": 0, "start": "2019-12-31 09:11:31.574381", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
2019-12-31T09:11:32.836228 (delta: 1.508862)         elapsed: 397.909875 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.119231", "end": "2019-12-31 09:11:39.218931", "rc": 0, "start": "2019-12-31 09:11:33.099700", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
2019-12-31T09:11:39.295576 (delta: 6.459277)         elapsed: 404.369223 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "166780539001.2873", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/166780539001.2873", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
2019-12-31T09:11:40.534916 (delta: 1.239279)         elapsed: 405.608563 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.6.94 9090 < /3.dump\"", "delta": "0:00:07.927033", "end": "2019-12-31 09:11:48.703451", "rc": 0, "start": "2019-12-31 09:11:40.776418", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-12-31T09:11:48.841324 (delta: 8.306353)         elapsed: 413.914971 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.051976", "end": "2019-12-31 09:11:50.225272", "rc": 0, "start": "2019-12-31 09:11:49.173296", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
2019-12-31T09:11:50.303340 (delta: 1.461883)         elapsed: 415.376987 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.260102", "end": "2019-12-31 09:11:51.858573", "rc": 0, "start": "2019-12-31 09:11:50.598471", "stderr": "", "stderr_lines": [], "stdout": "2293f729-2ba2-11ea-81e1-005056982131", "stdout_lines": ["2293f729-2ba2-11ea-81e1-005056982131"]}

TASK [Check for dataset name] **************************************************
2019-12-31T09:11:51.966280 (delta: 1.662888)         elapsed: 417.039927 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- zfs list cstor-2293f729-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131", "delta": "0:00:01.693869", "end": "2019-12-31 09:11:53.965895", "rc": 0, "start": "2019-12-31 09:11:52.272026", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-2293f729-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131   813M  23.3G   810M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-2293f729-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131   813M  23.3G   810M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
2019-12-31T09:11:54.160385 (delta: 2.194008)         elapsed: 419.234032 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- bash -c \"zfs send cstor-2293f729-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc > /snap.data\"", "delta": "0:00:17.382126", "end": "2019-12-31 09:12:11.761641", "rc": 0, "start": "2019-12-31 09:11:54.379515", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
2019-12-31T09:12:11.960124 (delta: 17.799678)         elapsed: 437.033771 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.292950", "end": "2019-12-31 09:12:13.565544", "rc": 0, "start": "2019-12-31 09:12:12.272594", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
2019-12-31T09:12:13.732002 (delta: 1.771744)         elapsed: 438.805649 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:05.653333", "end": "2019-12-31 09:12:19.730716", "rc": 0, "start": "2019-12-31 09:12:14.077383", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5e0b1083\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 971590c7b2227d88\n\tfromguid = 0\n\ttoname = cstor-2293f729-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc\nEND checksum = 6743aa8984b37e6/bf4c94f1915d693f/34b4b59423f1fdb0/cfadd3eef1198a5d\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 230800\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 1281\n\tTotal DRR_SPILL records = 0\n\tTotal records = 232090\n\tTotal write size = 945353216 (0x3858f200)\n\tTotal stream length = 1017765296 (0x3ca9ddb0)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5e0b1083", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 971590c7b2227d88", "\tfromguid = 0", "\ttoname = cstor-2293f729-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc", "END checksum = 6743aa8984b37e6/bf4c94f1915d693f/34b4b59423f1fdb0/cfadd3eef1198a5d", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 230800", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 1281", "\tTotal DRR_SPILL records = 0", "\tTotal records = 232090", "\tTotal write size = 945353216 (0x3858f200)", "\tTotal stream length = 1017765296 (0x3ca9ddb0)"]}

TASK [Install netcat on replica pod] *******************************************
2019-12-31T09:12:19.812516 (delta: 6.080415)         elapsed: 444.886163 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:06.952368", "end": "2019-12-31 09:12:27.061318", "rc": 0, "start": "2019-12-31 09:12:20.108950", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead."], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:2 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (212 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nnetcat is already the newest version (1.10-41).\n0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:2 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (212 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "netcat is already the newest version (1.10-41).", "0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded."]}

TASK [Start receiver to receive data object from replica pod] ******************
2019-12-31T09:12:27.274083 (delta: 7.461512)         elapsed: 452.34773 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "520432896846.3175", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/520432896846.3175", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
2019-12-31T09:12:28.589492 (delta: 1.315306)         elapsed: 453.663139 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.135279", "end": "2019-12-31 09:12:34.983302", "rc": 0, "start": "2019-12-31 09:12:28.848023", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
2019-12-31T09:12:35.057003 (delta: 6.467453)         elapsed: 460.13065 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.6.94 9090 < /1.dump\"", "delta": "0:00:15.978344", "end": "2019-12-31 09:12:51.240649", "rc": 0, "start": "2019-12-31 09:12:35.262305", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-12-31T09:12:51.322888 (delta: 16.265824)         elapsed: 476.396535 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.186016", "end": "2019-12-31 09:12:52.774420", "rc": 0, "start": "2019-12-31 09:12:51.588404", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
2019-12-31T09:12:52.851535 (delta: 1.528578)         elapsed: 477.925182 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.013398", "end": "2019-12-31 09:12:59.166518", "rc": 0, "start": "2019-12-31 09:12:53.153120", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
2019-12-31T09:12:59.242160 (delta: 6.390551)         elapsed: 484.315807 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "43892910228.3320", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/43892910228.3320", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
2019-12-31T09:13:00.450123 (delta: 1.207909)         elapsed: 485.52377 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.6.94 9090 < /3.dump\"", "delta": "0:00:07.769989", "end": "2019-12-31 09:13:08.440221", "rc": 0, "start": "2019-12-31 09:13:00.670232", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-12-31T09:13:08.545939 (delta: 8.095751)         elapsed: 493.619586 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.955736", "end": "2019-12-31 09:13:09.773702", "rc": 0, "start": "2019-12-31 09:13:08.817966", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
2019-12-31T09:13:09.867256 (delta: 1.321242)         elapsed: 494.940903 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.596101", "end": "2019-12-31 09:13:11.793484", "rc": 0, "start": "2019-12-31 09:13:10.197383", "stderr": "", "stderr_lines": [], "stdout": "22eafdf0-2ba2-11ea-81e1-005056982131", "stdout_lines": ["22eafdf0-2ba2-11ea-81e1-005056982131"]}

TASK [Check for dataset name] **************************************************
2019-12-31T09:13:11.880533 (delta: 2.013196)         elapsed: 496.95418 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- zfs list cstor-22eafdf0-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131", "delta": "0:00:01.435734", "end": "2019-12-31 09:13:13.558137", "rc": 0, "start": "2019-12-31 09:13:12.122403", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-22eafdf0-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131   817M  23.2G   810M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-22eafdf0-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131   817M  23.2G   810M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
2019-12-31T09:13:13.737702 (delta: 1.857115)         elapsed: 498.811349 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-22eafdf0-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc > /snap.data\"", "delta": "0:00:11.022042", "end": "2019-12-31 09:13:25.031287", "rc": 0, "start": "2019-12-31 09:13:14.009245", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
2019-12-31T09:13:25.152592 (delta: 11.414725)         elapsed: 510.226239 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.466036", "end": "2019-12-31 09:13:26.850921", "rc": 0, "start": "2019-12-31 09:13:25.384885", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
2019-12-31T09:13:27.035869 (delta: 1.883218)         elapsed: 512.109516 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:05.991846", "end": "2019-12-31 09:13:33.378199", "rc": 0, "start": "2019-12-31 09:13:27.386353", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5e0b1083\n\ttype = 3\n\tflags = 0x4\n\ttoguid = aaf9ace49cff42db\n\tfromguid = 0\n\ttoname = cstor-22eafdf0-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc\nEND checksum = 674337fa349296c/c522bb0863bbcc8/e577dfe7ed31fddb/7596dc5575bc49e5\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 230800\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 1281\n\tTotal DRR_SPILL records = 0\n\tTotal records = 232090\n\tTotal write size = 945353216 (0x3858f200)\n\tTotal stream length = 1017765296 (0x3ca9ddb0)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5e0b1083", "\ttype = 3", "\tflags = 0x4", "\ttoguid = aaf9ace49cff42db", "\tfromguid = 0", "\ttoname = cstor-22eafdf0-2ba2-11ea-81e1-005056982131/pvc-67410e10-2bac-11ea-81e1-005056982131@mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc", "END checksum = 674337fa349296c/c522bb0863bbcc8/e577dfe7ed31fddb/7596dc5575bc49e5", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 230800", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 1281", "\tTotal DRR_SPILL records = 0", "\tTotal records = 232090", "\tTotal write size = 945353216 (0x3858f200)", "\tTotal stream length = 1017765296 (0x3ca9ddb0)"]}

TASK [Install netcat on replica pod] *******************************************
2019-12-31T09:13:33.481264 (delta: 6.445251)         elapsed: 518.554911 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:07.632006", "end": "2019-12-31 09:13:41.346259", "rc": 0, "start": "2019-12-31 09:13:33.714253", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead."], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nErr:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (222 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nnetcat is already the newest version (1.10-41).\n0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Err:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (222 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "netcat is already the newest version (1.10-41).", "0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded."]}

TASK [Start receiver to receive data object from replica pod] ******************
2019-12-31T09:13:41.514530 (delta: 8.033203)         elapsed: 526.588177 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "999063422913.3624", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/999063422913.3624", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
2019-12-31T09:13:42.799129 (delta: 1.284501)         elapsed: 527.872776 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:05.950931", "end": "2019-12-31 09:13:48.983343", "rc": 0, "start": "2019-12-31 09:13:43.032412", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
2019-12-31T09:13:49.057886 (delta: 6.258703)         elapsed: 534.131533 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.6.94 9090 < /1.dump\"", "delta": "0:00:15.167272", "end": "2019-12-31 09:14:04.448659", "rc": 0, "start": "2019-12-31 09:13:49.281387", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-12-31T09:14:04.706303 (delta: 15.648359)         elapsed: 549.77995 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.438336", "end": "2019-12-31 09:14:06.447360", "rc": 0, "start": "2019-12-31 09:14:05.009024", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
2019-12-31T09:14:06.534477 (delta: 1.828076)         elapsed: 551.608124 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.139864", "end": "2019-12-31 09:14:13.073509", "rc": 0, "start": "2019-12-31 09:14:06.933645", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
2019-12-31T09:14:13.195615 (delta: 6.661071)         elapsed: 558.269262 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "171101074634.3770", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/171101074634.3770", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
2019-12-31T09:14:14.419762 (delta: 1.224101)         elapsed: 559.493409 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.20.6.94 9090 < /3.dump\"", "delta": "0:00:07.890548", "end": "2019-12-31 09:14:22.580767", "rc": 0, "start": "2019-12-31 09:14:14.690219", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
2019-12-31T09:14:22.789429 (delta: 8.369607)         elapsed: 567.863076 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.175342", "end": "2019-12-31 09:14:24.238196", "rc": 0, "start": "2019-12-31 09:14:23.062854", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2019-12-31T09:14:24.326980 (delta: 1.537425)         elapsed: 569.400627 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"base_replica": "cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26"}, "changed": false}

TASK [compare data object] *****************************************************
2019-12-31T09:14:24.467117 (delta: 0.140077)         elapsed: 569.540764 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.1.dump cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.1.dump", "delta": "0:00:01.198046", "end": "2019-12-31 09:14:25.976448", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "start": "2019-12-31 09:14:24.778402", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj.1.dump cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.1.dump", "delta": "0:00:04.853977", "end": "2019-12-31 09:14:31.060550", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj", "start": "2019-12-31 09:14:26.206573", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58.1.dump cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.1.dump", "delta": "0:00:03.380901", "end": "2019-12-31 09:14:34.662209", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58", "start": "2019-12-31 09:14:31.281308", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [compare meta data object] ************************************************
2019-12-31T09:14:34.739490 (delta: 10.27231)         elapsed: 579.813137 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.3.dump cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.3.dump", "delta": "0:00:01.011113", "end": "2019-12-31 09:14:36.002767", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26", "start": "2019-12-31 09:14:34.991654", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj.3.dump cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.3.dump", "delta": "0:00:01.119260", "end": "2019-12-31 09:14:37.365603", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-b8oh-68d69b5dd6-6mtjj", "start": "2019-12-31 09:14:36.246343", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58) => {"changed": true, "cmd": "diff cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58.3.dump cstor-block-disk-pool-stripe-8hew-77c7f755c9-t9f26.3.dump", "delta": "0:00:01.163068", "end": "2019-12-31 09:14:38.766242", "rc": 0, "rpod": "cstor-block-disk-pool-stripe-fw2o-6f4d77cd66-z7c58", "start": "2019-12-31 09:14:37.603174", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Destroy snapshot created for data verification] **************************
2019-12-31T09:14:38.858617 (delta: 4.119066)         elapsed: 583.932264 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-67410e10-2bac-11ea-81e1-005056982131-target-7bb5894964grw9w -n openebs --container cstor-istgt -- istgtcontrol snapdestroy pvc-67410e10-2bac-11ea-81e1-005056982131 mCq78EA8lEGgm4L7JHmKmVl63WQGQJzc 30 30", "delta": "0:00:01.696897", "end": "2019-12-31 09:14:40.815495", "rc": 0, "start": "2019-12-31 09:14:39.118598", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPDESTROY command", "stdout_lines": ["DONE SNAPDESTROY command"]}

TASK [Verify application data persistence] *************************************
2019-12-31T09:14:40.929969 (delta: 2.071273)         elapsed: 586.003616 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-12-31T09:14:41.068098 (delta: 0.138055)         elapsed: 586.141745 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-12-31T09:14:41.196712 (delta: 0.128548)         elapsed: 586.270359 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-12-31T09:14:41.374782 (delta: 0.17798)         elapsed: 586.448429 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-12-31T09:14:41.449127 (delta: 0.074268)         elapsed: 586.522774 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-12-31T09:14:41.580383 (delta: 0.131199)         elapsed: 586.65403 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-12-31T09:14:41.710705 (delta: 0.130236)         elapsed: 586.784352 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "29f47af49a2a3a5aa59a27f68d7e0ae0e21bf497", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0c41791561c2cc1d180fe9dc2c7444f6", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1577783681.79-30150557426557/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-12-31T09:14:44.429563 (delta: 2.718721)         elapsed: 589.50321 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.049395", "end": "2019-12-31 09:14:45.760467", "rc": 0, "start": "2019-12-31 09:14:44.711072", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-cvr-scaleup \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-cvr-scaleup ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-12-31T09:14:45.831705 (delta: 1.402077)         elapsed: 590.905352 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2019-12-31T08:15:00Z", "generation": 8, "name": "openebs-cvr-scaleup", "resourceVersion": "754808", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-cvr-scaleup", "uid": "a3e54920-2ba5-11ea-81e1-005056982131"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=113  changed=99   unreachable=0    failed=0   

2019-12-31T09:14:47.052006 (delta: 1.220221)         elapsed: 592.125653 ****** 
===============================================================================

```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
