### PR TITLE
refactor(experiment): Modified and updated the volume replica failure experiment

### DIFF
--- a/chaoslib/openebs/cstor_replica_network_delay.yaml
+++ b/chaoslib/openebs/cstor_replica_network_delay.yaml
@@ -8,55 +8,65 @@
   register: pv
 
 - name: Get istgt target pod details
-  shell: kubectl get pods  -l openebs.io/persistent-volume-claim="{{ pvc }}" -n {{ operator_ns }} -o custom-columns=:metadata.name --no-headers
+  shell: >
+     kubectl get pods  -l openebs.io/persistent-volume-claim={{ app_pvc }} 
+     -n {{ operator_ns }} -o custom-columns=:metadata.name --no-headers
   register: istgt_replica
 
 - name: Get Application  pod details
-  shell: kubectl get pods -n {{ app_ns }}  -l {{ label }}  --no-headers -o custom-columns=:metadata.name
+  shell: >
+    kubectl get pods -n {{ app_ns }} -l {{ label }}  --no-headers -o custom-columns=:metadata.name
   register: app_pod
+
+- name: Getting the application mount point
+  shell: >
+    kubectl get pod {{ app_pod.stdout }} -n {{ app_ns }} 
+    -o jsonpath='{.spec.containers[0].volumeMounts[0].mountPath}'
+  register: app_mount_path
 
 - name: Create an empty list of replica pods.
   set_fact:
      cstor_replicas_pod : []
 
-- block:
-    - name: Obtaining the storage class used from PVC
-      shell: kubectl get pvc {{ pvc }} -n {{ app_ns }} --no-headers -o custom-columns=:.spec.storageClassName
-      register: app_sc
+- name: Obtaining the storage class used from PVC
+  shell: >
+    kubectl get pvc {{ app_pvc }} -n {{ app_ns }} --no-headers -o custom-columns=:.spec.storageClassName
+  register: app_sc
 
-    - name: Obtaining the SPC from storage class
-      shell: kubectl get sc {{ app_sc.stdout }} --no-headers  -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/"//g'
-      register: spc
+- name: Obtaining the SPC from storage class
+  shell: >
+    kubectl get sc {{ app_sc.stdout }} --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/"//g'
+  register: spc
 
-    - name: Obtaining the pool deployments from cvr
-      shell: >
-        kubectl get cvr -n {{ operator_ns }}
-        -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
-        -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
-      args:
-        executable: /bin/bash
-      register: pool_deployment
+- name: Obtaining the pool deployments from cvr
+  shell: >
+    kubectl get cvr -n {{ operator_ns }}
+    -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+    -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  register: pool_deployment
 
-    - name: Obtaining the replicasets corresponding to pool deployements.
-      shell: >
-        kubectl get rs --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
-        -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
-      register: rs_list
-      with_items:
-        - "{{ pool_deployment.stdout_lines }}"
+- name: Obtaining the replicasets corresponding to pool deployements.
+  shell: >
+    kubectl get rs --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
+    -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
+  register: rs_list
+  with_items:
+    - "{{ pool_deployment.stdout_lines }}"
 
-    - name: Obtaining the pool pods
-      shell: >
-        kubectl get pod --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
-        -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
-      register: pool_pods
-      with_items:
-        - "{{ rs_list.results }}"
+- name: Obtaining the pool pods
+  shell: >
+    kubectl get pod --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
+    -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
+  register: pool_pods
+  with_items:
+    - "{{ rs_list.results }}"
 
-    - name: Build a list of replica pods
-      set_fact:
-        cstor_replicas_pod : "{{ cstor_replicas_pod }} + [ '{{ item.stdout }}' ]"
-      with_items: "{{ pool_pods.results }}"
+- name: Build a list of replica pods
+  set_fact:
+    cstor_replicas_pod : "{{ cstor_replicas_pod }} + [ '{{ item.stdout }}' ]"
+  with_items: "{{ pool_pods.results }}"
 
 #Select any cstor replica pod to inject packet loss
 - set_fact:
@@ -69,68 +79,77 @@
   ignore_errors: yes
 
 - name: Install tc command on targeted replica pod
-  shell: kubectl exec -it {{ targeted_replica_pod }} -n {{ operator_ns }} --container cstor-pool -- bash -c "apt-get update && apt-get -y install iproute2"
+  shell: >
+    kubectl exec -it {{ targeted_replica_pod }} -n {{ operator_ns }} 
+    --container cstor-pool -- bash -c "apt-get update && apt-get -y install iproute2"
   register: tc_apt_output
   when: "'tc' not in tc_status.stdout"
 
 - name: Inject packet loss on targeted replica
-  shell: kubectl exec -it {{ targeted_replica_pod }} -n {{ operator_ns }} --container cstor-pool -- bash -c "tc qdisc add dev eth0 root netem loss 100.00"
+  shell: >
+    kubectl exec -it {{ targeted_replica_pod }} -n {{ operator_ns }} 
+    --container cstor-pool -- bash -c "tc qdisc add dev eth0 root netem loss 100.00"
   register: tc_output
 
 - name: Check if targeted replica is disconnected
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"replicaId" |awk -F ':' '{print $2}' | tr -d ',' |wc -l
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} 
+    --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"replicaId" |awk -F ':' '{print $2}' | tr -d ',' |wc -l
   register: connected_replica
   until: "connected_replica.stdout == \"2\""
   delay: 30
   retries: 10
 
 - name: Get current iostats from target
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container cstor-istgt -- istgtcontrol -q iostats |json_pp| grep WriteIOPS |awk -F ':' '{print $2}' | tr -d -c 0-9
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} 
+    --container cstor-istgt -- istgtcontrol -q iostats |json_pp| grep WriteIOPS |awk -F ':' '{print $2}' | tr -d -c 0-9
   register: last_iostats
 
-- name: Generate database name
-  shell: cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
-  register: new_db_name
-
-- name: Create new database in the mysql
-  include_tasks: "/common/utils/mysql_data_persistence.yml"
-  vars:
-    status: 'LOAD'
-    #ns: "app-percona-ns"
-    #pod_name: "percona-786c6b7c7f-7qkxm"
-    ns: "{{ app_ns }}"
-    pod_name: "{{ app_pod.stdout }}"
-    dbuser: 'root'
-    dbpassword: 'k8sDem0'
-    dbname: "{{ new_db_name.stdout }}"
+- name: Writing data on application mount point
+  shell: >
+     kubectl exec -it {{ app_pod.stdout }} -n {{ app_ns }} 
+     -- sh -c "cd {{ app_mount_path.stdout }} && dd if=/dev/urandom of=test.txt bs=4k count=5000"
+  args:
+    executable: /bin/bash
 
 - name: Check if target got any new write IOs
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container cstor-istgt -- istgtcontrol -q iostats |json_pp| grep WriteIOPS |awk -F ':' '{print $2}' | tr -d -c 0-9
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container cstor-istgt 
+    -- istgtcontrol -q iostats |json_pp| grep WriteIOPS |awk -F ':' '{print $2}' | tr -d -c 0-9
   register: iostats
   retries: 10
   delay: 3
   until: iostats.stdout != last_iostats.stdout
 
 - name: Remove packet loss rule from targeted replica pod
-  shell: kubectl exec -it {{ targeted_replica_pod }} -n {{ operator_ns }} --container cstor-pool -- bash -c "tc qdisc del dev eth0 root netem loss 100.00"
+  shell: >
+    kubectl exec -it {{ targeted_replica_pod }} -n {{ operator_ns }} --container cstor-pool 
+    -- bash -c "tc qdisc del dev eth0 root netem loss 100.00"
   register: apt_rc
 
 - name: Wait until all replica gets connected
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"replicaId" |awk -F ':' '{print $2}' | tr -d ',' |wc -l
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+    -- istgtcontrol -q replica |json_pp |grep "\"replicaId" |awk -F ':' '{print $2}' | tr -d ',' |wc -l
   register: connected_replica
   until: "connected_replica.stdout == \"3\""
   delay: 30
   retries: 10
 
 - name: Wait until volume becomes healthy
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"status" |awk -F ':' '{print $2}' | tr -d ','
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+    -- istgtcontrol -q replica |json_pp |grep "\"status" |awk -F ':' '{print $2}' | tr -d ','
   register: volume_status
   until: volume_status.stdout.find("Degraded") == -1
   retries: 50
   delay: 10
 
 - name: Wait until all replica becomes healthy
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"Mode" |awk -F ':' '{print $2}' | tr -d ','
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+    -- istgtcontrol -q replica |json_pp |grep "\"Mode" |awk -F ':' '{print $2}' | tr -d ','
   register: replica_status
   until: replica_status.stdout.find("Degraded") == -1
   retries: 50
@@ -144,34 +163,37 @@
     snap_name: "{{ snapname.stdout }}"
 
 - name: Take snapshot for data verification
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol snapcreate {{ pv.stdout }} {{ snap_name }} 30 30
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+    -- istgtcontrol snapcreate {{ pv.stdout }} {{ snap_name }} 30 30
   register: snap_status
 
-- block:
-    - name: Install netcat on current host
-      shell: apt-get update && apt-get -y install netcat iproute2
-      register: dataset
+- name: Install netcat on current host
+  shell: apt-get update && apt-get -y install netcat iproute2
+  register: dataset
 
-    - include: fetch_data_from_replica.yml
-      loop: "{{ cstor_replicas_pod }}"
-      loop_control:
-        loop_var: rpod
+- include: fetch_data_from_replica.yml
+  loop: "{{ cstor_replicas_pod }}"
+  loop_control:
+    loop_var: rpod
 
-    - set_fact:
-        base_replica: "{{ cstor_replicas_pod | list | first }}"
+- set_fact:
+    base_replica: "{{ cstor_replicas_pod | list | first }}"
 
-    - name: compare data object
-      shell: diff {{ rpod }}.1.dump {{ base_replica }}.1.dump
-      loop: "{{ cstor_replicas_pod }}"
-      loop_control:
-        loop_var: rpod
+- name: compare data object
+  shell: diff {{ rpod }}.1.dump {{ base_replica }}.1.dump
+  loop: "{{ cstor_replicas_pod }}"
+  loop_control:
+    loop_var: rpod
 
-    - name: compare meta data object
-      shell: diff {{ rpod }}.3.dump {{ base_replica }}.3.dump
-      loop: "{{ cstor_replicas_pod }}"
-      loop_control:
-        loop_var: rpod
+- name: compare meta data object
+  shell: diff {{ rpod }}.3.dump {{ base_replica }}.3.dump
+  loop: "{{ cstor_replicas_pod }}"
+  loop_control:
+    loop_var: rpod
 
 - name: Destroy snapshot created for data verification
-  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol snapdestroy {{ pv.stdout }} {{ snap_name }} 30 30
+  shell: >
+    kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+    -- istgtcontrol snapdestroy {{ pv.stdout }} {{ snap_name }} 30 30
   register: snap_status

