### PR TITLE
fix-velero: Wait for minio bucket creation before deploying velero server

### DIFF
--- a/experiments/functional/backup_and_restore/setup_dependency.yml
+++ b/experiments/functional/backup_and_restore/setup_dependency.yml
@@ -28,6 +28,13 @@
   delay: 5
   retries: 15
 
+- name: Waiting for minio job to create bucket
+  shell: kubectl get pod -n velero -l job-name=minio-setup -o jsonpath='{.items[*].status.phase}'
+  register: minio_job_status
+  until: "'Succeeded' in minio_job_status.stdout"
+  delay: 5
+  retries: 10
+
 - block:
 
    - name: Installing velero server inside cluster


### PR DESCRIPTION

**What this PR does / why we need it**:
- Ansible script waits for bucket creation by minio job before deploying velero server. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Following is the log of ansible test container. [Platform: konvoy]**:
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/backup_and_restore/test.yml

PLAY [localhost] ***************************************************************
2020-01-07T10:19:56.851401 (delta: 0.07162)         elapsed: 0.07162 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:1
2020-01-07T10:19:56.871381 (delta: 0.019925)         elapsed: 0.0916 ********** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:12
2020-01-07T10:20:10.490885 (delta: 13.619465)         elapsed: 13.711104 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-01-07T10:20:10.683572 (delta: 0.192572)         elapsed: 13.903791 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-01-07T10:20:10.832244 (delta: 0.148605)         elapsed: 14.052463 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:15
2020-01-07T10:20:11.010332 (delta: 0.177983)         elapsed: 14.230551 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-01-07T10:20:11.177202 (delta: 0.166783)         elapsed: 14.397421 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cb23761ee0ecfea3a093f94c0443739c777b3007", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0da5664e16958d4f3c263662ebe36b5c", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1578392411.24-92444817841891/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-01-07T10:20:12.220423 (delta: 1.043164)         elapsed: 15.440642 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.262613", "end": "2020-01-07 10:20:14.018788", "rc": 0, "start": "2020-01-07 10:20:12.756175", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-01-07T10:20:14.100804 (delta: 1.880311)         elapsed: 17.321023 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-07T08:55:22Z", "generation": 5, "name": "velero-backup-restore", "resourceVersion": "119030", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "d5ba2643-147d-485b-ab3c-0d54f7247c04"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-01-07T10:20:15.805098 (delta: 1.704238)         elapsed: 19.025317 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-01-07T10:20:15.949956 (delta: 0.144778)         elapsed: 19.170175 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-01-07T10:20:16.142949 (delta: 0.192895)         elapsed: 19.363168 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /experiments/functional/backup_and_restore/test.yml:19
2020-01-07T10:20:16.226080 (delta: 0.083022)         elapsed: 19.446299 ******* 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2020-01-07T10:20:16.391009 (delta: 0.164874)         elapsed: 19.611228 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-backup -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:02.515781", "end": "2020-01-07 10:20:19.189359", "rc": 0, "start": "2020-01-07 10:20:16.673578", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2020-01-07T10:20:19.366914 (delta: 2.975816)         elapsed: 22.587133 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2020-01-07T10:20:19.555363 (delta: 0.188319)         elapsed: 22.775582 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:22
2020-01-07T10:20:19.770133 (delta: 0.214663)         elapsed: 22.990352 ******* 
included: /experiments/functional/backup_and_restore/setup_dependency.yml for 127.0.0.1

TASK [Downloading velero binary] ***********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:1
2020-01-07T10:20:20.001793 (delta: 0.231511)         elapsed: 23.222012 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "24c98ca1c9cfe5c754c76c07ba6cbc517bc68f92", "dest": "./velero-v1.1.0-linux-amd64.tar.gz", "gid": 0, "group": "root", "md5sum": "2f8fb6505764a6f937b8b5645d4b8fb8", "mode": "0644", "msg": "OK (26731554 bytes)", "owner": "root", "size": 26731554, "src": "/root/.ansible/tmp/ansible-tmp-1578392420.11-274741973113783/tmpOKAzjB", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/vmware-tanzu/velero/releases/download/v1.1.0/velero-v1.1.0-linux-amd64.tar.gz"}

TASK [Installing velero inside litmus container] *******************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:11
2020-01-07T10:20:27.678571 (delta: 7.676672)         elapsed: 30.89879 ******** 
 [WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "tar -xvf velero-v1.1.0-linux-amd64.tar.gz\n mv velero-v1.1.0-linux-amd64/velero /usr/local/bin/", "delta": "0:00:02.151143", "end": "2020-01-07 10:20:30.088757", "rc": 0, "start": "2020-01-07 10:20:27.937614", "stderr": "", "stderr_lines": [], "stdout": "velero-v1.1.0-linux-amd64/LICENSE\nvelero-v1.1.0-linux-amd64/examples/README.md\nvelero-v1.1.0-linux-amd64/examples/minio\nvelero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app\nvelero-v1.1.0-linux-amd64/examples/nginx-app/README.md\nvelero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml\nvelero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml\nvelero-v1.1.0-linux-amd64/velero", "stdout_lines": ["velero-v1.1.0-linux-amd64/LICENSE", "velero-v1.1.0-linux-amd64/examples/README.md", "velero-v1.1.0-linux-amd64/examples/minio", "velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app", "velero-v1.1.0-linux-amd64/examples/nginx-app/README.md", "velero-v1.1.0-linux-amd64/examples/nginx-app/base.yaml", "velero-v1.1.0-linux-amd64/examples/nginx-app/with-pv.yaml", "velero-v1.1.0-linux-amd64/velero"]}

