### PR TITLE
feat[yaml]: Implemented litmusbook to deploy jiva csi provisioner

### DIFF
--- a/providers/jiva-csi-provisioner/README.md
+++ b/providers/jiva-csi-provisioner/README.md
@@ -12,7 +12,7 @@
         - NODE_OS : The operating system of worker nodes.
         - REPLICA_SC : The name of storage class used to create volume replicas.
 
-### csi-cstor-sc.j2
+### csi-jiva-sc.j2
    - The storage class template which has to be populated with the given variables
 
 ### test_vars.yml

--- a/providers/jiva-csi-provisioner/README.md
+++ b/providers/jiva-csi-provisioner/README.md
@@ -1,0 +1,22 @@
+# LitmusBook to deploy the OpenEBS Jiva CSI Driver.
+
+## Description
+   - This LitmusBook is capable of setting up OpenEBS Jiva CSI Driver and create a storageclass.
+
+   - This test constitutes the below files. 
+
+### run_litmus_test.yml
+   - This includes the litmus job which triggers the test execution. The pod includes several environmental variables such as 
+        - PROVIDER_STORAGE_CLASS : The name of storageclass to create using jiva csi provisioner
+        - REPLICA_COUNT : The number of volume replicas to be created.
+        - NODE_OS : The operating system of worker nodes.
+        - REPLICA_SC : The name of storage class used to create volume replicas.
+
+### csi-cstor-sc.j2
+   - The storage class template which has to be populated with the given variables
+
+### test_vars.yml
+   - This test_vars file has the list of test specific variables used in LitmusBook
+
+### test.yml
+   - test.yml is the playbook where the test logic is built to deploy OpenEBS Jiva CSI Driver and create stoarge class.

--- a/providers/jiva-csi-provisioner/csi-jiva-sc.j2
+++ b/providers/jiva-csi-provisioner/csi-jiva-sc.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}"
+provisioner: jiva.csi.openebs.io
+parameters:
+  cas-type: "jiva"
+  replicaCount: "{{ replica_count }}"
+  replicaSC: "{{ replica_storageclass }}"

--- a/providers/jiva-csi-provisioner/run_litmus_test.yml
+++ b/providers/jiva-csi-provisioner/run_litmus_test.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-csi-provisioner-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: jiva-csi-provisioner
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-jiva-csi-sc
+          
+          - name: NODE_OS
+            value: ubuntu-16.04
+
+          - name: REPLICA_SC
+            value: openebs-hostpath
+
+          - name: REPLICA_COUNT
+            value: "3"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/jiva-csi-provisioner/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/jiva-csi-provisioner/run_litmus_test.yml
+++ b/providers/jiva-csi-provisioner/run_litmus_test.yml
@@ -22,6 +22,9 @@ spec:
             #value: log_plays
             value: default
 
+          - name: OPERATOR_IMAGE
+            value: ci
+
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-jiva-csi-sc
           

--- a/providers/jiva-csi-provisioner/run_litmus_test.yml
+++ b/providers/jiva-csi-provisioner/run_litmus_test.yml
@@ -37,5 +37,8 @@ spec:
           - name: REPLICA_COUNT
             value: "3"
 
+          - name: ACTION
+            value: provision  
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/jiva-csi-provisioner/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/jiva-csi-provisioner/test.yml
+++ b/providers/jiva-csi-provisioner/test.yml
@@ -16,13 +16,35 @@
           vars:
             status: 'SOT'
 
-        - name: Install Jiva operator in operator namespace
+        - name: Install prerequisites for Jiva operator in operator namespace
           shell: |
             kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/crds/openebs_v1alpha1_jivavolume_crd.yaml
             kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/service_account.yaml
             kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/role.yaml
             kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/role_binding.yaml
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/operator.yaml
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Download the Jiva operator spec
+          get_url:
+            url: https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/operator.yaml
+            dest: "./"
+            force: yes
+          register: result
+          until:  "'OK' in result.msg"
+          delay: 5
+          retries: 3
+
+        - name: Update the Jiva operator image
+          replace:
+            path: operator.yaml
+            regexp: ":ci"
+            replace: ":{{ operator_image }}"
+
+        - name: Install the Jiva operator in operator namespace
+          shell: kubectl apply -f operator.yaml
           args:
             executable: /bin/bash
           register: status
@@ -35,6 +57,7 @@
           args:
             executable: /bin/bash
           register: jiva_operator_pod
+          failed_when: "jiva_operator_pod.rc != 0"
           
         - name: Verify the status of Jiva operator
           shell: >
@@ -47,21 +70,59 @@
           delay: 10
           retries: 30
             
-        - name: Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04 
-          shell: >
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi-ubuntu-16.04.yaml
-          args:
-            executable: /bin/bash
+        - block:
+
+            - name: Download the Jiva CSI Driver if OS is either centos or ubuntu-16.04
+              get_url:
+                url: https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi-ubuntu-16.04.yaml
+                dest: "./"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3
+
+            - name: Update the operator image in jiva csi driver spec
+              replace:
+                path: jiva-csi-ubuntu-16.04.yaml
+                regexp: ":ci"
+                replace: ":{{ operator_image }}"
+
+            - name: Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04 
+              shell: >
+                kubectl apply -f jiva-csi-ubuntu-16.04.yaml
+              args:
+                executable: /bin/bash
+
           when: node_os == "ubuntu-16.04" or node_os == "centos"
     