--- a/experiments/chaos/openebs_volume_replica_failure/chaosutil.j2
+++ b/experiments/chaos/openebs_volume_replica_failure/chaosutil.j2
@@ -1,6 +1,6 @@
 {% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
   {% if stg_engine is defined and stg_engine == 'cstor' %}
-    chaosutil: openebs/cstor_pool_deploy_failure.yaml
+    chaosutil: openebs/cstor_replica_network_delay.yaml
   {% else %} 
     chaosutil: openebs/jiva_replica_pod_failure.yaml
   {% endif %}

--- a/experiments/chaos/openebs_volume_replica_failure/test.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/test.yml
@@ -45,7 +45,6 @@
             msg: 
               - "The application info is as follows:"
               - "Namespace        : {{ namespace }}"
-              # - "Target Namespace : {{ target_namespace }}"
               - "Label            : {{ label }}"
               - "PVC              : {{ pvc }}"  
               - "StorageClass     : {{ sc }}"
@@ -77,12 +76,10 @@
             pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''      
 
-
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
           app_ns: "{{ namespace }}"
-          target_ns: "{{ target_namespace }}"
           app_pvc: "{{ pvc }}"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
@@ -114,7 +111,6 @@
             ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
           when: data_persistence != ''
-
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_volume_replica_failure/test_vars.yml
+++ b/experiments/chaos/openebs_volume_replica_failure/test_vars.yml
@@ -5,5 +5,4 @@ pvc: "{{ lookup('env','APP_PVC') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
-
-
+operator_ns: openebs


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>
- Modified the litmus experiment to perform chaos in replica
- Removed the unnecessary block used in litmusbook.
- The util used in this litmusbook `cstor_replica_network_delay.yml` is written in the way of only used for percona. Modified the util and made the task more generic across any application we can perform the network delay
 
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [x] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

For JIVA
```
[root@master-1552853078 openebs_volume_replica_failure]# kubectl logs -f openebs-volume-replica-failure-qktfv-4wxgh -n litmus
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Oct  7 2019, 17:39:04) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_volume_replica_failure/test.yml

PLAY [localhost] ***************************************************************
2020-01-09T11:45:11.283786 (delta: 0.074327)         elapsed: 0.074327 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:2
2020-01-09T11:45:11.303063 (delta: 0.019199)         elapsed: 0.093604 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:13
2020-01-09T11:45:20.596536 (delta: 9.293451)         elapsed: 9.387077 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:2
2020-01-09T11:45:20.721329 (delta: 0.124725)         elapsed: 9.51187 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.173701", "end": "2020-01-09 11:45:22.476187", "rc": 0, "start": "2020-01-09 11:45:21.302486", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:10
2020-01-09T11:45:22.562882 (delta: 1.841436)         elapsed: 11.353423 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:02.289467", "end": "2020-01-09 11:45:25.155165", "rc": 0, "start": "2020-01-09 11:45:22.865698", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:18
2020-01-09T11:45:25.316380 (delta: 2.753403)         elapsed: 14.106921 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:22
2020-01-09T11:45:25.472784 (delta: 0.156316)         elapsed: 14.263325 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:27
2020-01-09T11:45:25.564127 (delta: 0.091261)         elapsed: 14.354668 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.114327", "end": "2020-01-09 11:45:26.955097", "rc": 0, "start": "2020-01-09 11:45:25.840770", "stderr": "", "stderr_lines": [], "stdout": "pvc-386344ec-32d4-11ea-b361-005056985c20", "stdout_lines": ["pvc-386344ec-32d4-11ea-b361-005056985c20"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:35
2020-01-09T11:45:27.022602 (delta: 1.458425)         elapsed: 15.813143 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-386344ec-32d4-11ea-b361-005056985c20 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.140074", "end": "2020-01-09 11:45:28.366011", "rc": 0, "start": "2020-01-09 11:45:27.225937", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:43
2020-01-09T11:45:28.451417 (delta: 1.428751)         elapsed: 17.241958 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:48
2020-01-09T11:45:28.536764 (delta: 0.085294)         elapsed: 17.327305 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7ac56380bcc9f7bcfd598e1059592ccc59fdc682", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "6082ba40ba1c8f1cd7f72c539dcbe47f", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1578570328.61-18340743063195/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:53
2020-01-09T11:45:29.460147 (delta: 0.923279)         elapsed: 18.250688 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1578570329.53-93916479010081/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:18
2020-01-09T11:45:29.993715 (delta: 0.533504)         elapsed: 18.784256 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:21
2020-01-09T11:45:30.132256 (delta: 0.138461)         elapsed: 18.922797 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_replica_pod_failure.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:24
2020-01-09T11:45:30.287842 (delta: 0.155505)         elapsed: 19.078383 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_replica_pod_failure.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:28
2020-01-09T11:45:30.482968 (delta: 0.195036)         elapsed: 19.273509 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:34
2020-01-09T11:45:30.704910 (delta: 0.221826)         elapsed: 19.495451 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-01-09T11:45:30.816958 (delta: 0.11199)         elapsed: 19.607499 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-01-09T11:45:30.911299 (delta: 0.094258)         elapsed: 19.70184 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:36
2020-01-09T11:45:31.022484 (delta: 0.111102)         elapsed: 19.813025 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-01-09T11:45:31.203599 (delta: 0.181044)         elapsed: 19.99414 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "46a9681baf51af739fe944f8e37ac0de8cf56874", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "801d881b0197ef1ef2e39156a656e1ab", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1578570331.28-237091858487527/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-01-09T11:45:31.753311 (delta: 0.549639)         elapsed: 20.543852 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.916956", "end": "2020-01-09 11:45:32.867612", "rc": 0, "start": "2020-01-09 11:45:31.950656", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-01-09T11:45:32.924393 (delta: 1.171026)         elapsed: 21.714934 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2020-01-09T10:14:03Z", "generation": 1, "name": "openebs-volume-replica-failure", "namespace": "", "resourceVersion": "783838", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-volume-replica-failure", "uid": "c31a20aa-32c8-11ea-b361-005056985c20"}, "spec": {"testMetadata": {"chaostype": "openebs/jiva_replica_pod_failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-01-09T11:45:34.463940 (delta: 1.539497)         elapsed: 23.254481 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-01-09T11:45:34.524249 (delta: 0.060236)         elapsed: 23.31479 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-01-09T11:45:34.603949 (delta: 0.079644)         elapsed: 23.39449 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:43
2020-01-09T11:45:34.687032 (delta: 0.082994)         elapsed: 23.477573 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace        : app-percona", 
        "Label            : name=percona", 
        "PVC              : percona-mysql-claim", 
        "StorageClass     : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:54
2020-01-09T11:45:34.792426 (delta: 0.105314)         elapsed: 23.582967 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-01-09T11:45:34.887632 (delta: 0.095146)         elapsed: 23.678173 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.153571", "end": "2020-01-09 11:45:36.281374", "rc": 0, "start": "2020-01-09 11:45:35.127803", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-09T11:37:06Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-09T11:37:06Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-01-09T11:45:36.384075 (delta: 1.496384)         elapsed: 25.174616 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.250209", "end": "2020-01-09 11:45:38.062652", "rc": 0, "start": "2020-01-09 11:45:36.812443", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:63
2020-01-09T11:45:38.203009 (delta: 1.818866)         elapsed: 26.99355 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.219443", "end": "2020-01-09 11:45:39.716446", "rc": 0, "start": "2020-01-09 11:45:38.497003", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-8mpl8", "stdout_lines": ["percona-cb697f8b4-8mpl8"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:71
2020-01-09T11:45:39.791290 (delta: 1.58818)         elapsed: 28.581831 ******** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-01-09T11:45:40.085619 (delta: 0.294273)         elapsed: 28.87616 ******** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database percona_device_tes;') => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-8mpl8 -n app-percona -- mysql -uroot -pk8sDem0 -e 'create database percona_device_tes;'", "delta": "0:00:01.426774", "end": "2020-01-09 11:45:41.736215", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database percona_device_tes;'", "rc": 0, "start": "2020-01-09 11:45:40.309441", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_tes) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-8mpl8 -n app-percona -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_tes", "delta": "0:00:01.310990", "end": "2020-01-09 11:45:43.242019", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_tes", "rc": 0, "start": "2020-01-09 11:45:41.931029", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' percona_device_tes) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-8mpl8 -n app-percona -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' percona_device_tes", "delta": "0:00:01.413273", "end": "2020-01-09 11:45:44.850951", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' percona_device_tes", "rc": 0, "start": "2020-01-09 11:45:43.437678", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-01-09T11:45:44.923695 (delta: 4.838016)         elapsed: 33.714236 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-01-09T11:45:45.007370 (delta: 0.083616)         elapsed: 33.797911 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-01-09T11:45:45.091641 (delta: 0.0842)         elapsed: 33.882182 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-01-09T11:45:45.176647 (delta: 0.084913)         elapsed: 33.967188 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-01-09T11:45:45.276686 (delta: 0.099945)         elapsed: 34.067227 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-01-09T11:45:45.400017 (delta: 0.123248)         elapsed: 34.190558 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-01-09T11:45:45.526949 (delta: 0.126835)         elapsed: 34.31749 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-01-09T11:45:45.667896 (delta: 0.140849)         elapsed: 34.458437 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-01-09T11:45:45.828628 (delta: 0.160591)         elapsed: 34.619169 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-01-09T11:45:45.898492 (delta: 0.069806)         elapsed: 34.689033 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:81
2020-01-09T11:45:45.972313 (delta: 0.073765)         elapsed: 34.762854 ******* 
included: /chaoslib/openebs/jiva_replica_pod_failure.yaml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:1
2020-01-09T11:45:46.193129 (delta: 0.220736)         elapsed: 34.98367 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona --no-headers", "delta": "0:00:01.321742", "end": "2020-01-09 11:45:47.720677", "rc": 0, "start": "2020-01-09 11:45:46.398935", "stderr": "", "stderr_lines": [], "stdout": "pvc-386344ec-32d4-11ea-b361-005056985c20", "stdout_lines": ["pvc-386344ec-32d4-11ea-b361-005056985c20"]}

TASK [Record the jiva replica deployment of the PV] ****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:10
2020-01-09T11:45:47.942144 (delta: 1.748955)         elapsed: 36.732685 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_deploy": "pvc-386344ec-32d4-11ea-b361-005056985c20-rep"}, "changed": false}

TASK [Obtain the number of replicas in the deployment] *************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:15
2020-01-09T11:45:48.035969 (delta: 0.09377)         elapsed: 36.82651 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment pvc-386344ec-32d4-11ea-b361-005056985c20-rep -n app-percona --no-headers -o custom-columns=:spec.replicas", "delta": "0:00:01.436300", "end": "2020-01-09 11:45:49.713728", "rc": 0, "start": "2020-01-09 11:45:48.277428", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the resourceVersion of the replica deploy before fault injection] ****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:23
2020-01-09T11:45:49.771501 (delta: 1.735471)         elapsed: 38.562042 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-386344ec-32d4-11ea-b361-005056985c20-rep -n app-percona --no-headers -o custom-columns=:metadata.resourceVersion", "delta": "0:00:01.278668", "end": "2020-01-09 11:45:51.317405", "rc": 0, "start": "2020-01-09 11:45:50.038737", "stderr": "", "stderr_lines": [], "stdout": "781712", "stdout_lines": ["781712"]}

TASK [Randomly pick a jiva replica pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:31
2020-01-09T11:45:51.372310 (delta: 1.600754)         elapsed: 40.162851 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n app-percona --no-headers | grep pvc-386344ec-32d4-11ea-b361-005056985c20 | shuf -n1 | awk '{print $1}'", "delta": "0:00:01.245125", "end": "2020-01-09 11:45:52.846564", "rc": 0, "start": "2020-01-09 11:45:51.601439", "stderr": "", "stderr_lines": [], "stdout": "pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-pm588", "stdout_lines": ["pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-pm588"]}

TASK [Kill the jiva replica pod] ***********************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:40
2020-01-09T11:45:52.933512 (delta: 1.561151)         elapsed: 41.724053 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-pm588 -n app-percona", "delta": "0:00:05.377105", "end": "2020-01-09 11:45:58.587179", "rc": 0, "start": "2020-01-09 11:45:53.210074", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-pm588\" deleted", "stdout_lines": ["pod \"pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-pm588\" deleted"]}

TASK [Check if the replica pod is scheduled back.] *****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:46
2020-01-09T11:45:58.649933 (delta: 5.716358)         elapsed: 47.440474 ******* 
FAILED - RETRYING: Check if the replica pod is scheduled back. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get deployment pvc-386344ec-32d4-11ea-b361-005056985c20-rep -n app-percona --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.344873", "end": "2020-01-09 11:46:31.837567", "rc": 0, "start": "2020-01-09 11:46:30.492694", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the resourceVersion of the replica deploy after fault injection] *****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:57
2020-01-09T11:46:31.953358 (delta: 33.303366)         elapsed: 80.743899 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-386344ec-32d4-11ea-b361-005056985c20-rep -n app-percona --no-headers -o custom-columns=:metadata.resourceVersion", "delta": "0:00:01.243457", "end": "2020-01-09 11:46:33.569134", "rc": 0, "start": "2020-01-09 11:46:32.325677", "stderr": "", "stderr_lines": [], "stdout": "783983", "stdout_lines": ["783983"]}

TASK [Compare resourceVersions of replica deployment] **************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:65
2020-01-09T11:46:33.663482 (delta: 1.710019)         elapsed: 82.454023 ******* 
ok: [127.0.0.1] => {
    "msg": "Verified replica pods were restarted by fault injection"
}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:87
2020-01-09T11:46:33.845703 (delta: 0.182151)         elapsed: 82.636244 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-01-09T11:46:34.086109 (delta: 0.240312)         elapsed: 82.87665 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.280183", "end": "2020-01-09 11:46:35.616064", "rc": 0, "start": "2020-01-09 11:46:34.335881", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-09T11:37:06Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-09T11:37:06Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-01-09T11:46:35.709862 (delta: 1.623688)         elapsed: 84.500403 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.337577", "end": "2020-01-09 11:46:37.348158", "rc": 0, "start": "2020-01-09 11:46:36.010581", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:96
2020-01-09T11:46:37.458058 (delta: 1.748118)         elapsed: 86.248599 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:99
2020-01-09T11:46:37.587391 (delta: 0.12923)         elapsed: 86.377932 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.289671", "end": "2020-01-09 11:46:39.296763", "rc": 0, "start": "2020-01-09 11:46:38.007092", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-8mpl8", "stdout_lines": ["percona-cb697f8b4-8mpl8"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:107
2020-01-09T11:46:39.377541 (delta: 1.790052)         elapsed: 88.168082 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-01-09T11:46:39.608719 (delta: 0.231107)         elapsed: 88.39926 ******** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database percona_device_tes;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database percona_device_tes;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_tes)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_tes", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' percona_device_tes)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' percona_device_tes", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-01-09T11:46:39.731457 (delta: 0.122681)         elapsed: 88.521998 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-cb697f8b4-8mpl8 -n app-percona", "delta": "0:00:09.766840", "end": "2020-01-09 11:46:49.900200", "rc": 0, "start": "2020-01-09 11:46:40.133360", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-cb697f8b4-8mpl8\" deleted", "stdout_lines": ["pod \"percona-cb697f8b4-8mpl8\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-01-09T11:46:50.036009 (delta: 10.304469)         elapsed: 98.82655 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona", "delta": "0:00:01.179042", "end": "2020-01-09 11:46:51.546082", "rc": 0, "start": "2020-01-09 11:46:50.367040", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                            READY   STATUS    RESTARTS   AGE\npercona-cb697f8b4-lbrb6                                         1/1     Running   0          10s\npvc-386344ec-32d4-11ea-b361-005056985c20-ctrl-cbdfc6598-rbf77   2/2     Running   0          10m\npvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-g5zwg   1/1     Running   0          10m\npvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-kprsz   1/1     Running   0          10m\npvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-q7wkl   1/1     Running   0          57s", "stdout_lines": ["NAME                                                            READY   STATUS    RESTARTS   AGE", "percona-cb697f8b4-lbrb6                                         1/1     Running   0          10s", "pvc-386344ec-32d4-11ea-b361-005056985c20-ctrl-cbdfc6598-rbf77   2/2     Running   0          10m", "pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-g5zwg   1/1     Running   0          10m", "pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-kprsz   1/1     Running   0          10m", "pvc-386344ec-32d4-11ea-b361-005056985c20-rep-66b9488c44-q7wkl   1/1     Running   0          57s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-01-09T11:46:51.690215 (delta: 1.654061)         elapsed: 100.480756 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.191026", "end": "2020-01-09 11:46:53.169336", "rc": 0, "start": "2020-01-09 11:46:51.978310", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-lbrb6", "stdout_lines": ["percona-cb697f8b4-lbrb6"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-01-09T11:46:53.258010 (delta: 1.56769)         elapsed: 102.048551 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-lbrb6\")].status.phase}'", "delta": "0:00:01.307137", "end": "2020-01-09 11:46:55.011032", "rc": 0, "start": "2020-01-09 11:46:53.703895", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-01-09T11:46:55.105324 (delta: 1.847233)         elapsed: 103.895865 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-lbrb6\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.085085", "end": "2020-01-09 11:46:56.470064", "rc": 0, "start": "2020-01-09 11:46:55.384979", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-09T11:46:44Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-09T11:46:44Z]]"]}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-01-09T11:46:56.589115 (delta: 1.483716)         elapsed: 105.379656 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-cb697f8b4-lbrb6 -n app-percona | grep 'ready for connections'", "delta": "0:00:01.374282", "end": "2020-01-09 11:46:58.376745", "rc": 0, "start": "2020-01-09 11:46:57.002463", "stderr": "", "stderr_lines": [], "stdout": "2020-01-09T11:46:45.845482Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2020-01-09T11:46:45.845482Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-01-09T11:46:58.459250 (delta: 1.869993)         elapsed: 107.249791 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-lbrb6 -n app-percona -- mysqlcheck -c percona_device_tes -uroot -pk8sDem0", "delta": "0:00:02.402115", "end": "2020-01-09 11:47:01.080148", "failed_when_result": false, "rc": 0, "start": "2020-01-09 11:46:58.678033", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "percona_device_tes.ttbl                            OK", "stdout_lines": ["percona_device_tes.ttbl                            OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-01-09T11:47:01.228129 (delta: 2.768822)         elapsed: 110.01867 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-lbrb6 -n app-percona -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' percona_device_tes;", "delta": "0:00:01.424643", "end": "2020-01-09 11:47:03.159997", "failed_when_result": false, "rc": 0, "start": "2020-01-09 11:47:01.735354", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-01-09T11:47:03.275732 (delta: 2.047425)         elapsed: 112.066273 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-01-09T11:47:03.396567 (delta: 0.1207)         elapsed: 112.187108 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:115
2020-01-09T11:47:03.515362 (delta: 0.118692)         elapsed: 112.305903 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:126
2020-01-09T11:47:03.682537 (delta: 0.167076)         elapsed: 112.473078 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-01-09T11:47:03.920617 (delta: 0.237976)         elapsed: 112.711158 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-01-09T11:47:04.035248 (delta: 0.114531)         elapsed: 112.825789 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-01-09T11:47:04.162167 (delta: 0.126814)         elapsed: 112.952708 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-01-09T11:47:04.288807 (delta: 0.126527)         elapsed: 113.079348 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "3a0ddee67e92fc5d67d655c843d6c01edd905b11", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c5e717927c8cddd321301711df137d96", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1578570424.42-135119231933903/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-01-09T11:47:07.139090 (delta: 2.850065)         elapsed: 115.929631 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.131754", "end": "2020-01-09 11:47:08.595677", "rc": 0, "start": "2020-01-09 11:47:07.463923", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_pod_failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_pod_failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-01-09T11:47:08.664545 (delta: 1.52534)         elapsed: 117.455086 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2020-01-09T10:14:03Z", "generation": 1, "name": "openebs-volume-replica-failure", "namespace": "", "resourceVersion": "784267", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-volume-replica-failure", "uid": "c31a20aa-32c8-11ea-b361-005056985c20"}, "spec": {"testMetadata": {"chaostype": "openebs/jiva_replica_pod_failure"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=34   unreachable=0    failed=0   

2020-01-09T11:47:09.885227 (delta: 1.220625)         elapsed: 118.675768 ****** 
=============================================================================== 
```
For cStor

```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15+ (default, Oct  7 2019, 17:39:04) [GCC 7.4.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_volume_replica_failure/test.yml

PLAY [localhost] ***************************************************************
2020-01-09T11:17:28.627257 (delta: 0.082071)         elapsed: 0.082071 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:2
2020-01-09T11:17:28.642964 (delta: 0.015647)         elapsed: 0.097778 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:13
2020-01-09T11:17:38.075777 (delta: 9.432779)         elapsed: 9.530591 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:2
2020-01-09T11:17:38.188269 (delta: 0.112425)         elapsed: 9.643083 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.117275", "end": "2020-01-09 11:17:39.747490", "rc": 0, "start": "2020-01-09 11:17:38.630215", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:10
2020-01-09T11:17:39.840393 (delta: 1.652043)         elapsed: 11.295207 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o custom-columns=:provisioner", "delta": "0:00:02.308947", "end": "2020-01-09 11:17:42.422088", "rc": 0, "start": "2020-01-09 11:17:40.113141", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:18
2020-01-09T11:17:42.490870 (delta: 2.650387)         elapsed: 13.945684 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-disk"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:22
2020-01-09T11:17:42.607722 (delta: 0.11679)         elapsed: 14.062536 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:27
2020-01-09T11:17:42.715977 (delta: 0.108144)         elapsed: 14.170791 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.306551", "end": "2020-01-09 11:17:44.332401", "rc": 0, "start": "2020-01-09 11:17:43.025850", "stderr": "", "stderr_lines": [], "stdout": "pvc-0da3bc46-312f-11ea-b361-005056985c20", "stdout_lines": ["pvc-0da3bc46-312f-11ea-b361-005056985c20"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:35
2020-01-09T11:17:44.405948 (delta: 1.689893)         elapsed: 15.860762 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-0da3bc46-312f-11ea-b361-005056985c20 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.266844", "end": "2020-01-09 11:17:45.986802", "rc": 0, "start": "2020-01-09 11:17:44.719958", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:43
2020-01-09T11:17:46.082631 (delta: 1.67662)         elapsed: 17.537445 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:48
2020-01-09T11:17:46.250769 (delta: 0.168007)         elapsed: 17.705583 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ebcdc2e8bc52679e8ee019bcad8187f62c963e26", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "ac9f9b26e876540d4da8730b1dfe603c", "mode": "0644", "owner": "root", "size": 61, "src": "/root/.ansible/tmp/ansible-tmp-1578568666.31-206332775672870/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_volume_replica_failure/test_prerequisites.yml:53
2020-01-09T11:17:47.198130 (delta: 0.947283)         elapsed: 18.652944 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1578568667.29-42591137258391/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:18
2020-01-09T11:17:47.748765 (delta: 0.550571)         elapsed: 19.203579 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:21
2020-01-09T11:17:47.840473 (delta: 0.091628)         elapsed: 19.295287 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_replica_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_volume_replica_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:24
2020-01-09T11:17:47.965469 (delta: 0.124926)         elapsed: 19.420283 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_replica_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:28
2020-01-09T11:17:48.133450 (delta: 0.167902)         elapsed: 19.588264 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:34
2020-01-09T11:17:48.325106 (delta: 0.191573)         elapsed: 19.77992 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-01-09T11:17:48.423653 (delta: 0.098451)         elapsed: 19.878467 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-01-09T11:17:48.512740 (delta: 0.089032)         elapsed: 19.967554 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:36
2020-01-09T11:17:48.612606 (delta: 0.099767)         elapsed: 20.06742 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-01-09T11:17:48.770569 (delta: 0.157879)         elapsed: 20.225383 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "28ead9a351aa1a3d91a21ce11ff08e1edeca21a2", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8cda0b81d9a96a7db45f48b00e82fa93", "mode": "0644", "owner": "root", "size": 466, "src": "/root/.ansible/tmp/ansible-tmp-1578568668.88-96272845850082/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-01-09T11:17:49.369913 (delta: 0.599275)         elapsed: 20.824727 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.110036", "end": "2020-01-09 11:17:50.727896", "rc": 0, "start": "2020-01-09 11:17:49.617860", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-01-09T11:17:50.786785 (delta: 1.416816)         elapsed: 22.241599 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2020-01-09T10:14:03Z", "generation": 1, "name": "openebs-volume-replica-failure", "namespace": "", "resourceVersion": "777093", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-volume-replica-failure", "uid": "c31a20aa-32c8-11ea-b361-005056985c20"}, "spec": {"testMetadata": {"chaostype": "openebs/cstor_replica_network_delay"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-01-09T11:17:52.307609 (delta: 1.520729)         elapsed: 23.762423 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-01-09T11:17:52.425447 (delta: 0.117758)         elapsed: 23.880261 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-01-09T11:17:52.565333 (delta: 0.139784)         elapsed: 24.020147 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:43
2020-01-09T11:17:52.641477 (delta: 0.076034)         elapsed: 24.096291 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace        : app-percona-ns", 
        "Label            : name=percona", 
        "PVC              : percona-mysql-claim", 
        "StorageClass     : openebs-cstor-disk"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:54
2020-01-09T11:17:52.768886 (delta: 0.127351)         elapsed: 24.2237 ********* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-01-09T11:17:52.907239 (delta: 0.138289)         elapsed: 24.362053 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.330344", "end": "2020-01-09 11:17:54.614070", "rc": 0, "start": "2020-01-09 11:17:53.283726", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-09T10:49:05Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-09T10:49:05Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-01-09T11:17:54.683911 (delta: 1.776564)         elapsed: 26.138725 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.244679", "end": "2020-01-09 11:17:56.149574", "rc": 0, "start": "2020-01-09 11:17:54.904895", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:63
2020-01-09T11:17:56.227057 (delta: 1.543092)         elapsed: 27.681871 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.161018", "end": "2020-01-09 11:17:57.594972", "rc": 0, "start": "2020-01-09 11:17:56.433954", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-z6gmf", "stdout_lines": ["percona-cb697f8b4-z6gmf"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:71
2020-01-09T11:17:57.691621 (delta: 1.464477)         elapsed: 29.146435 ******* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-01-09T11:17:58.007976 (delta: 0.316255)         elapsed: 29.46279 ******** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database percona_device_test;') => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-z6gmf -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database percona_device_test;'", "delta": "0:00:02.524317", "end": "2020-01-09 11:18:00.879046", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database percona_device_test;'", "rc": 0, "start": "2020-01-09 11:17:58.354729", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_test) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-z6gmf -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_test", "delta": "0:00:01.680941", "end": "2020-01-09 11:18:02.904533", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_test", "rc": 0, "start": "2020-01-09 11:18:01.223592", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' percona_device_test) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-z6gmf -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' percona_device_test", "delta": "0:00:02.565031", "end": "2020-01-09 11:18:05.839916", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' percona_device_test", "rc": 0, "start": "2020-01-09 11:18:03.274885", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-01-09T11:18:05.924400 (delta: 7.916356)         elapsed: 37.379214 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-01-09T11:18:05.990332 (delta: 0.065867)         elapsed: 37.445146 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-01-09T11:18:06.049844 (delta: 0.059419)         elapsed: 37.504658 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-01-09T11:18:06.111499 (delta: 0.061599)         elapsed: 37.566313 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-01-09T11:18:06.203464 (delta: 0.091903)         elapsed: 37.658278 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-01-09T11:18:06.292238 (delta: 0.0887)         elapsed: 37.747052 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-01-09T11:18:06.386037 (delta: 0.093726)         elapsed: 37.840851 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-01-09T11:18:06.485377 (delta: 0.099238)         elapsed: 37.940191 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-01-09T11:18:06.625669 (delta: 0.140189)         elapsed: 38.080483 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-01-09T11:18:06.756048 (delta: 0.13018)         elapsed: 38.210862 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:81
2020-01-09T11:18:06.879085 (delta: 0.122898)         elapsed: 38.333899 ******* 
included: /chaoslib/openebs/cstor_replica_network_delay.yaml for 127.0.0.1

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:1
2020-01-09T11:18:07.184879 (delta: 0.305689)         elapsed: 38.639693 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:01.081984", "end": "2020-01-09 11:18:08.517253", "rc": 0, "start": "2020-01-09 11:18:07.435269", "stderr": "", "stderr_lines": [], "stdout": "pvc-0da3bc46-312f-11ea-b361-005056985c20", "stdout_lines": ["pvc-0da3bc46-312f-11ea-b361-005056985c20"]}

TASK [Get istgt target pod details] ********************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:10
2020-01-09T11:18:08.573832 (delta: 1.388897)         elapsed: 40.028646 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/persistent-volume-claim=percona-mysql-claim -n openebs -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.225476", "end": "2020-01-09 11:18:10.088742", "rc": 0, "start": "2020-01-09 11:18:08.863266", "stderr": "", "stderr_lines": [], "stdout": "pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9", "stdout_lines": ["pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9"]}

TASK [Get Application  pod details] ********************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:16
2020-01-09T11:18:10.170114 (delta: 1.596227)         elapsed: 41.624928 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.177552", "end": "2020-01-09 11:18:11.683610", "rc": 0, "start": "2020-01-09 11:18:10.506058", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-z6gmf", "stdout_lines": ["percona-cb697f8b4-z6gmf"]}

TASK [Create an empty list of replica pods.] ***********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:21
2020-01-09T11:18:11.785930 (delta: 1.615762)         elapsed: 43.240744 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_replicas_pod": []}, "changed": false}

TASK [Obtaining the storage class used from PVC] *******************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:25
2020-01-09T11:18:11.967354 (delta: 0.181309)         elapsed: 43.422168 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:01.244500", "end": "2020-01-09 11:18:13.523174", "rc": 0, "start": "2020-01-09 11:18:12.278674", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Obtaining the SPC from storage class] ************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:30
2020-01-09T11:18:13.583913 (delta: 1.616451)         elapsed: 45.038727 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g'", "delta": "0:00:01.234439", "end": "2020-01-09 11:18:15.059397", "rc": 0, "start": "2020-01-09 11:18:13.824958", "stderr": "", "stderr_lines": [], "stdout": " cstor-block-disk-pool\n cstor", "stdout_lines": [" cstor-block-disk-pool", " cstor"]}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:35
2020-01-09T11:18:15.155782 (delta: 1.571798)         elapsed: 46.610596 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-0da3bc46-312f-11ea-b361-005056985c20 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.257508", "end": "2020-01-09 11:18:16.831934", "rc": 0, "start": "2020-01-09 11:18:15.574426", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-4oir\ncstor-block-disk-pool-guy9\ncstor-block-disk-pool-z892", "stdout_lines": ["cstor-block-disk-pool-4oir", "cstor-block-disk-pool-guy9", "cstor-block-disk-pool-z892"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:44
2020-01-09T11:18:16.947993 (delta: 1.792072)         elapsed: 48.402807 ******* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-4oir) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir\")].metadata.name}'", "delta": "0:00:01.279274", "end": "2020-01-09 11:18:18.544950", "item": "cstor-block-disk-pool-4oir", "rc": 0, "start": "2020-01-09 11:18:17.265676", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-4oir-56b74c6f7", "stdout_lines": ["cstor-block-disk-pool-4oir-56b74c6f7"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-guy9) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9\")].metadata.name}'", "delta": "0:00:01.327887", "end": "2020-01-09 11:18:20.138893", "item": "cstor-block-disk-pool-guy9", "rc": 0, "start": "2020-01-09 11:18:18.811006", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-guy9-67bb487fc6", "stdout_lines": ["cstor-block-disk-pool-guy9-67bb487fc6"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-z892) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892\")].metadata.name}'", "delta": "0:00:01.167284", "end": "2020-01-09 11:18:21.651046", "item": "cstor-block-disk-pool-z892", "rc": 0, "start": "2020-01-09 11:18:20.483762", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-z892-9fccbdbf8", "stdout_lines": ["cstor-block-disk-pool-z892-9fccbdbf8"]}

TASK [Obtaining the pool pods] *************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:52
2020-01-09T11:18:21.716547 (delta: 4.76842)         elapsed: 53.171361 ******** 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-4oir-56b74c6f7', '_ansible_item_result': True, u'delta': u'0:00:01.279274', 'stdout_lines': [u'cstor-block-disk-pool-4oir-56b74c6f7'], '_ansible_item_label': u'cstor-block-disk-pool-4oir', u'end': u'2020-01-09 11:18:18.544950', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir")].metadata.name}\'', 'item': u'cstor-block-disk-pool-4oir', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-09 11:18:17.265676', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir-56b74c6f7\")].metadata.name}'", "delta": "0:00:01.302696", "end": "2020-01-09 11:18:23.261977", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir\")].metadata.name}'", "delta": "0:00:01.279274", "end": "2020-01-09 11:18:18.544950", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-4oir", "rc": 0, "start": "2020-01-09 11:18:17.265676", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-4oir-56b74c6f7", "stdout_lines": ["cstor-block-disk-pool-4oir-56b74c6f7"]}, "rc": 0, "start": "2020-01-09 11:18:21.959281", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-4oir-56b74c6f7-t4fv4", "stdout_lines": ["cstor-block-disk-pool-4oir-56b74c6f7-t4fv4"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-guy9-67bb487fc6', '_ansible_item_result': True, u'delta': u'0:00:01.327887', 'stdout_lines': [u'cstor-block-disk-pool-guy9-67bb487fc6'], '_ansible_item_label': u'cstor-block-disk-pool-guy9', u'end': u'2020-01-09 11:18:20.138893', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9")].metadata.name}\'', 'item': u'cstor-block-disk-pool-guy9', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-09 11:18:18.811006', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9-67bb487fc6\")].metadata.name}'", "delta": "0:00:01.269915", "end": "2020-01-09 11:18:24.873457", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9\")].metadata.name}'", "delta": "0:00:01.327887", "end": "2020-01-09 11:18:20.138893", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-guy9", "rc": 0, "start": "2020-01-09 11:18:18.811006", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-guy9-67bb487fc6", "stdout_lines": ["cstor-block-disk-pool-guy9-67bb487fc6"]}, "rc": 0, "start": "2020-01-09 11:18:23.603542", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-guy9-67bb487fc6-hhht6", "stdout_lines": ["cstor-block-disk-pool-guy9-67bb487fc6-hhht6"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-z892-9fccbdbf8', '_ansible_item_result': True, u'delta': u'0:00:01.167284', 'stdout_lines': [u'cstor-block-disk-pool-z892-9fccbdbf8'], '_ansible_item_label': u'cstor-block-disk-pool-z892', u'end': u'2020-01-09 11:18:21.651046', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892")].metadata.name}\'', 'item': u'cstor-block-disk-pool-z892', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-09 11:18:20.483762', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892-9fccbdbf8\")].metadata.name}'", "delta": "0:00:01.190606", "end": "2020-01-09 11:18:26.299534", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892\")].metadata.name}'", "delta": "0:00:01.167284", "end": "2020-01-09 11:18:21.651046", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-z892", "rc": 0, "start": "2020-01-09 11:18:20.483762", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-z892-9fccbdbf8", "stdout_lines": ["cstor-block-disk-pool-z892-9fccbdbf8"]}, "rc": 0, "start": "2020-01-09 11:18:25.108928", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-z892-9fccbdbf8-zwrs7", "stdout_lines": ["cstor-block-disk-pool-z892-9fccbdbf8-zwrs7"]}

TASK [Build a list of replica pods] ********************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:60
2020-01-09T11:18:26.378189 (delta: 4.661575)         elapsed: 57.833003 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-4oir-56b74c6f7-t4fv4', '_ansible_item_result': True, u'delta': u'0:00:01.302696', 'stdout_lines': [u'cstor-block-disk-pool-4oir-56b74c6f7-t4fv4'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-4oir-56b74c6f7', '_ansible_item_result': True, u'delta': u'0:00:01.279274', 'stdout_lines': [u'cstor-block-disk-pool-4oir-56b74c6f7'], '_ansible_item_label': u'cstor-block-disk-pool-4oir', u'end': u'2020-01-09 11:18:18.544950', '_ansible_no_log': False, u'start': u'2020-01-09 11:18:17.265676', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-4oir', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2020-01-09 11:18:23.261977', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir-56b74c6f7")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-4oir-56b74c6f7', '_ansible_item_result': True, u'delta': u'0:00:01.279274', 'stdout_lines': [u'cstor-block-disk-pool-4oir-56b74c6f7'], '_ansible_item_label': u'cstor-block-disk-pool-4oir', u'end': u'2020-01-09 11:18:18.544950', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir")].metadata.name}\'', u'start': u'2020-01-09 11:18:17.265676', 'item': u'cstor-block-disk-pool-4oir', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-4oir-56b74c6f7")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-09 11:18:21.959281', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-4oir-56b74c6f7-t4fv4"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir-56b74c6f7\")].metadata.name}'", "delta": "0:00:01.302696", "end": "2020-01-09 11:18:23.261977", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir-56b74c6f7\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir\")].metadata.name}'", "delta": "0:00:01.279274", "end": "2020-01-09 11:18:18.544950", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-4oir\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-4oir", "rc": 0, "start": "2020-01-09 11:18:17.265676", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-4oir-56b74c6f7", "stdout_lines": ["cstor-block-disk-pool-4oir-56b74c6f7"]}, "rc": 0, "start": "2020-01-09 11:18:21.959281", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-4oir-56b74c6f7-t4fv4", "stdout_lines": ["cstor-block-disk-pool-4oir-56b74c6f7-t4fv4"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-guy9-67bb487fc6-hhht6', '_ansible_item_result': True, u'delta': u'0:00:01.269915', 'stdout_lines': [u'cstor-block-disk-pool-guy9-67bb487fc6-hhht6'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-guy9-67bb487fc6', '_ansible_item_result': True, u'delta': u'0:00:01.327887', 'stdout_lines': [u'cstor-block-disk-pool-guy9-67bb487fc6'], '_ansible_item_label': u'cstor-block-disk-pool-guy9', u'end': u'2020-01-09 11:18:20.138893', '_ansible_no_log': False, u'start': u'2020-01-09 11:18:18.811006', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-guy9', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2020-01-09 11:18:24.873457', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9-67bb487fc6")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-guy9-67bb487fc6', '_ansible_item_result': True, u'delta': u'0:00:01.327887', 'stdout_lines': [u'cstor-block-disk-pool-guy9-67bb487fc6'], '_ansible_item_label': u'cstor-block-disk-pool-guy9', u'end': u'2020-01-09 11:18:20.138893', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9")].metadata.name}\'', u'start': u'2020-01-09 11:18:18.811006', 'item': u'cstor-block-disk-pool-guy9', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-guy9-67bb487fc6")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-09 11:18:23.603542', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-4oir-56b74c6f7-t4fv4", "cstor-block-disk-pool-guy9-67bb487fc6-hhht6"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9-67bb487fc6\")].metadata.name}'", "delta": "0:00:01.269915", "end": "2020-01-09 11:18:24.873457", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9-67bb487fc6\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9\")].metadata.name}'", "delta": "0:00:01.327887", "end": "2020-01-09 11:18:20.138893", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-guy9\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-guy9", "rc": 0, "start": "2020-01-09 11:18:18.811006", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-guy9-67bb487fc6", "stdout_lines": ["cstor-block-disk-pool-guy9-67bb487fc6"]}, "rc": 0, "start": "2020-01-09 11:18:23.603542", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-guy9-67bb487fc6-hhht6", "stdout_lines": ["cstor-block-disk-pool-guy9-67bb487fc6-hhht6"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-z892-9fccbdbf8-zwrs7', '_ansible_item_result': True, u'delta': u'0:00:01.190606', 'stdout_lines': [u'cstor-block-disk-pool-z892-9fccbdbf8-zwrs7'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-z892-9fccbdbf8', '_ansible_item_result': True, u'delta': u'0:00:01.167284', 'stdout_lines': [u'cstor-block-disk-pool-z892-9fccbdbf8'], '_ansible_item_label': u'cstor-block-disk-pool-z892', u'end': u'2020-01-09 11:18:21.651046', '_ansible_no_log': False, u'start': u'2020-01-09 11:18:20.483762', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-z892', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2020-01-09 11:18:26.299534', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892-9fccbdbf8")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-z892-9fccbdbf8', '_ansible_item_result': True, u'delta': u'0:00:01.167284', 'stdout_lines': [u'cstor-block-disk-pool-z892-9fccbdbf8'], '_ansible_item_label': u'cstor-block-disk-pool-z892', u'end': u'2020-01-09 11:18:21.651046', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892")].metadata.name}\'', u'start': u'2020-01-09 11:18:20.483762', 'item': u'cstor-block-disk-pool-z892', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-z892-9fccbdbf8")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-01-09 11:18:25.108928', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-block-disk-pool-4oir-56b74c6f7-t4fv4", "cstor-block-disk-pool-guy9-67bb487fc6-hhht6", "cstor-block-disk-pool-z892-9fccbdbf8-zwrs7"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892-9fccbdbf8\")].metadata.name}'", "delta": "0:00:01.190606", "end": "2020-01-09 11:18:26.299534", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892-9fccbdbf8\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892\")].metadata.name}'", "delta": "0:00:01.167284", "end": "2020-01-09 11:18:21.651046", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-z892\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-z892", "rc": 0, "start": "2020-01-09 11:18:20.483762", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-z892-9fccbdbf8", "stdout_lines": ["cstor-block-disk-pool-z892-9fccbdbf8"]}, "rc": 0, "start": "2020-01-09 11:18:25.108928", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-z892-9fccbdbf8-zwrs7", "stdout_lines": ["cstor-block-disk-pool-z892-9fccbdbf8-zwrs7"]}}

TASK [set_fact] ****************************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:66
2020-01-09T11:18:26.581986 (delta: 0.203735)         elapsed: 58.0368 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"targeted_replica_pod": "cstor-block-disk-pool-4oir-56b74c6f7-t4fv4"}, "changed": false}

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:69
2020-01-09T11:18:26.705476 (delta: 0.123425)         elapsed: 58.16029 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"which tc\"", "delta": "0:00:01.457823", "end": "2020-01-09 11:18:28.577207", "rc": 0, "start": "2020-01-09 11:18:27.119384", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "/sbin/tc", "stdout_lines": ["/sbin/tc"]}

TASK [Install tc command on targeted replica pod] ******************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:75
2020-01-09T11:18:28.677632 (delta: 1.972092)         elapsed: 60.132446 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on targeted replica] **********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:82
2020-01-09T11:18:28.806682 (delta: 0.128968)         elapsed: 60.261496 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"tc qdisc add dev eth0 root netem loss 100.00\"", "delta": "0:00:01.254276", "end": "2020-01-09 11:18:30.470719", "rc": 0, "start": "2020-01-09 11:18:29.216443", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Check if targeted replica is disconnected] *******************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:88
2020-01-09T11:18:30.554272 (delta: 1.747427)         elapsed: 62.009086 ******* 
FAILED - RETRYING: Check if targeted replica is disconnected (10 retries left).
FAILED - RETRYING: Check if targeted replica is disconnected (9 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol -q replica |json_pp |grep \"\\\"replicaId\" |awk -F ':' '{print $2}' | tr -d ',' |wc -l", "delta": "0:00:01.440233", "end": "2020-01-09 11:19:35.681339", "rc": 0, "start": "2020-01-09 11:19:34.241106", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "2", "stdout_lines": ["2"]}

TASK [Get current iostats from target] *****************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:97
2020-01-09T11:19:35.851992 (delta: 65.297651)         elapsed: 127.306806 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol -q iostats |json_pp| grep WriteIOPS |awk -F ':' '{print $2}' | tr -d -c 0-9", "delta": "0:00:01.440505", "end": "2020-01-09 11:19:37.555179", "rc": 0, "start": "2020-01-09 11:19:36.114674", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "7964738", "stdout_lines": ["7964738"]}

TASK [Check if target got any new write IOs] ***********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:103
2020-01-09T11:19:37.664882 (delta: 1.812785)         elapsed: 129.119696 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol -q iostats |json_pp| grep WriteIOPS |awk -F ':' '{print $2}' | tr -d -c 0-9", "delta": "0:00:01.536193", "end": "2020-01-09 11:19:39.561931", "rc": 0, "start": "2020-01-09 11:19:38.025738", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "7964821", "stdout_lines": ["7964821"]}

TASK [Remove packet loss rule from targeted replica pod] ***********************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:112
2020-01-09T11:19:39.649765 (delta: 1.9848)         elapsed: 131.104579 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"tc qdisc del dev eth0 root netem loss 100.00\"", "delta": "0:00:01.450598", "end": "2020-01-09 11:19:41.436901", "rc": 0, "start": "2020-01-09 11:19:39.986303", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Wait until all replica gets connected] ***********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:118
2020-01-09T11:19:41.496742 (delta: 1.846874)         elapsed: 132.951556 ****** 
FAILED - RETRYING: Wait until all replica gets connected (10 retries left).
FAILED - RETRYING: Wait until all replica gets connected (9 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol -q replica |json_pp |grep \"\\\"replicaId\" |awk -F ':' '{print $2}' | tr -d ',' |wc -l", "delta": "0:00:01.526189", "end": "2020-01-09 11:20:46.684298", "rc": 0, "start": "2020-01-09 11:20:45.158109", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Wait until volume becomes healthy] ***************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:127
2020-01-09T11:20:46.760276 (delta: 65.263482)         elapsed: 198.21509 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol -q replica |json_pp |grep \"\\\"status\" |awk -F ':' '{print $2}' | tr -d ','", "delta": "0:00:01.535659", "end": "2020-01-09 11:20:48.535638", "rc": 0, "start": "2020-01-09 11:20:46.999979", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": " \"Healthy\"", "stdout_lines": [" \"Healthy\""]}

TASK [Wait until all replica becomes healthy] **********************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:136
2020-01-09T11:20:48.698190 (delta: 1.93785)         elapsed: 200.153004 ******* 
FAILED - RETRYING: Wait until all replica becomes healthy (50 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol -q replica |json_pp |grep \"\\\"Mode\" |awk -F ':' '{print $2}' | tr -d ','", "delta": "0:00:01.431907", "end": "2020-01-09 11:21:02.062977", "rc": 0, "start": "2020-01-09 11:21:00.631070", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": " \"Healthy\"\n \"Healthy\"\n \"Healthy\"", "stdout_lines": [" \"Healthy\"", " \"Healthy\"", " \"Healthy\""]}

TASK [Generate snapshot name] **************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:145
2020-01-09T11:21:02.135212 (delta: 13.436872)         elapsed: 213.590026 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1", "delta": "0:00:01.210087", "end": "2020-01-09 11:21:03.599472", "rc": 0, "start": "2020-01-09 11:21:02.389385", "stderr": "", "stderr_lines": [], "stdout": "LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW", "stdout_lines": ["LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW"]}

TASK [set_fact] ****************************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:149
2020-01-09T11:21:03.663632 (delta: 1.528363)         elapsed: 215.118446 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"snap_name": "LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW"}, "changed": false}

TASK [Take snapshot for data verification] *************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:152
2020-01-09T11:21:03.769881 (delta: 0.106192)         elapsed: 215.224695 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol snapcreate pvc-0da3bc46-312f-11ea-b361-005056985c20 LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW 30 30", "delta": "0:00:03.422460", "end": "2020-01-09 11:21:07.546011", "rc": 0, "start": "2020-01-09 11:21:04.123551", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPCREATE command", "stdout_lines": ["DONE SNAPCREATE command"]}

TASK [Install netcat on current host] ******************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:158
2020-01-09T11:21:07.689071 (delta: 3.919117)         elapsed: 219.143885 ****** 
 [WARNING]: Consider using the apt module rather than running apt-get.  If you
need to use command because apt is insufficient you can add warn=False to this
command task or set command_warnings=False in ansible.cfg to get rid of this
message.
changed: [127.0.0.1] => {"changed": true, "cmd": "apt-get update && apt-get -y install netcat iproute2", "delta": "0:00:11.879021", "end": "2020-01-09 11:21:19.985015", "rc": 0, "start": "2020-01-09 11:21:08.105994", "stderr": "", "stderr_lines": [], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease\nGet:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]\nGet:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]\nGet:4 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [10.8 kB]\nGet:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [1074 kB]\nGet:6 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [35.5 kB]\nGet:7 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1325 kB]\nGet:8 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [4241 B]\nGet:9 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]\nGet:10 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [777 kB]\nGet:11 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [21.8 kB]\nGet:12 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [6781 B]\nGet:13 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [796 kB]\nFetched 4304 kB in 6s (667 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\niproute2 is already the newest version (4.15.0-2ubuntu1).\nnetcat is already the newest version (1.10-41.1).\n0 upgraded, 0 newly installed, 0 to remove and 42 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease", "Get:2 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]", "Get:3 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]", "Get:4 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [10.8 kB]", "Get:5 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [1074 kB]", "Get:6 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [35.5 kB]", "Get:7 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1325 kB]", "Get:8 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [4241 B]", "Get:9 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]", "Get:10 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [777 kB]", "Get:11 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [21.8 kB]", "Get:12 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [6781 B]", "Get:13 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [796 kB]", "Fetched 4304 kB in 6s (667 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "iproute2 is already the newest version (4.15.0-2ubuntu1).", "netcat is already the newest version (1.10-41.1).", "0 upgraded, 0 newly installed, 0 to remove and 42 not upgraded."]}

TASK [include] *****************************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:162
2020-01-09T11:21:20.047548 (delta: 12.358378)         elapsed: 231.502362 ***** 
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1
included: /chaoslib/openebs/fetch_data_from_replica.yml for 127.0.0.1

TASK [Get replica id] **********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:1
2020-01-09T11:21:20.299788 (delta: 0.252185)         elapsed: 231.754602 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.229444", "end": "2020-01-09 11:21:21.770747", "rc": 0, "start": "2020-01-09 11:21:20.541303", "stderr": "", "stderr_lines": [], "stdout": "a1b5aa97-312e-11ea-b361-005056985c20", "stdout_lines": ["a1b5aa97-312e-11ea-b361-005056985c20"]}

TASK [Check for dataset name] **************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:5
2020-01-09T11:21:21.855421 (delta: 1.555557)         elapsed: 233.310235 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- zfs list cstor-a1b5aa97-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20", "delta": "0:00:01.495550", "end": "2020-01-09 11:21:23.763763", "rc": 0, "start": "2020-01-09 11:21:22.268213", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-a1b5aa97-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20   265M  47.9G   263M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-a1b5aa97-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20   265M  47.9G   263M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:13
2020-01-09T11:21:23.832597 (delta: 1.977081)         elapsed: 235.287411 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-a1b5aa97-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW > /snap.data\"", "delta": "0:00:10.325052", "end": "2020-01-09 11:21:34.361429", "rc": 0, "start": "2020-01-09 11:21:24.036377", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:17
2020-01-09T11:21:34.425023 (delta: 10.592366)         elapsed: 245.879837 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.369271", "end": "2020-01-09 11:21:36.000435", "rc": 0, "start": "2020-01-09 11:21:34.631164", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:21
2020-01-09T11:21:36.167856 (delta: 1.742773)         elapsed: 247.62267 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:03.639895", "end": "2020-01-09 11:21:40.045978", "rc": 0, "start": "2020-01-09 11:21:36.406083", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5e170ca2\n\ttype = 3\n\tflags = 0x4\n\ttoguid = d03cf30f2bf7ed02\n\tfromguid = 0\n\ttoname = cstor-a1b5aa97-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW\nEND checksum = 1da06c7b044ccc3/a771387ec078f940/e2341bdca7500879/c36aba616c3352eb\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 142198\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 7995\n\tTotal DRR_SPILL records = 0\n\tTotal records = 150202\n\tTotal write size = 582439424 (0x22b75200)\n\tTotal stream length = 629302448 (0x258264b0)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5e170ca2", "\ttype = 3", "\tflags = 0x4", "\ttoguid = d03cf30f2bf7ed02", "\tfromguid = 0", "\ttoname = cstor-a1b5aa97-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW", "END checksum = 1da06c7b044ccc3/a771387ec078f940/e2341bdca7500879/c36aba616c3352eb", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 142198", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 7995", "\tTotal DRR_SPILL records = 0", "\tTotal records = 150202", "\tTotal write size = 582439424 (0x22b75200)", "\tTotal stream length = 629302448 (0x258264b0)"]}

TASK [Install netcat on replica pod] *******************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:25
2020-01-09T11:21:40.193333 (delta: 4.025354)         elapsed: 251.648147 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:07.582905", "end": "2020-01-09 11:21:48.183037", "rc": 0, "start": "2020-01-09 11:21:40.600132", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead."], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nErr:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (232 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nnetcat is already the newest version (1.10-41).\n0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Err:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (232 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "netcat is already the newest version (1.10-41).", "0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded."]}

TASK [Start receiver to receive data object from replica pod] ******************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:29
2020-01-09T11:21:48.311640 (delta: 8.118209)         elapsed: 259.766454 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "792676024049.2098", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/792676024049.2098", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:35
2020-01-09T11:21:49.580799 (delta: 1.269044)         elapsed: 261.035613 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.070980", "end": "2020-01-09 11:21:55.843316", "rc": 0, "start": "2020-01-09 11:21:49.772336", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:39
2020-01-09T11:21:55.959885 (delta: 6.379012)         elapsed: 267.414699 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.12 9090 < /1.dump\"", "delta": "0:00:10.816534", "end": "2020-01-09 11:22:07.125104", "rc": 0, "start": "2020-01-09 11:21:56.308570", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:43
2020-01-09T11:22:07.254548 (delta: 11.29456)         elapsed: 278.709362 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.095669", "end": "2020-01-09 11:22:08.722363", "rc": 0, "start": "2020-01-09 11:22:07.626694", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:47
2020-01-09T11:22:08.780790 (delta: 1.526145)         elapsed: 280.235604 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.232995", "end": "2020-01-09 11:22:15.272247", "rc": 0, "start": "2020-01-09 11:22:09.039252", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:51
2020-01-09T11:22:15.389082 (delta: 6.608218)         elapsed: 286.843896 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "641699485617.2243", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/641699485617.2243", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:57
2020-01-09T11:22:16.715651 (delta: 1.326476)         elapsed: 288.170465 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-4oir-56b74c6f7-t4fv4 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.12 9090 < /3.dump\"", "delta": "0:00:07.362702", "end": "2020-01-09 11:22:24.292966", "rc": 0, "start": "2020-01-09 11:22:16.930264", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:61
2020-01-09T11:22:24.378723 (delta: 7.663016)         elapsed: 295.833537 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.092221", "end": "2020-01-09 11:22:25.682386", "rc": 0, "start": "2020-01-09 11:22:24.590165", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:1
2020-01-09T11:22:25.747856 (delta: 1.369079)         elapsed: 297.20267 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.065265", "end": "2020-01-09 11:22:27.112547", "rc": 0, "start": "2020-01-09 11:22:26.047282", "stderr": "", "stderr_lines": [], "stdout": "a1c86836-312e-11ea-b361-005056985c20", "stdout_lines": ["a1c86836-312e-11ea-b361-005056985c20"]}

TASK [Check for dataset name] **************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:5
2020-01-09T11:22:27.175154 (delta: 1.427209)         elapsed: 298.629968 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- zfs list cstor-a1c86836-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20", "delta": "0:00:01.541248", "end": "2020-01-09 11:22:29.049512", "rc": 0, "start": "2020-01-09 11:22:27.508264", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-a1c86836-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20   268M  47.9G   263M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-a1c86836-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20   268M  47.9G   263M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:13
2020-01-09T11:22:29.246492 (delta: 2.071284)         elapsed: 300.701306 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-a1c86836-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW > /snap.data\"", "delta": "0:00:08.753720", "end": "2020-01-09 11:22:38.278886", "rc": 0, "start": "2020-01-09 11:22:29.525166", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:17
2020-01-09T11:22:38.439033 (delta: 9.192435)         elapsed: 309.893847 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.644655", "end": "2020-01-09 11:22:40.323899", "rc": 0, "start": "2020-01-09 11:22:38.679244", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:21
2020-01-09T11:22:40.400499 (delta: 1.961363)         elapsed: 311.855313 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:03.734888", "end": "2020-01-09 11:22:44.366084", "rc": 0, "start": "2020-01-09 11:22:40.631196", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5e170ca2\n\ttype = 3\n\tflags = 0x4\n\ttoguid = 204d33cb051c9899\n\tfromguid = 0\n\ttoname = cstor-a1c86836-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW\nEND checksum = 1d81ad26b8270d9/46a1b63d1c5ac482/33ea44c193c3347c/46b66acefb310e4b\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 142198\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 7995\n\tTotal DRR_SPILL records = 0\n\tTotal records = 150202\n\tTotal write size = 582439424 (0x22b75200)\n\tTotal stream length = 629302448 (0x258264b0)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5e170ca2", "\ttype = 3", "\tflags = 0x4", "\ttoguid = 204d33cb051c9899", "\tfromguid = 0", "\ttoname = cstor-a1c86836-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW", "END checksum = 1d81ad26b8270d9/46a1b63d1c5ac482/33ea44c193c3347c/46b66acefb310e4b", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 142198", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 7995", "\tTotal DRR_SPILL records = 0", "\tTotal records = 150202", "\tTotal write size = 582439424 (0x22b75200)", "\tTotal stream length = 629302448 (0x258264b0)"]}

TASK [Install netcat on replica pod] *******************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:25
2020-01-09T11:22:44.498258 (delta: 4.097684)         elapsed: 315.953072 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:07.286395", "end": "2020-01-09 11:22:52.175092", "rc": 0, "start": "2020-01-09 11:22:44.888697", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead."], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:2 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (198 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nnetcat is already the newest version (1.10-41).\n0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:2 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (198 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "netcat is already the newest version (1.10-41).", "0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded."]}

TASK [Start receiver to receive data object from replica pod] ******************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:29
2020-01-09T11:22:52.300280 (delta: 7.801875)         elapsed: 323.755094 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "717696803152.2543", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/717696803152.2543", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:35
2020-01-09T11:22:53.587983 (delta: 1.28761)         elapsed: 325.042797 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.129360", "end": "2020-01-09 11:22:59.905065", "rc": 0, "start": "2020-01-09 11:22:53.775705", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:39
2020-01-09T11:23:00.021289 (delta: 6.433249)         elapsed: 331.476103 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.12 9090 < /1.dump\"", "delta": "0:00:11.473314", "end": "2020-01-09 11:23:11.751022", "rc": 0, "start": "2020-01-09 11:23:00.277708", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:43
2020-01-09T11:23:11.825239 (delta: 11.803861)         elapsed: 343.280053 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:00.946298", "end": "2020-01-09 11:23:13.000544", "rc": 0, "start": "2020-01-09 11:23:12.054246", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:47
2020-01-09T11:23:13.057765 (delta: 1.232471)         elapsed: 344.512579 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.123692", "end": "2020-01-09 11:23:19.394678", "rc": 0, "start": "2020-01-09 11:23:13.270986", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:51
2020-01-09T11:23:19.453384 (delta: 6.395545)         elapsed: 350.908198 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "289720896101.2688", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/289720896101.2688", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:57
2020-01-09T11:23:20.637723 (delta: 1.184283)         elapsed: 352.092537 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-guy9-67bb487fc6-hhht6 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.12 9090 < /3.dump\"", "delta": "0:00:07.620947", "end": "2020-01-09 11:23:28.530149", "rc": 0, "start": "2020-01-09 11:23:20.909202", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:61
2020-01-09T11:23:28.649041 (delta: 8.011256)         elapsed: 360.103855 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.144853", "end": "2020-01-09 11:23:30.161034", "rc": 0, "start": "2020-01-09 11:23:29.016181", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Get replica id] **********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:1
2020-01-09T11:23:30.220223 (delta: 1.57108)         elapsed: 361.675037 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs -o custom-columns=:.spec.containers[*].env[0].value --no-headers | cut -d \",\" -f1", "delta": "0:00:01.356405", "end": "2020-01-09 11:23:31.874731", "rc": 0, "start": "2020-01-09 11:23:30.518326", "stderr": "", "stderr_lines": [], "stdout": "a193b3c4-312e-11ea-b361-005056985c20", "stdout_lines": ["a193b3c4-312e-11ea-b361-005056985c20"]}

TASK [Check for dataset name] **************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:5
2020-01-09T11:23:31.984303 (delta: 1.764027)         elapsed: 363.439117 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- zfs list cstor-a193b3c4-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20", "delta": "0:00:01.699858", "end": "2020-01-09 11:23:34.085913", "rc": 0, "start": "2020-01-09 11:23:32.386055", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT\ncstor-a193b3c4-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20   270M  47.9G   262M  -", "stdout_lines": ["NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT", "cstor-a193b3c4-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20   270M  47.9G   262M  -"]}

TASK [Dump snapshot datastream to a file] **************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:13
2020-01-09T11:23:34.203556 (delta: 2.219168)         elapsed: 365.65837 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- bash -c \"zfs send cstor-a193b3c4-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW > /snap.data\"", "delta": "0:00:10.000923", "end": "2020-01-09 11:23:44.516368", "rc": 0, "start": "2020-01-09 11:23:34.515445", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove any object dump files from replica pod] ***************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:17
2020-01-09T11:23:44.603089 (delta: 10.399434)         elapsed: 376.057903 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- rm -rf 1.dump 3.dump", "delta": "0:00:01.590485", "end": "2020-01-09 11:23:46.473697", "rc": 0, "start": "2020-01-09 11:23:44.883212", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Parse snapshot stream and create dump files] *****************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:21
2020-01-09T11:23:46.532384 (delta: 1.929217)         elapsed: 377.987198 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- bash -c \"zstreamdump -w -1 < /snap.data\"", "delta": "0:00:03.763248", "end": "2020-01-09 11:23:50.531893", "rc": 0, "start": "2020-01-09 11:23:46.768645", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "BEGIN record\n\thdrtype = 1\n\tfeatures = 0\n\tmagic = 2f5bacbac\n\tcreation_time = 5e170ca2\n\ttype = 3\n\tflags = 0x4\n\ttoguid = e4943f232f0dc935\n\tfromguid = 0\n\ttoname = cstor-a193b3c4-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW\nEND checksum = 1da3b754dcbeff8/7bd680be03b58c24/1bc2a205de6a3f9d/76561200d5837278\nSUMMARY:\n\tTotal DRR_BEGIN records = 1\n\tTotal DRR_END records = 1\n\tTotal DRR_OBJECT records = 3\n\tTotal DRR_FREEOBJECTS records = 4\n\tTotal DRR_WRITE records = 142198\n\tTotal DRR_WRITE_BYREF records = 0\n\tTotal DRR_WRITE_EMBEDDED records = 0\n\tTotal DRR_FREE records = 7995\n\tTotal DRR_SPILL records = 0\n\tTotal records = 150202\n\tTotal write size = 582439424 (0x22b75200)\n\tTotal stream length = 629302448 (0x258264b0)", "stdout_lines": ["BEGIN record", "\thdrtype = 1", "\tfeatures = 0", "\tmagic = 2f5bacbac", "\tcreation_time = 5e170ca2", "\ttype = 3", "\tflags = 0x4", "\ttoguid = e4943f232f0dc935", "\tfromguid = 0", "\ttoname = cstor-a193b3c4-312e-11ea-b361-005056985c20/pvc-0da3bc46-312f-11ea-b361-005056985c20@LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW", "END checksum = 1da3b754dcbeff8/7bd680be03b58c24/1bc2a205de6a3f9d/76561200d5837278", "SUMMARY:", "\tTotal DRR_BEGIN records = 1", "\tTotal DRR_END records = 1", "\tTotal DRR_OBJECT records = 3", "\tTotal DRR_FREEOBJECTS records = 4", "\tTotal DRR_WRITE records = 142198", "\tTotal DRR_WRITE_BYREF records = 0", "\tTotal DRR_WRITE_EMBEDDED records = 0", "\tTotal DRR_FREE records = 7995", "\tTotal DRR_SPILL records = 0", "\tTotal records = 150202", "\tTotal write size = 582439424 (0x22b75200)", "\tTotal stream length = 629302448 (0x258264b0)"]}

TASK [Install netcat on replica pod] *******************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:25
2020-01-09T11:23:50.600452 (delta: 4.068014)         elapsed: 382.055266 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- bash -c \"apt-get update && apt-get -y install netcat\"", "delta": "0:00:06.982758", "end": "2020-01-09 11:23:57.960365", "rc": 0, "start": "2020-01-09 11:23:50.977607", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nCouldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nW: Some index files failed to download. They have been ignored, or old ones used instead.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "Couldn't create tempfiles for splitting up /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/security.ubuntu.com_ubuntu_dists_xenial-security_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-updates_InReleaseCouldn't create tempfiles for splitting up /var/lib/apt/lists/partial/archive.ubuntu.com_ubuntu_dists_xenial-backports_InReleaseW: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://security.ubuntu.com/ubuntu xenial-security InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-updates InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.ubuntu.com/ubuntu xenial-backports InRelease: Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-updates/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/xenial-backports/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Failed to fetch http://security.ubuntu.com/ubuntu/dists/xenial-security/InRelease  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "W: Some index files failed to download. They have been ignored, or old ones used instead."], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nErr:1 http://archive.ubuntu.com/ubuntu xenial InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nErr:2 http://security.ubuntu.com/ubuntu xenial-security InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nErr:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nErr:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\n  Could not execute 'apt-key' to verify signature (is gnupg installed?)\nFetched 325 kB in 1s (213 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nnetcat is already the newest version (1.10-41).\n0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Err:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Err:2 http://security.ubuntu.com/ubuntu xenial-security InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Err:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Err:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "  Could not execute 'apt-key' to verify signature (is gnupg installed?)", "Fetched 325 kB in 1s (213 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "netcat is already the newest version (1.10-41).", "0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded."]}

TASK [Start receiver to receive data object from replica pod] ******************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:29
2020-01-09T11:23:58.026306 (delta: 7.425797)         elapsed: 389.48112 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "442970947330.2990", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/442970947330.2990", "started": 1}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:35
2020-01-09T11:23:59.240675 (delta: 1.214295)         elapsed: 390.695489 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.160775", "end": "2020-01-09 11:24:05.585661", "rc": 0, "start": "2020-01-09 11:23:59.424886", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Send data object from replica pod] ***************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:39
2020-01-09T11:24:05.712120 (delta: 6.471392)         elapsed: 397.166934 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.12 9090 < /1.dump\"", "delta": "0:00:10.338150", "end": "2020-01-09 11:24:16.372234", "rc": 0, "start": "2020-01-09 11:24:06.034084", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:43
2020-01-09T11:24:16.429512 (delta: 10.717275)         elapsed: 407.884326 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.065027", "end": "2020-01-09 11:24:17.713403", "rc": 0, "start": "2020-01-09 11:24:16.648376", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Wait for few seconds for nc receiver] ************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:47
2020-01-09T11:24:17.793496 (delta: 1.363929)         elapsed: 409.24831 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.176950", "end": "2020-01-09 11:24:24.249456", "rc": 0, "start": "2020-01-09 11:24:18.072506", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Start receiver to receive meta-data object from replica pod] *************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:51
2020-01-09T11:24:24.384392 (delta: 6.590804)         elapsed: 415.839206 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "13753793439.3135", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/13753793439.3135", "started": 1}

TASK [Send meta-data object from replica pod] **********************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:57
2020-01-09T11:24:25.697651 (delta: 1.313153)         elapsed: 417.152465 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-z892-9fccbdbf8-zwrs7 -n openebs --container cstor-pool -- bash -c \"nc -w 3 172.23.6.12 9090 < /3.dump\"", "delta": "0:00:07.609440", "end": "2020-01-09 11:24:33.513943", "rc": 0, "start": "2020-01-09 11:24:25.904503", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [kill receiver] ***********************************************************
task path: /chaoslib/openebs/fetch_data_from_replica.yml:61
2020-01-09T11:24:33.577962 (delta: 7.880253)         elapsed: 425.032776 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "bash -c \"for i in `ps aux |grep \\\"nc -l -p 9090\\\" |grep -v grep |awk -F ' ' '{print $2}'`; do kill -9 $i; done\"", "delta": "0:00:01.148553", "end": "2020-01-09 11:24:34.963992", "rc": 0, "start": "2020-01-09 11:24:33.815439", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:167
2020-01-09T11:24:35.037734 (delta: 1.459712)         elapsed: 426.492548 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"base_replica": "cstor-block-disk-pool-4oir-56b74c6f7-t4fv4"}, "changed": false}