TASK [Checking the velero version] *********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:16
2020-01-07T10:20:30.184820 (delta: 2.506202)         elapsed: 33.405039 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero version", "delta": "0:00:01.408160", "end": "2020-01-07 10:20:31.960108", "failed_when_result": false, "rc": 0, "start": "2020-01-07 10:20:30.551948", "stderr": "", "stderr_lines": [], "stdout": "Client:\n\tVersion: v1.1.0\n\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608\n<error getting server version: namespaces \"velero\" not found>", "stdout_lines": ["Client:", "\tVersion: v1.1.0", "\tGit commit: a357f21aec6b39a8244dd23e469cc4519f1fe608", "<error getting server version: namespaces \"velero\" not found>"]}

TASK [Installing minio s3-bucket] **********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:21
2020-01-07T10:20:32.150832 (delta: 1.965927)         elapsed: 35.371051 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f velero-v1.1.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "delta": "0:00:02.151749", "end": "2020-01-07 10:20:34.728256", "rc": 0, "start": "2020-01-07 10:20:32.576507", "stderr": "", "stderr_lines": [], "stdout": "namespace/velero created\ndeployment.apps/minio created\nservice/minio created\njob.batch/minio-setup created", "stdout_lines": ["namespace/velero created", "deployment.apps/minio created", "service/minio created", "job.batch/minio-setup created"]}

TASK [Checking for minio pod status] *******************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:24
2020-01-07T10:20:34.933155 (delta: 2.782164)         elapsed: 38.153374 ******* 
FAILED - RETRYING: Checking for minio pod status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.481628", "end": "2020-01-07 10:20:43.444738", "rc": 0, "start": "2020-01-07 10:20:41.963110", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Waiting for minio job to create bucket] **********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:31
2020-01-07T10:20:43.562847 (delta: 8.629615)         elapsed: 46.783066 ******* 
FAILED - RETRYING: Waiting for minio job to create bucket (10 retries left).
FAILED - RETRYING: Waiting for minio job to create bucket (9 retries left).
FAILED - RETRYING: Waiting for minio job to create bucket (8 retries left).
FAILED - RETRYING: Waiting for minio job to create bucket (7 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pod -n velero -l job-name=minio-setup -o jsonpath='{.items[*].status.phase}'", "delta": "0:00:01.484504", "end": "2020-01-07 10:21:12.192404", "rc": 0, "start": "2020-01-07 10:21:10.707900", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:40
2020-01-07T10:21:12.290639 (delta: 28.727688)         elapsed: 75.510858 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching restic demonset for privileged access] **************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:50
2020-01-07T10:21:12.392186 (delta: 0.101482)         elapsed: 75.612405 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the number of compute nodes] *************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:55
2020-01-07T10:21:12.501462 (delta: 0.109214)         elapsed: 75.721681 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status of restic demonset pods] *****************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:59
2020-01-07T10:21:12.660214 (delta: 0.158672)         elapsed: 75.880433 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:70
2020-01-07T10:21:12.848597 (delta: 0.188292)         elapsed: 76.068816 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero install --provider aws --bucket velero --secret-file ./credentials-velero --use-volume-snapshots=false --backup-location-config region=minio,s3ForcePathStyle=\"true\",s3Url=http://minio.velero.svc:9000", "delta": "0:00:03.127237", "end": "2020-01-07 10:21:16.417237", "rc": 0, "start": "2020-01-07 10:21:13.290000", "stderr": "", "stderr_lines": [], "stdout": "CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource\nCustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding\nCustomResourceDefinition/resticrepositories.velero.io: created\nCustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource\nCustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/serverstatusrequests.velero.io: created\nCustomResourceDefinition/schedules.velero.io: attempting to create resource\nCustomResourceDefinition/schedules.velero.io: already exists, proceeding\nCustomResourceDefinition/schedules.velero.io: created\nCustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumebackups.velero.io: created\nCustomResourceDefinition/downloadrequests.velero.io: attempting to create resource\nCustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding\nCustomResourceDefinition/downloadrequests.velero.io: created\nCustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource\nCustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding\nCustomResourceDefinition/deletebackuprequests.velero.io: created\nCustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding\nCustomResourceDefinition/podvolumerestores.velero.io: created\nCustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource\nCustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding\nCustomResourceDefinition/backupstoragelocations.velero.io: created\nCustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource\nCustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding\nCustomResourceDefinition/volumesnapshotlocations.velero.io: created\nCustomResourceDefinition/backups.velero.io: attempting to create resource\nCustomResourceDefinition/backups.velero.io: already exists, proceeding\nCustomResourceDefinition/backups.velero.io: created\nCustomResourceDefinition/restores.velero.io: attempting to create resource\nCustomResourceDefinition/restores.velero.io: already exists, proceeding\nCustomResourceDefinition/restores.velero.io: created\nWaiting for resources to be ready in cluster...\nNamespace/velero: attempting to create resource\nNamespace/velero: already exists, proceeding\nNamespace/velero: created\nClusterRoleBinding/velero: attempting to create resource\nClusterRoleBinding/velero: already exists, proceeding\nClusterRoleBinding/velero: created\nServiceAccount/velero: attempting to create resource\nServiceAccount/velero: created\nSecret/cloud-credentials: attempting to create resource\nSecret/cloud-credentials: created\nBackupStorageLocation/default: attempting to create resource\nBackupStorageLocation/default: created\nDeployment/velero: attempting to create resource\nDeployment/velero: created\nVelero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status.", "stdout_lines": ["CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource", "CustomResourceDefinition/resticrepositories.velero.io: already exists, proceeding", "CustomResourceDefinition/resticrepositories.velero.io: created", "CustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource", "CustomResourceDefinition/serverstatusrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/serverstatusrequests.velero.io: created", "CustomResourceDefinition/schedules.velero.io: attempting to create resource", "CustomResourceDefinition/schedules.velero.io: already exists, proceeding", "CustomResourceDefinition/schedules.velero.io: created", "CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumebackups.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumebackups.velero.io: created", "CustomResourceDefinition/downloadrequests.velero.io: attempting to create resource", "CustomResourceDefinition/downloadrequests.velero.io: already exists, proceeding", "CustomResourceDefinition/downloadrequests.velero.io: created", "CustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource", "CustomResourceDefinition/deletebackuprequests.velero.io: already exists, proceeding", "CustomResourceDefinition/deletebackuprequests.velero.io: created", "CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumerestores.velero.io: already exists, proceeding", "CustomResourceDefinition/podvolumerestores.velero.io: created", "CustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource", "CustomResourceDefinition/backupstoragelocations.velero.io: already exists, proceeding", "CustomResourceDefinition/backupstoragelocations.velero.io: created", "CustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource", "CustomResourceDefinition/volumesnapshotlocations.velero.io: already exists, proceeding", "CustomResourceDefinition/volumesnapshotlocations.velero.io: created", "CustomResourceDefinition/backups.velero.io: attempting to create resource", "CustomResourceDefinition/backups.velero.io: already exists, proceeding", "CustomResourceDefinition/backups.velero.io: created", "CustomResourceDefinition/restores.velero.io: attempting to create resource", "CustomResourceDefinition/restores.velero.io: already exists, proceeding", "CustomResourceDefinition/restores.velero.io: created", "Waiting for resources to be ready in cluster...", "Namespace/velero: attempting to create resource", "Namespace/velero: already exists, proceeding", "Namespace/velero: created", "ClusterRoleBinding/velero: attempting to create resource", "ClusterRoleBinding/velero: already exists, proceeding", "ClusterRoleBinding/velero: created", "ServiceAccount/velero: attempting to create resource", "ServiceAccount/velero: created", "Secret/cloud-credentials: attempting to create resource", "Secret/cloud-credentials: created", "BackupStorageLocation/default: attempting to create resource", "BackupStorageLocation/default: created", "Deployment/velero: attempting to create resource", "Deployment/velero: created", "Velero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status."]}