-        - name: Deploy CSI Driver if os is ubuntu 18.04
-          shell: >
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi.yaml
-          args:
-            executable: /bin/bash
+        - block: 
+
+            - name: Download the Jiva CSI Driver if OS is ubuntu-18.04
+              get_url:
+                url: https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi.yaml
+                dest: "./"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3
+
+            - name: Update the operator image in jiva csi driver spec
+              replace:
+                path: jiva-csi.yaml
+                regexp: ":ci"
+                replace: ":{{ operator_image }}"
+
+            - name: Deploy CSI Driver if os is ubuntu 18.04
+              shell: >
+                kubectl apply -f jiva-csi.yaml
+              args:
+                executable: /bin/bash
+
           when: node_os == "ubuntu-18.04"
 
-        - name: check if csi-controller pod is running
+        - name: check if jiva csi-controller pod is running
           shell: >
             kubectl get pods -n kube-system -l app=openebs-jiva-csi-controller 
             --no-headers -o custom-columns=:status.phase
@@ -79,6 +140,7 @@
           args:
             executable: /bin/bash
           register: desired_count
+          failed_when: "desired_count.rc != 0"
 
         - name: Check if the desired count matches the ready pods
           command: >

--- a/providers/jiva-csi-provisioner/test.yml
+++ b/providers/jiva-csi-provisioner/test.yml
@@ -1,0 +1,118 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Install Jiva operator in operator namespace
+          shell: |
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/crds/openebs_v1alpha1_jivavolume_crd.yaml
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/service_account.yaml
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/role.yaml
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/role_binding.yaml
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/operator.yaml
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Obtain the Jiva operator pod in operator namespace
+          shell: >
+            kubectl get po -n {{ operator_ns }} --no-headers -l name=jiva-operator 
+            -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: jiva_operator_pod
+          
+        - name: Verify the status of Jiva operator
+          shell: >
+            kubectl get po {{ jiva_operator_pod.stdout }} -n {{ operator_ns }} 
+            --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: jiva_operator
+          until: "'Running' in jiva_operator.stdout"
+          delay: 10
+          retries: 30
+            
+        - name: Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04 
+          shell: >
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi-ubuntu-16.04.yaml
+          args:
+            executable: /bin/bash
+          when: node_os == "ubuntu-16.04" or node_os == "centos"
+    
+        - name: Deploy CSI Driver if os is ubuntu 18.04
+          shell: >
+            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi.yaml
+          args:
+            executable: /bin/bash
+          when: node_os == "ubuntu-18.04"
+
+        - name: check if csi-controller pod is running
+          shell: >
+            kubectl get pods -n kube-system -l app=openebs-jiva-csi-controller 
+            --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: csi_controller
+          until: "'Running' in csi_controller.stdout"
+          delay: 10
+          retries: 30
+
+        - name: Obtain the desired number of openebs-csi-node pods
+          shell: >
+            kubectl get daemonset openebs-jiva-csi-node -n kube-system 
+            --no-headers -o custom-columns=:status.desiredNumberScheduled
+          args:
+            executable: /bin/bash
+          register: desired_count
+
+        - name: Check if the desired count matches the ready pods
+          command: >
+            kubectl get daemonset openebs-jiva-csi-node -n kube-system --no-headers 
+            -o custom-columns=:status.numberReady
+          args:
+            executable: /bin/bash
+          register: ready_pods
+          until: "desired_count.stdout == ready_pods.stdout"
+          delay: 5
+          retries: 50
+
+        - name: Update the storage class template with the variables.
+          template:
+            src: csi-jiva-sc.j2
+            dest: csi-jiva-sc.yml
+
+        - name: Create Storageclass
+          shell: kubectl apply -f csi-jiva-sc.yml
+          args:
+            executable: /bin/bash
+          register: sc_result
+          failed_when: "sc_result.rc != 0"
+         
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/providers/jiva-csi-provisioner/test.yml
+++ b/providers/jiva-csi-provisioner/test.yml
@@ -15,18 +15,7 @@
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:
             status: 'SOT'
-
-        - name: Install prerequisites for Jiva operator in operator namespace
-          shell: |
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/crds/openebs_v1alpha1_jivavolume_crd.yaml
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/service_account.yaml
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/role.yaml
-            kubectl apply -f https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/role_binding.yaml
-          args:
-            executable: /bin/bash
-          register: status
-          failed_when: "status.rc != 0"
-
+        
         - name: Download the Jiva operator spec
           get_url:
             url: https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/operator.yaml
@@ -43,33 +32,6 @@
             regexp: ":ci"
             replace: ":{{ operator_image }}"
 
-        - name: Install the Jiva operator in operator namespace
-          shell: kubectl apply -f operator.yaml
-          args:
-            executable: /bin/bash
-          register: status
-          failed_when: "status.rc != 0"
-
-        - name: Obtain the Jiva operator pod in operator namespace
-          shell: >
-            kubectl get po -n {{ operator_ns }} --no-headers -l name=jiva-operator 
-            -o custom-columns=:.metadata.name
-          args:
-            executable: /bin/bash
-          register: jiva_operator_pod
-          failed_when: "jiva_operator_pod.rc != 0"
-          
-        - name: Verify the status of Jiva operator
-          shell: >
-            kubectl get po {{ jiva_operator_pod.stdout }} -n {{ operator_ns }} 
-            --no-headers -o custom-columns=:.status.phase
-          args:
-            executable: /bin/bash
-          register: jiva_operator
-          until: "'Running' in jiva_operator.stdout"
-          delay: 10
-          retries: 30
-            
         - block:
 
             - name: Download the Jiva CSI Driver if OS is either centos or ubuntu-16.04