TASK [compare data object] *****************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:170
2020-01-09T11:24:35.126802 (delta: 0.089002)         elapsed: 426.581616 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-4oir-56b74c6f7-t4fv4) => {"changed": true, "cmd": "diff cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.1.dump cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.1.dump", "delta": "0:00:01.165642", "end": "2020-01-09 11:24:36.541962", "rc": 0, "rpod": "cstor-block-disk-pool-4oir-56b74c6f7-t4fv4", "start": "2020-01-09 11:24:35.376320", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-guy9-67bb487fc6-hhht6) => {"changed": true, "cmd": "diff cstor-block-disk-pool-guy9-67bb487fc6-hhht6.1.dump cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.1.dump", "delta": "0:00:02.416665", "end": "2020-01-09 11:24:39.194786", "rc": 0, "rpod": "cstor-block-disk-pool-guy9-67bb487fc6-hhht6", "start": "2020-01-09 11:24:36.778121", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-z892-9fccbdbf8-zwrs7) => {"changed": true, "cmd": "diff cstor-block-disk-pool-z892-9fccbdbf8-zwrs7.1.dump cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.1.dump", "delta": "0:00:02.311760", "end": "2020-01-09 11:24:41.743955", "rc": 0, "rpod": "cstor-block-disk-pool-z892-9fccbdbf8-zwrs7", "start": "2020-01-09 11:24:39.432195", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [compare meta data object] ************************************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:176
2020-01-09T11:24:41.815750 (delta: 6.688873)         elapsed: 433.270564 ****** 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-4oir-56b74c6f7-t4fv4) => {"changed": true, "cmd": "diff cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.3.dump cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.3.dump", "delta": "0:00:01.154466", "end": "2020-01-09 11:24:43.254906", "rc": 0, "rpod": "cstor-block-disk-pool-4oir-56b74c6f7-t4fv4", "start": "2020-01-09 11:24:42.100440", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-guy9-67bb487fc6-hhht6) => {"changed": true, "cmd": "diff cstor-block-disk-pool-guy9-67bb487fc6-hhht6.3.dump cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.3.dump", "delta": "0:00:01.229099", "end": "2020-01-09 11:24:44.688299", "rc": 0, "rpod": "cstor-block-disk-pool-guy9-67bb487fc6-hhht6", "start": "2020-01-09 11:24:43.459200", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-z892-9fccbdbf8-zwrs7) => {"changed": true, "cmd": "diff cstor-block-disk-pool-z892-9fccbdbf8-zwrs7.3.dump cstor-block-disk-pool-4oir-56b74c6f7-t4fv4.3.dump", "delta": "0:00:01.134933", "end": "2020-01-09 11:24:46.011281", "rc": 0, "rpod": "cstor-block-disk-pool-z892-9fccbdbf8-zwrs7", "start": "2020-01-09 11:24:44.876348", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Destroy snapshot created for data verification] **************************
task path: /chaoslib/openebs/cstor_replica_network_delay.yaml:182
2020-01-09T11:24:46.070182 (delta: 4.254351)         elapsed: 437.524996 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-0da3bc46-312f-11ea-b361-005056985c20-target-d4d6b66f9-6rxj9 -n openebs --container cstor-istgt -- istgtcontrol snapdestroy pvc-0da3bc46-312f-11ea-b361-005056985c20 LGRysLY9POtRgq2bLb4N4LRwsHyZsKFW 30 30", "delta": "0:00:01.491922", "end": "2020-01-09 11:24:47.843271", "rc": 0, "start": "2020-01-09 11:24:46.351349", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "DONE SNAPDESTROY command", "stdout_lines": ["DONE SNAPDESTROY command"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:87
2020-01-09T11:24:47.932739 (delta: 1.862504)         elapsed: 439.387553 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-01-09T11:24:48.113480 (delta: 0.18064)         elapsed: 439.568294 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.306013", "end": "2020-01-09 11:24:49.670249", "rc": 0, "start": "2020-01-09 11:24:48.364236", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-09T10:49:05Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-09T10:49:05Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-01-09T11:24:49.780365 (delta: 1.666829)         elapsed: 441.235179 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.105314", "end": "2020-01-09 11:24:51.350086", "rc": 0, "start": "2020-01-09 11:24:50.244772", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:96
2020-01-09T11:24:51.444400 (delta: 1.663904)         elapsed: 442.899214 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:99
2020-01-09T11:24:51.582465 (delta: 0.137976)         elapsed: 443.037279 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.221632", "end": "2020-01-09 11:24:53.104574", "rc": 0, "start": "2020-01-09 11:24:51.882942", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-z6gmf", "stdout_lines": ["percona-cb697f8b4-z6gmf"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:107
2020-01-09T11:24:53.195922 (delta: 1.613358)         elapsed: 444.650736 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-01-09T11:24:53.533297 (delta: 0.337296)         elapsed: 444.988111 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database percona_device_test;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database percona_device_test;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_test)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' percona_device_test", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' percona_device_test)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' percona_device_test", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-01-09T11:24:53.649238 (delta: 0.115893)         elapsed: 445.104052 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-cb697f8b4-z6gmf -n app-percona-ns", "delta": "0:00:14.512735", "end": "2020-01-09 11:25:08.527943", "rc": 0, "start": "2020-01-09 11:24:54.015208", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-cb697f8b4-z6gmf\" deleted", "stdout_lines": ["pod \"percona-cb697f8b4-z6gmf\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-01-09T11:25:08.663333 (delta: 15.014025)         elapsed: 460.118147 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns", "delta": "0:00:01.286222", "end": "2020-01-09 11:25:10.402805", "rc": 0, "start": "2020-01-09 11:25:09.116583", "stderr": "", "stderr_lines": [], "stdout": "NAME                      READY   STATUS    RESTARTS   AGE\npercona-cb697f8b4-kgkjk   1/1     Running   0          15s", "stdout_lines": ["NAME                      READY   STATUS    RESTARTS   AGE", "percona-cb697f8b4-kgkjk   1/1     Running   0          15s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-01-09T11:25:10.508963 (delta: 1.845533)         elapsed: 461.963777 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.153185", "end": "2020-01-09 11:25:12.061951", "rc": 0, "start": "2020-01-09 11:25:10.908766", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-kgkjk", "stdout_lines": ["percona-cb697f8b4-kgkjk"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-01-09T11:25:12.168011 (delta: 1.65896)         elapsed: 463.622825 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-kgkjk\")].status.phase}'", "delta": "0:00:01.254072", "end": "2020-01-09 11:25:13.738009", "rc": 0, "start": "2020-01-09 11:25:12.483937", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-01-09T11:25:13.838554 (delta: 1.670449)         elapsed: 465.293368 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-cb697f8b4-kgkjk\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.060246", "end": "2020-01-09 11:25:15.309464", "rc": 0, "start": "2020-01-09 11:25:14.249218", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-01-09T11:24:57Z]]", "stdout_lines": ["map[running:map[startedAt:2020-01-09T11:24:57Z]]"]}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-01-09T11:25:15.381583 (delta: 1.542959)         elapsed: 466.836397 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-cb697f8b4-kgkjk -n app-percona-ns | grep 'ready for connections'", "delta": "0:00:01.277971", "end": "2020-01-09 11:25:17.031726", "rc": 0, "start": "2020-01-09 11:25:15.753755", "stderr": "", "stderr_lines": [], "stdout": "2020-01-09T11:24:59.326229Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2020-01-09T11:24:59.326229Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-01-09T11:25:17.126676 (delta: 1.74501)         elapsed: 468.58149 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-kgkjk -n app-percona-ns -- mysqlcheck -c percona_device_test -uroot -pk8sDem0", "delta": "0:00:01.442510", "end": "2020-01-09 11:25:18.895142", "failed_when_result": false, "rc": 0, "start": "2020-01-09 11:25:17.452632", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "percona_device_test.ttbl                           OK", "stdout_lines": ["percona_device_test.ttbl                           OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-01-09T11:25:19.035594 (delta: 1.908821)         elapsed: 470.490408 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-kgkjk -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' percona_device_test;", "delta": "0:00:01.579943", "end": "2020-01-09 11:25:20.947142", "failed_when_result": false, "rc": 0, "start": "2020-01-09 11:25:19.367199", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-01-09T11:25:21.078036 (delta: 2.042307)         elapsed: 472.53285 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-01-09T11:25:21.192689 (delta: 0.114566)         elapsed: 472.647503 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:115
2020-01-09T11:25:21.309433 (delta: 0.116645)         elapsed: 472.764247 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_volume_replica_failure/test.yml:126
2020-01-09T11:25:21.419498 (delta: 0.109969)         elapsed: 472.874312 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-01-09T11:25:21.549649 (delta: 0.130091)         elapsed: 473.004463 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-01-09T11:25:21.610019 (delta: 0.060312)         elapsed: 473.064833 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-01-09T11:25:21.666904 (delta: 0.056827)         elapsed: 473.121718 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-01-09T11:25:21.724322 (delta: 0.057356)         elapsed: 473.179136 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8c76e09f875b719b3baa42e2e2c80454f54742be", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "938051007e301440ec057fbeddf7bc3e", "mode": "0644", "owner": "root", "size": 464, "src": "/root/.ansible/tmp/ansible-tmp-1578569121.81-145137292802615/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-01-09T11:25:24.393450 (delta: 2.669065)         elapsed: 475.848264 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.046303", "end": "2020-01-09 11:25:25.689675", "rc": 0, "start": "2020-01-09 11:25:24.643372", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-volume-replica-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-volume-replica-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-01-09T11:25:25.769598 (delta: 1.376081)         elapsed: 477.224412 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"clusterName": "", "creationTimestamp": "2020-01-09T10:14:03Z", "generation": 1, "name": "openebs-volume-replica-failure", "namespace": "", "resourceVersion": "778875", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-volume-replica-failure", "uid": "c31a20aa-32c8-11ea-b361-005056985c20"}, "spec": {"testMetadata": {"chaostype": "openebs/cstor_replica_network_delay"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=118  changed=92   unreachable=0    failed=0   

2020-01-09T11:25:26.929936 (delta: 1.160244)         elapsed: 478.38475 ******* 
=============================================================================== 
```