TASK [Checking for velero server status] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:81
2020-01-07T10:21:16.606570 (delta: 3.757868)         elapsed: 79.826789 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.405875", "end": "2020-01-07 10:21:25.193502", "rc": 0, "start": "2020-01-07 10:21:23.787627", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Installing development image of OpenEBS velero-plugin] *******************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:88
2020-01-07T10:21:25.304604 (delta: 8.697888)         elapsed: 88.524823 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero plugin add openebs/velero-plugin:ci", "delta": "0:00:01.217163", "end": "2020-01-07 10:21:26.846140", "rc": 0, "start": "2020-01-07 10:21:25.628977", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Checking for velero server status] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:92
2020-01-07T10:21:26.940044 (delta: 1.63536)         elapsed: 90.160263 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.441261", "end": "2020-01-07 10:21:28.738356", "rc": 0, "start": "2020-01-07 10:21:27.297095", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Creating volume snapshot location] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:99
2020-01-07T10:21:28.934220 (delta: 1.994086)         elapsed: 92.154439 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f volume-snapshot-location.yml", "delta": "0:00:01.985395", "end": "2020-01-07 10:21:31.420306", "failed_when_result": false, "rc": 0, "start": "2020-01-07 10:21:29.434911", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotlocation.velero.io/minio created", "stdout_lines": ["volumesnapshotlocation.velero.io/minio created"]}

TASK [Get Application pod details] *********************************************
task path: /experiments/functional/backup_and_restore/test.yml:24
2020-01-07T10:21:31.516293 (delta: 2.581966)         elapsed: 94.736512 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-backup -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.390730", "end": "2020-01-07 10:21:33.314274", "rc": 0, "start": "2020-01-07 10:21:31.923544", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-qp6cg", "stdout_lines": ["percona-7c6969cf78-qp6cg"]}