@@ -87,13 +49,7 @@
                 path: jiva-csi-ubuntu-16.04.yaml
                 regexp: ":ci"
                 replace: ":{{ operator_image }}"
-
-            - name: Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04 
-              shell: >
-                kubectl apply -f jiva-csi-ubuntu-16.04.yaml
-              args:
-                executable: /bin/bash
-
+            
           when: node_os == "ubuntu-16.04" or node_os == "centos"
     
         - block: 
@@ -113,58 +69,173 @@
                 path: jiva-csi.yaml
                 regexp: ":ci"
                 replace: ":{{ operator_image }}"
-
-            - name: Deploy CSI Driver if os is ubuntu 18.04
-              shell: >
-                kubectl apply -f jiva-csi.yaml
-              args:
-                executable: /bin/bash
-
+            
           when: node_os == "ubuntu-18.04"
 
-        - name: check if jiva csi-controller pod is running
-          shell: >
-            kubectl get pods -n kube-system -l app=openebs-jiva-csi-controller 
-            --no-headers -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: csi_controller
-          until: "'Running' in csi_controller.stdout"
-          delay: 10
-          retries: 30
+        - block: 
+            - name: Install the Jiva operator in operator namespace
+              shell: kubectl apply -f operator.yaml
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
 
-        - name: Obtain the desired number of openebs-csi-node pods
-          shell: >
-            kubectl get daemonset openebs-jiva-csi-node -n kube-system 
-            --no-headers -o custom-columns=:status.desiredNumberScheduled
-          args:
-            executable: /bin/bash
-          register: desired_count
-          failed_when: "desired_count.rc != 0"
+            - name: Obtain the Jiva operator pod in operator namespace
+              shell: >
+                kubectl get po -n {{ operator_ns }} --no-headers -l name=jiva-operator 
+                -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: jiva_operator_pod
+              failed_when: "jiva_operator_pod.rc != 0"
+              
+            - name: Verify the status of Jiva operator
+              shell: >
+                kubectl get po {{ jiva_operator_pod.stdout }} -n {{ operator_ns }} 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: jiva_operator
+              until: "'Running' in jiva_operator.stdout"
+              delay: 10
+              retries: 30
+                
+            - block:
+                
+                - name: Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04 
+                  shell: >
+                    kubectl apply -f jiva-csi-ubuntu-16.04.yaml
+                  args:
+                    executable: /bin/bash
+                  register: status
+                  failed_when: "status.rc != 0"
 
-        - name: Check if the desired count matches the ready pods
-          command: >
-            kubectl get daemonset openebs-jiva-csi-node -n kube-system --no-headers 
-            -o custom-columns=:status.numberReady
-          args:
-            executable: /bin/bash
-          register: ready_pods
-          until: "desired_count.stdout == ready_pods.stdout"
-          delay: 5
-          retries: 50
+              when: node_os == "ubuntu-16.04" or node_os == "centos"
+        
+            - block: 
+                
+                - name: Deploy CSI Driver if os is ubuntu 18.04
+                  shell: >
+                    kubectl apply -f jiva-csi.yaml
+                  args:
+                    executable: /bin/bash
+                  register: status
+                  failed_when: "status.rc != 0"
 
-        - name: Update the storage class template with the variables.
-          template:
-            src: csi-jiva-sc.j2
-            dest: csi-jiva-sc.yml
+              when: node_os == "ubuntu-18.04"
 
