### PR TITLE
Refactor litmusbook(backup&restore) to setup velero server based on provided version

### DIFF
--- a/experiments/functional/backup_and_restore/setup_dependency.yml
+++ b/experiments/functional/backup_and_restore/setup_dependency.yml
@@ -46,6 +46,19 @@
           --use-volume-snapshots=false \
           --use-restic \
           --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+     when: velero_version == "v1.1.0"
+
+   - name: Installing velero server inside cluster
+     shell: >
+        velero install \
+          --provider aws \
+          --bucket velero \
+          --secret-file ./credentials-velero \
+          --plugins velero/velero-plugin-for-aws:v1.0.0 \
+          --use-volume-snapshots=false \
+          --use-restic \
+          --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+     when: velero_version == "v1.2.0"
 
    - name: Patching restic demonset for privileged access
      shell: kubectl patch ds restic -n velero --patch "$(cat patch.yml)"
@@ -75,6 +88,18 @@
          --secret-file ./credentials-velero \
          --use-volume-snapshots=false \
          --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+     when: velero_version == "v1.1.0"
+
+   - name: Installing velero server inside cluster
+     shell: >
+       velero install \
+         --provider aws \
+         --bucket velero \
+         --secret-file ./credentials-velero \
+         --use-volume-snapshots=false \
+         --plugins velero/velero-plugin-for-aws:v1.0.0 \
+         --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
+     when: velero_version == "v1.2.0"
 
   when: storage_engine == "cstor"  
 


### PR DESCRIPTION

Signed-off-by: shashank855 <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Velero 1.2.0 requires --pugins flag to be passed while installing velero server. This PR deploys velero server based on velero version passed as env.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