TASK [Create new database in the mysql] ****************************************
task path: /experiments/functional/backup_and_restore/test.yml:28
2020-01-07T10:21:33.433054 (delta: 1.916709)         elapsed: 96.653273 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-01-07T10:21:33.717101 (delta: 0.283926)         elapsed: 96.93732 ******** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;') => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-qp6cg -n percona-backup -- mysql -uroot -pk8sDem0 -e 'create database backup;'", "delta": "0:00:01.927123", "end": "2020-01-07 10:21:35.997488", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "rc": 0, "start": "2020-01-07 10:21:34.070365", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-qp6cg -n percona-backup -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "delta": "0:00:02.388716", "end": "2020-01-07 10:21:38.840818", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "rc": 0, "start": "2020-01-07 10:21:36.452102", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup) => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-qp6cg -n percona-backup -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "delta": "0:00:01.929152", "end": "2020-01-07 10:21:41.208121", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "rc": 0, "start": "2020-01-07 10:21:39.278969", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-01-07T10:21:41.318906 (delta: 7.601743)         elapsed: 104.539125 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-01-07T10:21:41.427940 (delta: 0.108944)         elapsed: 104.648159 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-01-07T10:21:41.536347 (delta: 0.108337)         elapsed: 104.756566 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-01-07T10:21:41.686897 (delta: 0.150457)         elapsed: 104.907116 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-01-07T10:21:41.866718 (delta: 0.179669)         elapsed: 105.086937 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-01-07T10:21:42.041260 (delta: 0.174438)         elapsed: 105.261479 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-01-07T10:21:42.246320 (delta: 0.204939)         elapsed: 105.466539 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-01-07T10:21:42.348594 (delta: 0.10216)         elapsed: 105.568813 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-01-07T10:21:42.445782 (delta: 0.09712)         elapsed: 105.666001 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-01-07T10:21:42.536107 (delta: 0.090247)         elapsed: 105.756326 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application deployment name] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:40
2020-01-07T10:21:42.686563 (delta: 0.150377)         elapsed: 105.906782 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Fetching the volume name of application] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:44
2020-01-07T10:21:42.880884 (delta: 0.194197)         elapsed: 106.101103 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Annotating the application pod] ******************************************
task path: /experiments/functional/backup_and_restore/test.yml:48
2020-01-07T10:21:42.993978 (delta: 0.112954)         elapsed: 106.214197 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup for the provided application] ****************************
task path: /experiments/functional/backup_and_restore/test.yml:53
2020-01-07T10:21:43.135774 (delta: 0.141694)         elapsed: 106.355993 ****** 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2020-01-07T10:21:43.420033 (delta: 0.284164)         elapsed: 106.640252 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero backup create percona-backup --include-namespaces=percona-backup --snapshot-volumes --volume-snapshot-locations=minio", "delta": "0:00:01.419849", "end": "2020-01-07 10:21:45.165262", "rc": 0, "start": "2020-01-07 10:21:43.745413", "stderr": "", "stderr_lines": [], "stdout": "Backup request \"percona-backup\" submitted successfully.\nRun `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details.", "stdout_lines": ["Backup request \"percona-backup\" submitted successfully.", "Run `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details."]}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:16
2020-01-07T10:21:45.266952 (delta: 1.846829)         elapsed: 108.487171 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:26
2020-01-07T10:21:45.386321 (delta: 0.119302)         elapsed: 108.60654 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:34
2020-01-07T10:21:45.541417 (delta: 0.155028)         elapsed: 108.761636 ****** 
FAILED - RETRYING: Getting the state of Backup (60 retries left).
FAILED - RETRYING: Getting the state of Backup (59 retries left).
FAILED - RETRYING: Getting the state of Backup (58 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get backup percona-backup -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.565563", "end": "2020-01-07 10:22:07.874814", "rc": 0, "start": "2020-01-07 10:22:06.309251", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:45
2020-01-07T10:22:08.021643 (delta: 22.480133)         elapsed: 131.241862 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:51
2020-01-07T10:22:08.164593 (delta: 0.142868)         elapsed: 131.384812 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:57
2020-01-07T10:22:08.332796 (delta: 0.168066)         elapsed: 131.553015 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:61
2020-01-07T10:22:08.504460 (delta: 0.17156)         elapsed: 131.724679 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting Application] ****************************************************
task path: /experiments/functional/backup_and_restore/test.yml:58
2020-01-07T10:22:08.677881 (delta: 0.17332)         elapsed: 131.8981 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc,deploy,svc --all -n percona-backup\n kubectl delete ns percona-backup", "delta": "0:00:15.540994", "end": "2020-01-07 10:22:24.694741", "rc": 0, "start": "2020-01-07 10:22:09.153747", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"percona-mysql-claim\" deleted\ndeployment.extensions \"percona\" deleted\nservice \"percona-mysql\" deleted\nnamespace \"percona-backup\" deleted", "stdout_lines": ["persistentvolumeclaim \"percona-mysql-claim\" deleted", "deployment.extensions \"percona\" deleted", "service \"percona-mysql\" deleted", "namespace \"percona-backup\" deleted"]}

TASK [Checking whether namespace is deleted] ***********************************
task path: /experiments/functional/backup_and_restore/test.yml:63
2020-01-07T10:22:24.881849 (delta: 16.20383)         elapsed: 148.102068 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.415757", "end": "2020-01-07 10:22:26.541241", "rc": 0, "start": "2020-01-07 10:22:25.125484", "stderr": "", "stderr_lines": [], "stdout": "app-nfsv4-ns\napp-wordpress-ns\nbusybox\nbusybox-csi\nbusybox-jiva-snap\nbusybox-snap\ncert-manager\ndefault\ne2e\nfio\nfio-jiva\nfio-jiva-snapshot-del\nkommander\nkube-node-lease\nkube-public\nkube-system\nkubeaddons\nlitmus\nlogging\nmemleak-jiva\nnode-failure-cstor\nopenebs\npool-kill\npost-rebuild\nvelero", "stdout_lines": ["app-nfsv4-ns", "app-wordpress-ns", "busybox", "busybox-csi", "busybox-jiva-snap", "busybox-snap", "cert-manager", "default", "e2e", "fio", "fio-jiva", "fio-jiva-snapshot-del", "kommander", "kube-node-lease", "kube-public", "kube-system", "kubeaddons", "litmus", "logging", "memleak-jiva", "node-failure-cstor", "openebs", "pool-kill", "post-rebuild", "velero"]}