-        - name: Create Storageclass
-          shell: kubectl apply -f csi-jiva-sc.yml
-          args:
-            executable: /bin/bash
-          register: sc_result
-          failed_when: "sc_result.rc != 0"
-         
+            - name: check if jiva csi-controller pod is running
+              shell: >
+                kubectl get pods -n kube-system -l app=openebs-jiva-csi-controller 
+                --no-headers -o custom-columns=:status.phase
+              args:
+                executable: /bin/bash
+              register: csi_controller
+              until: "'Running' in csi_controller.stdout"
+              delay: 10
+              retries: 30
+
+            - name: Obtain the desired number of openebs-csi-node pods
+              shell: >
+                kubectl get daemonset openebs-jiva-csi-node -n kube-system 
+                --no-headers -o custom-columns=:status.desiredNumberScheduled
+              args:
+                executable: /bin/bash
+              register: desired_count
+              failed_when: "desired_count.rc != 0"
+
+            - name: Check if the desired count matches the ready pods
+              command: >
+                kubectl get daemonset openebs-jiva-csi-node -n kube-system --no-headers 
+                -o custom-columns=:status.numberReady
+              args:
+                executable: /bin/bash
+              register: ready_pods
+              until: "desired_count.stdout == ready_pods.stdout"
+              delay: 5
+              retries: 50
+
+            - name: Update the storage class template with the variables.
+              template:
+                src: csi-jiva-sc.j2
+                dest: csi-jiva-sc.yml
+
+            - name: Create Storageclass
+              shell: kubectl apply -f csi-jiva-sc.yml
+              args:
+                executable: /bin/bash
+              register: sc_result
+              failed_when: "sc_result.rc != 0"
+          
+          when: action == "provision"
+
+        - block:
+            
+            - name: Delete Jiva CSI Driver if OS is either centos or ubuntu-16.04 
+              shell: >
+                kubectl delete -f jiva-csi-ubuntu-16.04.yaml
+              args:
+                executable: /bin/bash
+              when: node_os == "ubuntu-16.04" or node_os == "centos"
+        
+            - name: Delete CSI Driver if os is ubuntu 18.04
+              shell: >
+                kubectl delete -f jiva-csi.yaml
+              args:
+                executable: /bin/bash
+              when: node_os == "ubuntu-18.04"
+
+            - name: Verify if the Jiva CSI controller pod is deleted
+              shell: >
+                kubectl get pod -n kube-system -l app=openebs-jiva-csi-controller 
+                --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: jiva_csi_controller
+              until: "jiva_csi_controller.stdout == ''"
+              delay: 10
+              retries: 30
+
+            - name: Verify if the Jiva CSI node pod is deleted
+              shell: >
+                kubectl get pod -n kube-system -l app=openebs-jiva-csi-node 
+                --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: jiva_csi_node
+              until: "jiva_csi_node.stdout == ''"
+              delay: 10
+              retries: 30  
+                  
+            - name: Delete jiva operator from operator namespace
+              shell: >
+                kubectl delete -f operator.yaml
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - name: Verify if the Jiva operator pod is deleted
+              shell: >
+                kubectl get pod -n {{ operator_ns }} -l name=jiva-operator 
+                --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: jiva_operator
+              until: "jiva_operator.stdout == ''"
+              delay: 10
+              retries: 30  
+              
+            - name: Delete the storage class created
+              shell: >
+                kubectl delete sc {{ storage_class }}
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+              
+          when: action == "deprovision"
+
         - set_fact:
             flag: "Pass"
 

--- a/providers/jiva-csi-provisioner/test_vars.yml
+++ b/providers/jiva-csi-provisioner/test_vars.yml
@@ -13,3 +13,5 @@ replica_storageclass: "{{ lookup('env','REPLICA_SC') }}"
 replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
 
 node_os: "{{ lookup('env','NODE_OS') }}"
+
+operator_image: "{{ lookup('env','OPERATOR_IMAGE') }}"

--- a/providers/jiva-csi-provisioner/test_vars.yml
+++ b/providers/jiva-csi-provisioner/test_vars.yml
@@ -1,0 +1,15 @@
+---
+
+# Test specific parameters
+
+operator_ns: 'openebs'
+
+test_name: "jiva-csi-provision"
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+replica_storageclass: "{{ lookup('env','REPLICA_SC') }}"
+
+replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
+
+node_os: "{{ lookup('env','NODE_OS') }}"

--- a/providers/jiva-csi-provisioner/test_vars.yml
+++ b/providers/jiva-csi-provisioner/test_vars.yml
@@ -15,3 +15,5 @@ replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
 node_os: "{{ lookup('env','NODE_OS') }}"
 
 operator_image: "{{ lookup('env','OPERATOR_IMAGE') }}"
+
+action: "{{ lookup('env','ACTION') }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented litmusbook to deploy jiva csi provisioner
**Special notes for your reviewer**:
Logs for provisioning of Jiva CSI driver