TASK [Restoring Application] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:75
2020-01-07T10:22:26.696615 (delta: 1.814587)         elapsed: 149.916834 ****** 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2020-01-07T10:22:27.079680 (delta: 0.382978)         elapsed: 150.299899 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:16
2020-01-07T10:22:27.166572 (delta: 0.086817)         elapsed: 150.386791 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:26
2020-01-07T10:22:27.265779 (delta: 0.099119)         elapsed: 150.485998 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:34
2020-01-07T10:22:27.360698 (delta: 0.094846)         elapsed: 150.580917 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:45
2020-01-07T10:22:27.460981 (delta: 0.100209)         elapsed: 150.6812 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns percona-backup", "delta": "0:00:01.425323", "end": "2020-01-07 10:22:29.328780", "failed_when_result": false, "rc": 0, "start": "2020-01-07 10:22:27.903457", "stderr": "", "stderr_lines": [], "stdout": "namespace/percona-backup created", "stdout_lines": ["namespace/percona-backup created"]}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:51
2020-01-07T10:22:29.497225 (delta: 2.036172)         elapsed: 152.717444 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero restore create --from-backup percona-backup --restore-volumes=true", "delta": "0:00:01.467553", "end": "2020-01-07 10:22:31.419190", "rc": 0, "start": "2020-01-07 10:22:29.951637", "stderr": "", "stderr_lines": [], "stdout": "Restore request \"percona-backup-20200107102231\" submitted successfully.\nRun `velero restore describe percona-backup-20200107102231` or `velero restore logs percona-backup-20200107102231` for more details.", "stdout_lines": ["Restore request \"percona-backup-20200107102231\" submitted successfully.", "Run `velero restore describe percona-backup-20200107102231` or `velero restore logs percona-backup-20200107102231` for more details."]}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:57
2020-01-07T10:22:31.569116 (delta: 2.071814)         elapsed: 154.789335 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero get restore | grep percona-backup | awk '{print $1}'", "delta": "0:00:01.344636", "end": "2020-01-07 10:22:33.377817", "rc": 0, "start": "2020-01-07 10:22:32.033181", "stderr": "", "stderr_lines": [], "stdout": "percona-backup-20200107102231", "stdout_lines": ["percona-backup-20200107102231"]}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:61
2020-01-07T10:22:33.476808 (delta: 1.907557)         elapsed: 156.697027 ****** 
FAILED - RETRYING: Checking the restore status (45 retries left).
FAILED - RETRYING: Checking the restore status (44 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get restore percona-backup-20200107102231 -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.443604", "end": "2020-01-07 10:22:49.016871", "rc": 0, "start": "2020-01-07 10:22:47.573267", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Getting the volume name] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:82
2020-01-07T10:22:49.167687 (delta: 15.690809)         elapsed: 172.387906 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n percona-backup -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.493853", "end": "2020-01-07 10:22:51.019590", "rc": 0, "start": "2020-01-07 10:22:49.525737", "stderr": "", "stderr_lines": [], "stdout": "pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "stdout_lines": ["pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7"]}

TASK [Getting the target IP] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:86
2020-01-07T10:22:51.204291 (delta: 2.036519)         elapsed: 174.42451 ******* 
FAILED - RETRYING: Getting the target IP (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7 -o jsonpath='{.items[0].status.podIP}'", "delta": "0:00:01.463621", "end": "2020-01-07 10:23:00.020221", "rc": 0, "start": "2020-01-07 10:22:58.556600", "stderr": "", "stderr_lines": [], "stdout": "172.168.122.166", "stdout_lines": ["172.168.122.166"]}

TASK [Getting the volume name] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:93
2020-01-07T10:23:00.135819 (delta: 8.931431)         elapsed: 183.356038 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n percona-backup -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.573944", "end": "2020-01-07 10:23:02.027157", "rc": 0, "start": "2020-01-07 10:23:00.453213", "stderr": "", "stderr_lines": [], "stdout": "pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "stdout_lines": ["pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7"]}

TASK [Getting the CVR name from the corresponding PV] **************************
task path: /experiments/functional/backup_and_restore/test.yml:97
2020-01-07T10:23:02.175796 (delta: 2.039909)         elapsed: 185.396015 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7 -o jsonpath='{range.items[*]}{.metadata.labels.cstorpool\\.openebs\\.io/name}{\"\\n\"}{end}'", "delta": "0:00:01.591593", "end": "2020-01-07 10:23:04.255148", "rc": 0, "start": "2020-01-07 10:23:02.663555", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-dmz4\ncstor-block-disk-pool-stripe-i2et\ncstor-block-disk-pool-stripe-sm9c", "stdout_lines": ["cstor-block-disk-pool-stripe-dmz4", "cstor-block-disk-pool-stripe-i2et", "cstor-block-disk-pool-stripe-sm9c"]}