```
PLAY [localhost] ***************************************************************
2020-01-20T10:30:13.077244 (delta: 0.117569)         elapsed: 0.117569 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-01-20T10:30:13.103558 (delta: 0.026268)         elapsed: 0.143883 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-01-20T10:30:20.897083 (delta: 7.793478)         elapsed: 7.937408 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-01-20T10:30:21.056407 (delta: 0.159276)         elapsed: 8.096732 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-01-20T10:30:21.158712 (delta: 0.102251)         elapsed: 8.199037 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-01-20T10:30:21.260241 (delta: 0.101475)         elapsed: 8.300566 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-20T10:30:21.448911 (delta: 0.188614)         elapsed: 8.489236 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "13be18118bc024919afda6d34595a44f38e4b828", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bf8b2bca5f52db7ce550866ee1d8f384", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1579516221.54-205125941268444/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:30:22.690621 (delta: 1.241652)         elapsed: 9.730946 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.641950", "end": "2020-01-20 10:30:23.920132", "rc": 0, "start": "2020-01-20 10:30:23.278182", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:30:24.003777 (delta: 1.313102)         elapsed: 11.044102 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-20T08:04:25Z", "generation": 25, "name": "jiva-csi-provision", "resourceVersion": "64548", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-provision", "uid": "52233379-baee-448d-8d60-1318611b3403"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-20T10:30:25.845205 (delta: 1.841374)         elapsed: 12.88553 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:30:25.931572 (delta: 0.086313)         elapsed: 12.971897 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:30:26.016852 (delta: 0.085224)         elapsed: 13.057177 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Download the Jiva operator spec] *****************************************
2020-01-20T10:30:26.100807 (delta: 0.0839)         elapsed: 13.141132 ********* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "20bb54da707642d368a2fc600b67b3e5410f2751", "dest": "./operator.yaml", "gid": 0, "group": "root", "md5sum": "1456c93f75ffcd348eaee50dd1603a6a", "mode": "0644", "msg": "OK (4454 bytes)", "owner": "root", "size": 4454, "src": "/root/.ansible/tmp/ansible-tmp-1579516226.18-78027670103653/tmpkf4_G2", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/operator.yaml"}

TASK [Update the Jiva operator image] ******************************************
2020-01-20T10:30:27.437946 (delta: 1.337084)         elapsed: 14.478271 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Download the Jiva CSI Driver if OS is either centos or ubuntu-16.04] *****
2020-01-20T10:30:28.182830 (delta: 0.744828)         elapsed: 15.223155 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "511939ec9229378f2aed04847d2dfea643524bc3", "dest": "./jiva-csi-ubuntu-16.04.yaml", "gid": 0, "group": "root", "md5sum": "475e3d36272e9e4f5cebb3b14cacf21c", "mode": "0644", "msg": "OK (11062 bytes)", "owner": "root", "size": 11062, "src": "/root/.ansible/tmp/ansible-tmp-1579516228.29-32270582361030/tmpwhP9qe", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi-ubuntu-16.04.yaml"}

TASK [Update the operator image in jiva csi driver spec] ***********************
2020-01-20T10:30:29.066800 (delta: 0.883915)         elapsed: 16.107125 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Download the Jiva CSI Driver if OS is ubuntu-18.04] **********************
2020-01-20T10:30:29.458255 (delta: 0.391398)         elapsed: 16.49858 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the operator image in jiva csi driver spec] ***********************
2020-01-20T10:30:29.563715 (delta: 0.105406)         elapsed: 16.60404 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install the Jiva operator in operator namespace] *************************
2020-01-20T10:30:29.669022 (delta: 0.10525)         elapsed: 16.709347 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f operator.yaml", "delta": "0:00:01.591337", "end": "2020-01-20 10:30:31.564333", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:30:29.972996", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/jivavolumes.openebs.io created\nserviceaccount/jiva-operator created\nrole.rbac.authorization.k8s.io/jiva-operator created\nrolebinding.rbac.authorization.k8s.io/jiva-operator created\ndeployment.apps/jiva-operator created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/jivavolumes.openebs.io created", "serviceaccount/jiva-operator created", "role.rbac.authorization.k8s.io/jiva-operator created", "rolebinding.rbac.authorization.k8s.io/jiva-operator created", "deployment.apps/jiva-operator created"]}

TASK [Obtain the Jiva operator pod in operator namespace] **********************
2020-01-20T10:30:31.658895 (delta: 1.989818)         elapsed: 18.69922 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs --no-headers -l name=jiva-operator -o custom-columns=:.metadata.name", "delta": "0:00:00.821034", "end": "2020-01-20 10:30:32.786529", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:30:31.965495", "stderr": "", "stderr_lines": [], "stdout": "jiva-operator-5c7c584764-2tff8", "stdout_lines": ["jiva-operator-5c7c584764-2tff8"]}

TASK [Verify the status of Jiva operator] **************************************
2020-01-20T10:30:32.881450 (delta: 1.2225)         elapsed: 19.921775 ********* 
FAILED - RETRYING: Verify the status of Jiva operator (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get po jiva-operator-5c7c584764-2tff8 -n openebs --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.821953", "end": "2020-01-20 10:30:45.087212", "rc": 0, "start": "2020-01-20 10:30:44.265259", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04] ***********
2020-01-20T10:30:45.181303 (delta: 12.299799)         elapsed: 32.221628 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f jiva-csi-ubuntu-16.04.yaml", "delta": "0:00:01.556354", "end": "2020-01-20 10:30:47.050907", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:30:45.494553", "stderr": "", "stderr_lines": [], "stdout": "csidriver.storage.k8s.io/jiva.csi.openebs.com created\nserviceaccount/openebs-jiva-csi-controller-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-jiva-csi-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-jiva-csi-binding created\nstatefulset.apps/openebs-jiva-csi-controller created\nclusterrole.rbac.authorization.k8s.io/openebs-jiva-csi-attacher-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-jiva-csi-attacher-binding created\nserviceaccount/openebs-jiva-csi-node-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-jiva-csi-registrar-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-jiva-csi-registrar-binding created\ndaemonset.apps/openebs-jiva-csi-node created", "stdout_lines": ["csidriver.storage.k8s.io/jiva.csi.openebs.com created", "serviceaccount/openebs-jiva-csi-controller-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-jiva-csi-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-jiva-csi-binding created", "statefulset.apps/openebs-jiva-csi-controller created", "clusterrole.rbac.authorization.k8s.io/openebs-jiva-csi-attacher-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-jiva-csi-attacher-binding created", "serviceaccount/openebs-jiva-csi-node-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-jiva-csi-registrar-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-jiva-csi-registrar-binding created", "daemonset.apps/openebs-jiva-csi-node created"]}

TASK [Deploy CSI Driver if os is ubuntu 18.04] *********************************
2020-01-20T10:30:47.150757 (delta: 1.969399)         elapsed: 34.191082 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if jiva csi-controller pod is running] *****************************
2020-01-20T10:30:47.272753 (delta: 0.121941)         elapsed: 34.313078 ******* 
FAILED - RETRYING: check if jiva csi-controller pod is running (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-jiva-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.848312", "end": "2020-01-20 10:30:59.562855", "rc": 0, "start": "2020-01-20 10:30:58.714543", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2020-01-20T10:30:59.655685 (delta: 12.382877)         elapsed: 46.69601 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get daemonset openebs-jiva-csi-node -n kube-system --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:00.833039", "end": "2020-01-20 10:31:00.791897", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:30:59.958858", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if the desired count matches the ready pods] ***********************
2020-01-20T10:31:00.887506 (delta: 1.231767)         elapsed: 47.927831 ******* 
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": ["kubectl", "get", "daemonset", "openebs-jiva-csi-node", "-n", "kube-system", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:00.815490", "end": "2020-01-20 10:31:02.021340", "rc": 0, "start": "2020-01-20 10:31:01.205850", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Update the storage class template with the variables.] *******************
2020-01-20T10:31:02.118465 (delta: 1.230905)         elapsed: 49.15879 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "39e27187b29fdf4d2a7c96d7623ec8b3ecedda14", "dest": "./csi-jiva-sc.yml", "gid": 0, "group": "root", "md5sum": "d9d9d8f09d82527d6e0b9d873b0aa620", "mode": "0644", "owner": "root", "size": 209, "src": "/root/.ansible/tmp/ansible-tmp-1579516262.22-154880808739902/source", "state": "file", "uid": 0}

TASK [Create Storageclass] *****************************************************
2020-01-20T10:31:02.724152 (delta: 0.605631)         elapsed: 49.764477 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-jiva-sc.yml", "delta": "0:00:01.070102", "end": "2020-01-20 10:31:04.099213", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:31:03.029111", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-jiva-csi-sc created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-jiva-csi-sc created"]}

TASK [Delete Jiva CSI Driver if OS is either centos or ubuntu-16.04] ***********
2020-01-20T10:31:04.193888 (delta: 1.46968)         elapsed: 51.234213 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete CSI Driver if os is ubuntu 18.04] *********************************
2020-01-20T10:31:04.301840 (delta: 0.107896)         elapsed: 51.342165 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the Jiva CSI controller pod is deleted] ************************
2020-01-20T10:31:04.409791 (delta: 0.107895)         elapsed: 51.450116 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the Jiva CSI node pod is deleted] ******************************
2020-01-20T10:31:04.515146 (delta: 0.105301)         elapsed: 51.555471 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete jiva operator from operator namespace] ****************************
2020-01-20T10:31:04.622053 (delta: 0.106852)         elapsed: 51.662378 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the Jiva operator pod is deleted] ******************************
2020-01-20T10:31:04.729832 (delta: 0.107725)         elapsed: 51.770157 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the storage class created] ****************************************
2020-01-20T10:31:04.836312 (delta: 0.106423)         elapsed: 51.876637 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-01-20T10:31:04.942840 (delta: 0.106473)         elapsed: 51.983165 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-01-20T10:31:05.078047 (delta: 0.135153)         elapsed: 52.118372 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-20T10:31:05.251910 (delta: 0.173807)         elapsed: 52.292235 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:31:05.339891 (delta: 0.087923)         elapsed: 52.380216 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:31:05.428209 (delta: 0.088262)         elapsed: 52.468534 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-20T10:31:05.515807 (delta: 0.087542)         elapsed: 52.556132 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b48a8531518fc22f8cac533d772dff743d67dbbe", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a4eb55db512dfe470b08d0c9bf15749d", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1579516265.61-198702307186665/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:31:07.370882 (delta: 1.855019)         elapsed: 54.411207 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.624482", "end": "2020-01-20 10:31:08.282277", "rc": 0, "start": "2020-01-20 10:31:07.657795", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:31:08.364755 (delta: 0.993815)         elapsed: 55.40508 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-20T08:04:25Z", "generation": 26, "name": "jiva-csi-provision", "resourceVersion": "64864", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-provision", "uid": "52233379-baee-448d-8d60-1318611b3403"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=19   unreachable=0    failed=0   

2020-01-20T10:31:09.805754 (delta: 1.440943)         elapsed: 56.846079 ******* 
=============================================================================== 
```

Logs for deprovisioning of jiva CSI driver
```
PLAY [localhost] ***************************************************************
2020-01-20T10:40:02.723350 (delta: 0.11688)         elapsed: 0.11688 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-01-20T10:40:02.749631 (delta: 0.026236)         elapsed: 0.143161 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-01-20T10:40:10.556582 (delta: 7.806906)         elapsed: 7.950112 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-01-20T10:40:10.710054 (delta: 0.153421)         elapsed: 8.103584 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-01-20T10:40:10.811952 (delta: 0.101843)         elapsed: 8.205482 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-01-20T10:40:10.912749 (delta: 0.100743)         elapsed: 8.306279 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-20T10:40:11.099784 (delta: 0.186979)         elapsed: 8.493314 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "13be18118bc024919afda6d34595a44f38e4b828", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bf8b2bca5f52db7ce550866ee1d8f384", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1579516811.19-270293316938487/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:40:12.345428 (delta: 1.245588)         elapsed: 9.738958 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.647575", "end": "2020-01-20 10:40:13.583534", "rc": 0, "start": "2020-01-20 10:40:12.935959", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:40:13.665963 (delta: 1.32048)         elapsed: 11.059493 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-20T08:04:25Z", "generation": 27, "name": "jiva-csi-provision", "resourceVersion": "67045", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-provision", "uid": "52233379-baee-448d-8d60-1318611b3403"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-20T10:40:15.515598 (delta: 1.849582)         elapsed: 12.909128 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:40:15.600901 (delta: 0.085249)         elapsed: 12.994431 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:40:15.686881 (delta: 0.085925)         elapsed: 13.080411 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Download the Jiva operator spec] *****************************************
2020-01-20T10:40:15.770606 (delta: 0.083635)         elapsed: 13.164136 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "20bb54da707642d368a2fc600b67b3e5410f2751", "dest": "./operator.yaml", "gid": 0, "group": "root", "md5sum": "1456c93f75ffcd348eaee50dd1603a6a", "mode": "0644", "msg": "OK (4454 bytes)", "owner": "root", "size": 4454, "src": "/root/.ansible/tmp/ansible-tmp-1579516815.85-215591520664741/tmpxGezhl", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/jiva-operator/master/deploy/operator.yaml"}

TASK [Update the Jiva operator image] ******************************************
2020-01-20T10:40:17.089040 (delta: 1.318376)         elapsed: 14.48257 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Download the Jiva CSI Driver if OS is either centos or ubuntu-16.04] *****
2020-01-20T10:40:17.827498 (delta: 0.738405)         elapsed: 15.221028 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "511939ec9229378f2aed04847d2dfea643524bc3", "dest": "./jiva-csi-ubuntu-16.04.yaml", "gid": 0, "group": "root", "md5sum": "475e3d36272e9e4f5cebb3b14cacf21c", "mode": "0644", "msg": "OK (11062 bytes)", "owner": "root", "size": 11062, "src": "/root/.ansible/tmp/ansible-tmp-1579516817.94-133379730949741/tmpWrDtwG", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/jiva-csi/master/deploy/jiva-csi-ubuntu-16.04.yaml"}

TASK [Update the operator image in jiva csi driver spec] ***********************
2020-01-20T10:40:18.700002 (delta: 0.87245)         elapsed: 16.093532 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Download the Jiva CSI Driver if OS is ubuntu-18.04] **********************
2020-01-20T10:40:19.094931 (delta: 0.394873)         elapsed: 16.488461 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the operator image in jiva csi driver spec] ***********************
2020-01-20T10:40:19.199389 (delta: 0.104402)         elapsed: 16.592919 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install the Jiva operator in operator namespace] *************************
2020-01-20T10:40:19.303770 (delta: 0.104321)         elapsed: 16.6973 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the Jiva operator pod in operator namespace] **********************
2020-01-20T10:40:19.407226 (delta: 0.1034)         elapsed: 16.800756 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the status of Jiva operator] **************************************
2020-01-20T10:40:19.510876 (delta: 0.103596)         elapsed: 16.904406 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy Jiva CSI Driver if OS is either centos or ubuntu-16.04] ***********
2020-01-20T10:40:19.614461 (delta: 0.103531)         elapsed: 17.007991 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy CSI Driver if os is ubuntu 18.04] *********************************
2020-01-20T10:40:19.719511 (delta: 0.104996)         elapsed: 17.113041 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if jiva csi-controller pod is running] *****************************
2020-01-20T10:40:19.824041 (delta: 0.104475)         elapsed: 17.217571 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2020-01-20T10:40:19.927814 (delta: 0.103716)         elapsed: 17.321344 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the desired count matches the ready pods] ***********************
2020-01-20T10:40:20.031933 (delta: 0.104065)         elapsed: 17.425463 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the storage class template with the variables.] *******************
2020-01-20T10:40:20.137094 (delta: 0.105106)         elapsed: 17.530624 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Create Storageclass] *****************************************************
2020-01-20T10:40:20.248693 (delta: 0.11154)         elapsed: 17.642223 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete Jiva CSI Driver if OS is either centos or ubuntu-16.04] ***********
2020-01-20T10:40:20.353608 (delta: 0.104859)         elapsed: 17.747138 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f jiva-csi-ubuntu-16.04.yaml", "delta": "0:00:01.359281", "end": "2020-01-20 10:40:22.025403", "rc": 0, "start": "2020-01-20 10:40:20.666122", "stderr": "", "stderr_lines": [], "stdout": "csidriver.storage.k8s.io \"jiva.csi.openebs.com\" deleted\nserviceaccount \"openebs-jiva-csi-controller-sa\" deleted\nclusterrole.rbac.authorization.k8s.io \"openebs-jiva-csi-role\" deleted\nclusterrolebinding.rbac.authorization.k8s.io \"openebs-jiva-csi-binding\" deleted\nstatefulset.apps \"openebs-jiva-csi-controller\" deleted\nclusterrole.rbac.authorization.k8s.io \"openebs-jiva-csi-attacher-role\" deleted\nclusterrolebinding.rbac.authorization.k8s.io \"openebs-jiva-csi-attacher-binding\" deleted\nserviceaccount \"openebs-jiva-csi-node-sa\" deleted\nclusterrole.rbac.authorization.k8s.io \"openebs-jiva-csi-registrar-role\" deleted\nclusterrolebinding.rbac.authorization.k8s.io \"openebs-jiva-csi-registrar-binding\" deleted\ndaemonset.apps \"openebs-jiva-csi-node\" deleted", "stdout_lines": ["csidriver.storage.k8s.io \"jiva.csi.openebs.com\" deleted", "serviceaccount \"openebs-jiva-csi-controller-sa\" deleted", "clusterrole.rbac.authorization.k8s.io \"openebs-jiva-csi-role\" deleted", "clusterrolebinding.rbac.authorization.k8s.io \"openebs-jiva-csi-binding\" deleted", "statefulset.apps \"openebs-jiva-csi-controller\" deleted", "clusterrole.rbac.authorization.k8s.io \"openebs-jiva-csi-attacher-role\" deleted", "clusterrolebinding.rbac.authorization.k8s.io \"openebs-jiva-csi-attacher-binding\" deleted", "serviceaccount \"openebs-jiva-csi-node-sa\" deleted", "clusterrole.rbac.authorization.k8s.io \"openebs-jiva-csi-registrar-role\" deleted", "clusterrolebinding.rbac.authorization.k8s.io \"openebs-jiva-csi-registrar-binding\" deleted", "daemonset.apps \"openebs-jiva-csi-node\" deleted"]}

TASK [Delete CSI Driver if os is ubuntu 18.04] *********************************
2020-01-20T10:40:22.109433 (delta: 1.755739)         elapsed: 19.502963 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the Jiva CSI controller pod is deleted] ************************
2020-01-20T10:40:22.231512 (delta: 0.122023)         elapsed: 19.625042 ******* 
FAILED - RETRYING: Verify if the Jiva CSI controller pod is deleted (30 retries left).
FAILED - RETRYING: Verify if the Jiva CSI controller pod is deleted (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod -n kube-system -l app=openebs-jiva-csi-controller --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.821139", "end": "2020-01-20 10:40:45.624285", "rc": 0, "start": "2020-01-20 10:40:44.803146", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify if the Jiva CSI node pod is deleted] ******************************
2020-01-20T10:40:45.717088 (delta: 23.485516)         elapsed: 43.110618 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n kube-system -l app=openebs-jiva-csi-node --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.836645", "end": "2020-01-20 10:40:46.858070", "rc": 0, "start": "2020-01-20 10:40:46.021425", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Delete jiva operator from operator namespace] ****************************
2020-01-20T10:40:46.952086 (delta: 1.234942)         elapsed: 44.345616 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f operator.yaml", "delta": "0:00:00.914458", "end": "2020-01-20 10:40:48.181869", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:40:47.267411", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io \"jivavolumes.openebs.io\" deleted\nserviceaccount \"jiva-operator\" deleted\nrole.rbac.authorization.k8s.io \"jiva-operator\" deleted\nrolebinding.rbac.authorization.k8s.io \"jiva-operator\" deleted\ndeployment.apps \"jiva-operator\" deleted", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io \"jivavolumes.openebs.io\" deleted", "serviceaccount \"jiva-operator\" deleted", "role.rbac.authorization.k8s.io \"jiva-operator\" deleted", "rolebinding.rbac.authorization.k8s.io \"jiva-operator\" deleted", "deployment.apps \"jiva-operator\" deleted"]}

TASK [Verify if the Jiva operator pod is deleted] ******************************
2020-01-20T10:40:48.277379 (delta: 1.325238)         elapsed: 45.670909 ******* 
FAILED - RETRYING: Verify if the Jiva operator pod is deleted (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n openebs -l name=jiva-operator --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.845108", "end": "2020-01-20 10:41:00.484606", "rc": 0, "start": "2020-01-20 10:40:59.639498", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Delete the storage class created] ****************************************
2020-01-20T10:41:00.578843 (delta: 12.301411)         elapsed: 57.972373 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete sc openebs-jiva-csi-sc", "delta": "0:00:00.863872", "end": "2020-01-20 10:41:01.751166", "failed_when_result": false, "rc": 0, "start": "2020-01-20 10:41:00.887294", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io \"openebs-jiva-csi-sc\" deleted", "stdout_lines": ["storageclass.storage.k8s.io \"openebs-jiva-csi-sc\" deleted"]}

TASK [set_fact] ****************************************************************
2020-01-20T10:41:01.847122 (delta: 1.268224)         elapsed: 59.240652 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-01-20T10:41:01.978457 (delta: 0.131283)         elapsed: 59.371987 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-20T10:41:02.149485 (delta: 0.170973)         elapsed: 59.543015 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:41:02.238698 (delta: 0.089123)         elapsed: 59.632228 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:41:02.325304 (delta: 0.086516)         elapsed: 59.718834 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-20T10:41:02.412260 (delta: 0.086899)         elapsed: 59.80579 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b48a8531518fc22f8cac533d772dff743d67dbbe", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a4eb55db512dfe470b08d0c9bf15749d", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1579516862.51-261949954219361/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-20T10:41:04.298021 (delta: 1.885703)         elapsed: 61.691551 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.637740", "end": "2020-01-20 10:41:05.223225", "rc": 0, "start": "2020-01-20 10:41:04.585485", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-20T10:41:05.307255 (delta: 1.009177)         elapsed: 62.700785 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-20T08:04:25Z", "generation": 28, "name": "jiva-csi-provision", "resourceVersion": "67317", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-provision", "uid": "52233379-baee-448d-8d60-1318611b3403"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=16   unreachable=0    failed=0   

2020-01-20T10:41:06.749036 (delta: 1.441725)         elapsed: 64.142566 ******* 
=============================================================================== 
```