TASK [Geting the CSP name corresponding to CVR] ********************************
task path: /experiments/functional/backup_and_restore/test.yml:101
2020-01-07T10:23:04.432449 (delta: 2.256469)         elapsed: 187.652668 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-dmz4) => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-stripe-dmz4 -n openebs -o jsonpath='{.metadata.name}'", "delta": "0:00:01.461345", "end": "2020-01-07 10:23:06.407053", "item": "cstor-block-disk-pool-stripe-dmz4", "rc": 0, "start": "2020-01-07 10:23:04.945708", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-dmz4", "stdout_lines": ["cstor-block-disk-pool-stripe-dmz4"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-i2et) => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-stripe-i2et -n openebs -o jsonpath='{.metadata.name}'", "delta": "0:00:01.324747", "end": "2020-01-07 10:23:08.108085", "item": "cstor-block-disk-pool-stripe-i2et", "rc": 0, "start": "2020-01-07 10:23:06.783338", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-i2et", "stdout_lines": ["cstor-block-disk-pool-stripe-i2et"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-sm9c) => {"changed": true, "cmd": "kubectl get csp cstor-block-disk-pool-stripe-sm9c -n openebs -o jsonpath='{.metadata.name}'", "delta": "0:00:01.381301", "end": "2020-01-07 10:23:09.905876", "item": "cstor-block-disk-pool-stripe-sm9c", "rc": 0, "start": "2020-01-07 10:23:08.524575", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-sm9c", "stdout_lines": ["cstor-block-disk-pool-stripe-sm9c"]}

TASK [Getting the pool pod name] ***********************************************
task path: /experiments/functional/backup_and_restore/test.yml:106
2020-01-07T10:23:10.035906 (delta: 5.603351)         elapsed: 193.256125 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-dmz4) => {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", "delta": "0:00:01.649565", "end": "2020-01-07 10:23:12.093416", "item": "cstor-block-disk-pool-stripe-dmz4", "rc": 0, "start": "2020-01-07 10:23:10.443851", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs", "stdout_lines": ["cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-i2et) => {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", "delta": "0:00:01.733240", "end": "2020-01-07 10:23:14.142103", "item": "cstor-block-disk-pool-stripe-i2et", "rc": 0, "start": "2020-01-07 10:23:12.408863", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd", "stdout_lines": ["cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-stripe-sm9c) => {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", "delta": "0:00:01.762447", "end": "2020-01-07 10:23:16.314192", "item": "cstor-block-disk-pool-stripe-sm9c", "rc": 0, "start": "2020-01-07 10:23:14.551745", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg", "stdout_lines": ["cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg"]}

TASK [Getting the volume name inside cstor pool] *******************************
task path: /experiments/functional/backup_and_restore/test.yml:111
2020-01-07T10:23:16.513824 (delta: 6.477794)         elapsed: 199.734043 ****** 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs', '_ansible_item_result': True, u'delta': u'0:00:01.649565', 'stdout_lines': [u'cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-dmz4', u'end': u'2020-01-07 10:23:12.093416', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", 'item': u'cstor-block-disk-pool-stripe-dmz4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-07 10:23:10.443851', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs -n openebs -c cstor-pool -- zfs list | grep pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7 | awk '{print $1}') >> cstor-vol", "delta": "0:00:02.208779", "end": "2020-01-07 10:23:19.016882", "item": {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", "delta": "0:00:01.649565", "end": "2020-01-07 10:23:12.093416", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-dmz4", "rc": 0, "start": "2020-01-07 10:23:10.443851", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs", "stdout_lines": ["cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs"]}, "rc": 0, "start": "2020-01-07 10:23:16.808103", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd', '_ansible_item_result': True, u'delta': u'0:00:01.733240', 'stdout_lines': [u'cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-i2et', u'end': u'2020-01-07 10:23:14.142103', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", 'item': u'cstor-block-disk-pool-stripe-i2et', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-07 10:23:12.408863', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd -n openebs -c cstor-pool -- zfs list | grep pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7 | awk '{print $1}') >> cstor-vol", "delta": "0:00:02.359781", "end": "2020-01-07 10:23:21.785482", "item": {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", "delta": "0:00:01.733240", "end": "2020-01-07 10:23:14.142103", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-i2et", "rc": 0, "start": "2020-01-07 10:23:12.408863", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd", "stdout_lines": ["cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd"]}, "rc": 0, "start": "2020-01-07 10:23:19.425701", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg', '_ansible_item_result': True, u'delta': u'0:00:01.762447', 'stdout_lines': [u'cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-sm9c', u'end': u'2020-01-07 10:23:16.314192', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", 'item': u'cstor-block-disk-pool-stripe-sm9c', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-07 10:23:14.551745', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "echo $(kubectl exec -it cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg -n openebs -c cstor-pool -- zfs list | grep pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7 | awk '{print $1}') >> cstor-vol", "delta": "0:00:02.571892", "end": "2020-01-07 10:23:24.594698", "item": {"changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", "delta": "0:00:01.762447", "end": "2020-01-07 10:23:16.314192", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-sm9c", "rc": 0, "start": "2020-01-07 10:23:14.551745", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg", "stdout_lines": ["cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg"]}, "rc": 0, "start": "2020-01-07 10:23:22.022806", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Assigning the cstor-pool volume name to variable] ************************
task path: /experiments/functional/backup_and_restore/test.yml:116
2020-01-07T10:23:24.776457 (delta: 8.262497)         elapsed: 207.996676 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat ./cstor-vol", "delta": "0:00:01.579667", "end": "2020-01-07 10:23:26.634453", "rc": 0, "start": "2020-01-07 10:23:25.054786", "stderr": "", "stderr_lines": [], "stdout": "cstor-e214414a-318c-43af-8b8c-48d35234d7d1/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7\ncstor-84d22fc4-d8dd-49ec-b264-060e71dc9b9f/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7\ncstor-fcc77ab3-c43a-460e-924d-311d09d95a25/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "stdout_lines": ["cstor-e214414a-318c-43af-8b8c-48d35234d7d1/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "cstor-84d22fc4-d8dd-49ec-b264-060e71dc9b9f/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "cstor-fcc77ab3-c43a-460e-924d-311d09d95a25/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7"]}

TASK [Setting target IP for volume inside cstor pool] **************************
task path: /experiments/functional/backup_and_restore/test.yml:120
2020-01-07T10:23:26.719843 (delta: 1.943325)         elapsed: 209.940062 ****** 
changed: [127.0.0.1] => (item=[{'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs', '_ansible_item_result': True, u'delta': u'0:00:01.649565', 'stdout_lines': [u'cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-dmz4', u'end': u'2020-01-07 10:23:12.093416', '_ansible_no_log': False, u'start': u'2020-01-07 10:23:10.443851', 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", 'item': u'cstor-block-disk-pool-stripe-dmz4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'cstor-e214414a-318c-43af-8b8c-48d35234d7d1/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7']) => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs -n openebs -- zfs set io.openebs:targetip=172.168.122.166 cstor-e214414a-318c-43af-8b8c-48d35234d7d1/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "delta": "0:00:02.415228", "end": "2020-01-07 10:23:29.523488", "item": [{"_ansible_ignore_errors": null, "_ansible_item_label": "cstor-block-disk-pool-stripe-dmz4", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", "delta": "0:00:01.649565", "end": "2020-01-07 10:23:12.093416", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-dmz4 | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-dmz4", "rc": 0, "start": "2020-01-07 10:23:10.443851", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs", "stdout_lines": ["cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs"]}, "cstor-e214414a-318c-43af-8b8c-48d35234d7d1/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7"], "rc": 0, "start": "2020-01-07 10:23:27.108260", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-stripe-dmz4-85cbbcbd84-4khzs -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[{'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd', '_ansible_item_result': True, u'delta': u'0:00:01.733240', 'stdout_lines': [u'cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-i2et', u'end': u'2020-01-07 10:23:14.142103', '_ansible_no_log': False, u'start': u'2020-01-07 10:23:12.408863', 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", 'item': u'cstor-block-disk-pool-stripe-i2et', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'cstor-84d22fc4-d8dd-49ec-b264-060e71dc9b9f/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7']) => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd -n openebs -- zfs set io.openebs:targetip=172.168.122.166 cstor-84d22fc4-d8dd-49ec-b264-060e71dc9b9f/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "delta": "0:00:02.534864", "end": "2020-01-07 10:23:32.475088", "item": [{"_ansible_ignore_errors": null, "_ansible_item_label": "cstor-block-disk-pool-stripe-i2et", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", "delta": "0:00:01.733240", "end": "2020-01-07 10:23:14.142103", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-i2et | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-i2et", "rc": 0, "start": "2020-01-07 10:23:12.408863", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd", "stdout_lines": ["cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd"]}, "cstor-84d22fc4-d8dd-49ec-b264-060e71dc9b9f/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7"], "rc": 0, "start": "2020-01-07 10:23:29.940224", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-stripe-i2et-c48c967b6-jddgd -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[{'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg', '_ansible_item_result': True, u'delta': u'0:00:01.762447', 'stdout_lines': [u'cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg'], '_ansible_item_label': u'cstor-block-disk-pool-stripe-sm9c', u'end': u'2020-01-07 10:23:16.314192', '_ansible_no_log': False, u'start': u'2020-01-07 10:23:14.551745', 'failed': False, u'cmd': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", 'item': u'cstor-block-disk-pool-stripe-sm9c', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u"kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'cstor-fcc77ab3-c43a-460e-924d-311d09d95a25/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7']) => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg -n openebs -- zfs set io.openebs:targetip=172.168.122.166 cstor-fcc77ab3-c43a-460e-924d-311d09d95a25/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7", "delta": "0:00:02.469762", "end": "2020-01-07 10:23:35.247856", "item": [{"_ansible_ignore_errors": null, "_ansible_item_label": "cstor-block-disk-pool-stripe-sm9c", "_ansible_item_result": true, "_ansible_no_log": false, "_ansible_parsed": true, "changed": true, "cmd": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", "delta": "0:00:01.762447", "end": "2020-01-07 10:23:16.314192", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -n openebs | grep cstor-block-disk-pool-stripe-sm9c | awk '{print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-stripe-sm9c", "rc": 0, "start": "2020-01-07 10:23:14.551745", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg", "stdout_lines": ["cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg"]}, "cstor-fcc77ab3-c43a-460e-924d-311d09d95a25/pvc-7f6cbba8-12d8-45ce-8d68-cda3b61232d7"], "rc": 0, "start": "2020-01-07 10:23:32.778094", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-stripe-sm9c-5f55687966-82blg -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Waiting for application to be in running state] **************************
task path: /experiments/functional/backup_and_restore/test.yml:128
2020-01-07T10:23:35.376102 (delta: 8.656199)         elapsed: 218.596321 ****** 
FAILED - RETRYING: Waiting for application to be in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod percona-7c6969cf78-qp6cg -n percona-backup -o jsonpath='{.status.phase}'", "delta": "0:00:01.712811", "end": "2020-01-07 10:23:44.535277", "rc": 0, "start": "2020-01-07 10:23:42.822466", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying Data persistense] **********************************************
task path: /experiments/functional/backup_and_restore/test.yml:135
2020-01-07T10:23:44.728227 (delta: 9.352045)         elapsed: 227.948446 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-01-07T10:23:45.085475 (delta: 0.357143)         elapsed: 228.305694 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-01-07T10:23:45.238193 (delta: 0.152668)         elapsed: 228.458412 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7c6969cf78-qp6cg -n percona-backup", "delta": "0:00:13.099493", "end": "2020-01-07 10:23:58.599903", "rc": 0, "start": "2020-01-07 10:23:45.500410", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7c6969cf78-qp6cg\" deleted", "stdout_lines": ["pod \"percona-7c6969cf78-qp6cg\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-01-07T10:23:58.780482 (delta: 13.542219)         elapsed: 242.000701 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-backup", "delta": "0:00:01.505452", "end": "2020-01-07 10:24:00.648083", "rc": 0, "start": "2020-01-07 10:23:59.142631", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS    RESTARTS   AGE\npercona-7c6969cf78-5b76p   1/1     Running   0          13s", "stdout_lines": ["NAME                       READY   STATUS    RESTARTS   AGE", "percona-7c6969cf78-5b76p   1/1     Running   0          13s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-01-07T10:24:00.770418 (delta: 1.989833)         elapsed: 243.990637 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-backup -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.828654", "end": "2020-01-07 10:24:02.957074", "rc": 0, "start": "2020-01-07 10:24:01.128420", "stderr": "", "stderr_lines": [], "stdout": "percona-7c6969cf78-5b76p", "stdout_lines": ["percona-7c6969cf78-5b76p"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-01-07T10:24:03.136220 (delta: 2.365732)         elapsed: 246.356439 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-backup -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-5b76p\")].status.phase}'", "delta": "0:00:01.547619", "end": "2020-01-07 10:24:04.983979", "rc": 0, "start": "2020-01-07 10:24:03.436360", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-01-07T10:24:05.133890 (delta: 1.997573)         elapsed: 248.354109 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-backup -o jsonpath='{.items[?(@.metadata.name==\"percona-7c6969cf78-5b76p\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.769504", "end": "2020-01-07 10:24:07.281904", "rc": 0, "start": "2020-01-07 10:24:05.512400", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-07T10:23:50Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-07T10:23:50Z]]"]}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-01-07T10:24:07.470621 (delta: 2.336618)         elapsed: 250.69084 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-7c6969cf78-5b76p -n percona-backup | grep 'ready for connections'", "delta": "0:00:01.656923", "end": "2020-01-07 10:24:09.469731", "rc": 0, "start": "2020-01-07 10:24:07.812808", "stderr": "", "stderr_lines": [], "stdout": "2020-01-07T10:23:51.896567Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2020-01-07T10:23:51.896567Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-01-07T10:24:09.644466 (delta: 2.173744)         elapsed: 252.864685 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-5b76p -n percona-backup -- mysqlcheck -c backup -uroot -pk8sDem0", "delta": "0:00:02.326848", "end": "2020-01-07 10:24:12.263524", "failed_when_result": false, "rc": 0, "start": "2020-01-07 10:24:09.936676", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "backup.ttbl                                        OK", "stdout_lines": ["backup.ttbl                                        OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-01-07T10:24:12.366913 (delta: 2.72233)         elapsed: 255.587132 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7c6969cf78-5b76p -n percona-backup -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' backup;", "delta": "0:00:02.215280", "end": "2020-01-07 10:24:14.951529", "failed_when_result": false, "rc": 0, "start": "2020-01-07 10:24:12.736249", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-01-07T10:24:15.167849 (delta: 2.800846)         elapsed: 258.388068 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-01-07T10:24:15.256716 (delta: 0.088777)         elapsed: 258.476935 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/backup_and_restore/test.yml:146
2020-01-07T10:24:15.353614 (delta: 0.096831)         elapsed: 258.573833 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:154
2020-01-07T10:24:15.488977 (delta: 0.135295)         elapsed: 258.709196 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-01-07T10:24:15.694288 (delta: 0.205244)         elapsed: 258.914507 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-01-07T10:24:15.772729 (delta: 0.078382)         elapsed: 258.992948 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-01-07T10:24:15.882461 (delta: 0.10967)         elapsed: 259.10268 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-01-07T10:24:15.981759 (delta: 0.099233)         elapsed: 259.201978 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "218cc4cd06f4a20f4ce3c234b033d66800aa02b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9f2161a292cb589ce3599bf99ea6818b", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1578392656.07-265832894571048/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-01-07T10:24:19.345795 (delta: 3.363968)         elapsed: 262.566014 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.395281", "end": "2020-01-07 10:24:21.046578", "rc": 0, "start": "2020-01-07 10:24:19.651297", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-01-07T10:24:21.134800 (delta: 1.788943)         elapsed: 264.355019 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-07T08:55:22Z", "generation": 6, "name": "velero-backup-restore", "resourceVersion": "121440", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "d5ba2643-147d-485b-ab3c-0d54f7247c04"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

TASK [Deprovisioning Velero server] ********************************************
task path: /experiments/functional/backup_and_restore/test.yml:158
2020-01-07T10:24:22.460621 (delta: 1.325764)         elapsed: 265.68084 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete namespace velero", "delta": "0:00:24.342083", "end": "2020-01-07 10:24:47.246277", "rc": 0, "start": "2020-01-07 10:24:22.904194", "stderr": "", "stderr_lines": [], "stdout": "namespace \"velero\" deleted", "stdout_lines": ["namespace \"velero\" deleted"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=58   changed=47   unreachable=0    failed=0   

2020-01-07T10:24:47.323465 (delta: 24.862764)         elapsed: 290.543684 *****
```
