### PR TITLE
feat[yaml]: Implemented litmusbook to provision/deprovision jiva-csi-volume

### DIFF
--- a/experiments/functional/jiva-csi/jiva-csi-busybox/jiva-csi-busybox-sc.j2
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/jiva-csi-busybox-sc.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}"
+provisioner: jiva.csi.openebs.io
+parameters:
+  cas-type: "jiva"
+  replicaCount: "{{ replica_count }}"
+  replicaSC: "{{ replica_storageclass }}"

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/jiva-csi-busybox.j2
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/jiva-csi-busybox.j2
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox
+  namespace: {{ app_ns }}
+  labels:
+    app: {{ app_label }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ app_label }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_label }}
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: {{ pvc_name }}

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/jiva-csi-pvc.j2
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/jiva-csi-pvc.j2
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ pvc_name }}
+  namespace: {{ app_ns }}
+spec:
+  storageClassName: {{ storage_class }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ storage_capacity }}

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/run_litmus_test.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/run_litmus_test.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-csi-busybox-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: jiva-csi-busybox
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: APP_LABEL
+            value: ''
+
+          - name: APP_NAMESPACE
+            value: ''
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-jiva-csi-sc
+                    
+          - name: PVC
+            value: ''
+
+          - name: CAPACITY
+            value: 5Gi  
+          
+          # supported values for ACTION (provision,deprovision)
+          - name: ACTION
+            value: provision  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/jiva-csi-provisioner/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/run_litmus_test.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/run_litmus_test.yml
@@ -29,7 +29,13 @@ spec:
             value: ''
 
           - name: PROVIDER_STORAGE_CLASS
-            value: openebs-jiva-csi-sc
+            value: openebs-jiva-csi-busybox
+
+          - name: REPLICA_SC
+            value: openebs-hostpath
+
+          - name: REPLICA_COUNT
+            value: "3"
                     
           - name: PVC
             value: ''

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/test.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/test.yml
@@ -1,0 +1,206 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - block:
+
+            - include_tasks: /utils/k8s/create_ns.yml
+
+            - name: Verify if the provider storage class is present
+              shell: >
+                kubectl get storageclass {{ storage_class }}
+              args:
+                executable: /bin/bash
+              register: provider_sc
+              failed_when: "storage_class not in provider_sc.stdout"
+
+            - name: Update the pvc template with the variables.
+              template:
+                src: jiva-csi-pvc.j2
+                dest: jiva-csi-pvc.yml
+
+            - name: Create Persistent Volume Claim
+              shell: kubectl apply -f jiva-csi-pvc.yml
+              args:
+                executable: /bin/bash
+              register: pvc_result
+              failed_when: "pvc_result.rc != 0"
+
+            - name: Update the busybox app template with the variables.
+              template:
+                src: jiva-csi-busybox.j2
+                dest: jiva-csi-busybox.yml
+
+            - name: Deploy busybox application on top of the created pvc
+              shell: kubectl apply -f jiva-csi-busybox.yml
+              args:
+                executable: /bin/bash
+              register: busybox_result
+              failed_when: "busybox_result.rc != 0"
+            
+            - name: Verify the application pod status
+              shell: >
+                kubectl get pod -n {{ app_ns }} -l app={{ app_label }}
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: status
+              until: "'Running' in status.stdout"
+              delay: 10
+              retries: 30
+
+            - name: Obtain the volume name
+              shell: >
+                kubectl get pvc {{ pvc_name }} -n {{ app_ns }} 
+                --no-headers -o custom-columns=:.spec.volumeName
+              args:
+                executable: /bin/bash
+              register: app_pv
+              failed_when: "app_pv.rc != 0"
+
+            - name: Obtain the controller pod name in operator namespace
+              shell: >
+                kubectl get pod -n {{ operator_ns }} -l openebs.io/component=jiva-controller,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+                --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: controller_pod
+              failed_when: "controller_pod.rc != 0"
+
+            - name: Obtain the replica count of the persistent volume
+              shell: >
+                kubectl get pod "{{ controller_pod.stdout }}" -n openebs 
+                --no-headers -o jsonpath='{.spec.containers[*].env[*].value}'
+              args:
+                executable: /bin/bash
+              register: replica_count
+              failed_when: "replica_count.rc != 0"
+
+            - name: Recording the replica count of the persistent volume
+              set_fact:
+                rep_count: "{{ replica_count.stdout }}"
+
+            - name: Verify the controller pod is running
+              shell: >
+                kubectl get pod -n {{ operator_ns }} -l openebs.io/component=jiva-controller,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "'Running' not in status.stdout"
+
+            - name: Verify all the replica-pod is running
+              shell: >
+                kubectl get sts -n {{ operator_ns }} -l openebs.io/component=jiva-replica,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+                --no-headers -o custom-columns=:.status.readyReplicas
+              args:
+                executable: /bin/bash
+              register: ready_rep
+              failed_when: "rep_count|int != ready_rep.stdout|int"
+
+          when: action == "provision"
+
+        - block:
+        
+            - name: Delete the application deployment
+              shell: >
+                kubectl delete deployment busybox -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - name: Verify if the application pod is deleted
+              shell: >
+                kubectl get pod -n {{ app_ns }} -l app={{ app_label }} 
+                --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: status
+              until: "status.stdout == ''"
+              delay: 10
+              retries: 30
+
+            - name: Obtain the volume name
+              shell: >
+                kubectl get pvc {{ pvc_name }} -n {{ app_ns }} 
+                --no-headers -o custom-columns=:.spec.volumeName
+              args:
+                executable: /bin/bash
+              register: app_pv
+              failed_when: "app_pv.rc != 0"
+
+            - name: Delete the application pvc
+              shell: >
+                kubectl delete pvc {{ pvc_name }} -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - name: Verify if the application pvc is deleted
+              shell: >
+                kubectl get pvc {{ pvc_name }} -n {{ app_ns }} 
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "pvc_name in status.stdout"
+            
+            - name: Verify the controller pod is deleted
+              shell: >
+                kubectl get pod -n {{ operator_ns }} -l openebs.io/component=jiva-controller,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: status
+              until: "status.stdout == ''"
+              delay: 10
+              retries: 30
+
+            - name: Verify the replica-pod is deleted
+              shell: >
+                kubectl get pod -n {{ operator_ns }} -l openebs.io/component=jiva-replica,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: status
+              until: "status.stdout == ''"
+              delay: 10
+              retries: 30
+
+            - name: Delete the application namespace
+              shell: kubectl delete namespace {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+          when: action == "deprovision"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/test.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/test.yml
@@ -20,6 +20,18 @@
 
             - include_tasks: /utils/k8s/create_ns.yml
 
+            - name: Update the storage class template with the variables.
+              template:
+                src: jiva-csi-busybox-sc.j2
+                dest: jiva-csi-busybox-sc.yml
+
+            - name: Create Storage Class
+              shell: kubectl apply -f jiva-csi-busybox-sc.yml
+              args:
+                executable: /bin/bash
+              register: sc_result
+              failed_when: "sc_result.rc != 0"        
+
             - name: Verify if the provider storage class is present
               shell: >
                 kubectl get storageclass {{ storage_class }}
@@ -188,6 +200,14 @@
                 executable: /bin/bash
               register: status
               failed_when: "status.rc != 0"
+
+            - name: Delete the storage class created
+              shell: >
+                kubectl delete sc {{ storage_class }}
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"  
 
           when: action == "deprovision"
 

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/test_vars.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/test_vars.yml
@@ -12,6 +12,10 @@ operator_ns: 'openebs'
 
 pvc_name: "{{ lookup('env','PVC') }}"
 
+replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
+
+replica_storageclass: "{{ lookup('env','REPLICA_SC') }}"
+
 storage_capacity: "{{ lookup('env','CAPACITY') }}"
 
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"

--- a/experiments/functional/jiva-csi/jiva-csi-busybox/test_vars.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-busybox/test_vars.yml
@@ -1,0 +1,19 @@
+---
+
+# Test specific parameters
+
+action: "{{ lookup('env','ACTION') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+operator_ns: 'openebs'
+
+pvc_name: "{{ lookup('env','PVC') }}"
+
+storage_capacity: "{{ lookup('env','CAPACITY') }}"
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+test_name: "jiva-csi-busybox"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented litmusbook to provision/deprovision jiva-csi-volume

 *Special notes for your reviewer**:
logs for provisioning of jiva-csi-volume
```
PLAY [localhost] ***************************************************************
2020-01-23T09:59:05.589712 (delta: 0.065889)         elapsed: 0.065889 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-01-23T09:59:05.604796 (delta: 0.015028)         elapsed: 0.080973 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-01-23T09:59:16.906211 (delta: 11.301395)         elapsed: 11.382388 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-01-23T09:59:17.091221 (delta: 0.184952)         elapsed: 11.567398 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-01-23T09:59:17.222173 (delta: 0.130886)         elapsed: 11.69835 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-01-23T09:59:17.372091 (delta: 0.149851)         elapsed: 11.848268 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-23T09:59:17.638193 (delta: 0.266027)         elapsed: 12.11437 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d642b0604da4041b7b89e45064fbc4c19185ac73", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "e5d0f9fd49c829bf7a4ffc59d2451254", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1579773557.7-201978101030634/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T09:59:18.620153 (delta: 0.981907)         elapsed: 13.09633 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.968250", "end": "2020-01-23 09:59:20.050666", "rc": 0, "start": "2020-01-23 09:59:19.082416", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-busybox \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-busybox ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T09:59:20.147356 (delta: 1.526663)         elapsed: 14.623533 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-23T05:26:35Z", "generation": 29, "name": "jiva-csi-busybox", "resourceVersion": "330323", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-busybox", "uid": "ed2f5eff-019b-4d1b-b532-18e3eb74cd69"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-23T09:59:21.802276 (delta: 1.654853)         elapsed: 16.278453 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T09:59:21.939183 (delta: 0.136694)         elapsed: 16.41536 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T09:59:22.086330 (delta: 0.147067)         elapsed: 16.562507 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-01-23T09:59:22.239297 (delta: 0.152797)         elapsed: 16.715474 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2020-01-23T09:59:22.501047 (delta: 0.261669)         elapsed: 16.977224 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.478826", "end": "2020-01-23 09:59:24.241248", "rc": 0, "start": "2020-01-23 09:59:22.762422", "stderr": "", "stderr_lines": [], "stdout": "aman\ndefault\nkube-node-lease\nkube-public\nkube-system\nlitmus\nopenebs", "stdout_lines": ["aman", "default", "kube-node-lease", "kube-public", "kube-system", "litmus", "openebs"]}

TASK [Create test specific namespace.] *****************************************
2020-01-23T09:59:24.384925 (delta: 1.883814)         elapsed: 18.861102 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns sam", "delta": "0:00:01.081203", "end": "2020-01-23 09:59:25.901275", "rc": 0, "start": "2020-01-23 09:59:24.820072", "stderr": "", "stderr_lines": [], "stdout": "namespace/sam created", "stdout_lines": ["namespace/sam created"]}

TASK [include_tasks] ***********************************************************
2020-01-23T09:59:26.000370 (delta: 1.615085)         elapsed: 20.476547 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2020-01-23T09:59:26.269711 (delta: 0.26926)         elapsed: 20.745888 ******** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2020-01-23T09:59:25Z", "name": "sam", "resourceVersion": "330341", "selfLink": "/api/v1/namespaces/sam", "uid": "a65d1ba9-b358-4a9d-86ce-2d07529e2061"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [Verify if the provider storage class is present] *************************
2020-01-23T09:59:27.878660 (delta: 1.608857)         elapsed: 22.354837 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get storageclass openebs-jiva-csi-sc", "delta": "0:00:01.046972", "end": "2020-01-23 09:59:29.283418", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:59:28.236446", "stderr": "", "stderr_lines": [], "stdout": "NAME                  PROVISIONER           RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE\nopenebs-jiva-csi-sc   jiva.csi.openebs.io   Delete          Immediate           false                  4h38m", "stdout_lines": ["NAME                  PROVISIONER           RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE", "openebs-jiva-csi-sc   jiva.csi.openebs.io   Delete          Immediate           false                  4h38m"]}

TASK [Update the pvc template with the variables.] *****************************
2020-01-23T09:59:29.376404 (delta: 1.497637)         elapsed: 23.852581 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "07afb6f1f4f85ab2744647b7a2cd8f810e8c7ab7", "dest": "./jiva-csi-pvc.yml", "gid": 0, "group": "root", "md5sum": "a30df2f8a7469b8601b4b2e1706d15a9", "mode": "0644", "owner": "root", "size": 208, "src": "/root/.ansible/tmp/ansible-tmp-1579773569.5-84516199659171/source", "state": "file", "uid": 0}

TASK [Create Persistent Volume Claim] ******************************************
2020-01-23T09:59:30.027784 (delta: 0.651314)         elapsed: 24.503961 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f jiva-csi-pvc.yml", "delta": "0:00:01.430015", "end": "2020-01-23 09:59:31.684195", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:59:30.254180", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/csi created", "stdout_lines": ["persistentvolumeclaim/csi created"]}

TASK [Update the busybox app template with the variables.] *********************
2020-01-23T09:59:31.778495 (delta: 1.750589)         elapsed: 26.254672 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7f4caf360f2d1ae53046ce2cdd9fa6f8623f1d10", "dest": "./jiva-csi-busybox.yml", "gid": 0, "group": "root", "md5sum": "eee8546138180baa79d0ad5877a120dd", "mode": "0644", "owner": "root", "size": 606, "src": "/root/.ansible/tmp/ansible-tmp-1579773571.91-236155262373598/source", "state": "file", "uid": 0}

TASK [Deploy busybox application on top of the created pvc] ********************
2020-01-23T09:59:32.606311 (delta: 0.827742)         elapsed: 27.082488 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f jiva-csi-busybox.yml", "delta": "0:00:01.652715", "end": "2020-01-23 09:59:34.535889", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:59:32.883174", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/busybox created", "stdout_lines": ["deployment.apps/busybox created"]}

TASK [Verify the application pod status] ***************************************
2020-01-23T09:59:34.636714 (delta: 2.030343)         elapsed: 29.112891 ******* 
FAILED - RETRYING: Verify the application pod status (30 retries left).
FAILED - RETRYING: Verify the application pod status (29 retries left).
FAILED - RETRYING: Verify the application pod status (28 retries left).
FAILED - RETRYING: Verify the application pod status (27 retries left).
FAILED - RETRYING: Verify the application pod status (26 retries left).
FAILED - RETRYING: Verify the application pod status (25 retries left).
changed: [127.0.0.1] => {"attempts": 7, "changed": true, "cmd": "kubectl get pod -n sam -l app=jiva-csi --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.014433", "end": "2020-01-23 10:00:44.210735", "rc": 0, "start": "2020-01-23 10:00:43.196302", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the volume name] **************************************************
2020-01-23T10:00:44.336661 (delta: 69.699876)         elapsed: 98.812838 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi -n sam --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.036175", "end": "2020-01-23 10:00:45.768920", "failed_when_result": false, "rc": 0, "start": "2020-01-23 10:00:44.732745", "stderr": "", "stderr_lines": [], "stdout": "pvc-99641f64-a03a-4962-86cc-f98be1494941", "stdout_lines": ["pvc-99641f64-a03a-4962-86cc-f98be1494941"]}

TASK [Obtain the controller pod name in operator namespace] ********************
2020-01-23T10:00:45.856027 (delta: 1.519296)         elapsed: 100.332204 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/component=jiva-controller,openebs.io/persistent-volume=\"pvc-99641f64-a03a-4962-86cc-f98be1494941\" --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.300297", "end": "2020-01-23 10:00:47.554333", "failed_when_result": false, "rc": 0, "start": "2020-01-23 10:00:46.254036", "stderr": "", "stderr_lines": [], "stdout": "pvc-99641f64-a03a-4962-86cc-f98be1494941-jiva-ctrl-778bfd5ldnrn", "stdout_lines": ["pvc-99641f64-a03a-4962-86cc-f98be1494941-jiva-ctrl-778bfd5ldnrn"]}

TASK [Obtain the replica count of the persistent volume] ***********************
2020-01-23T10:00:47.680120 (delta: 1.824047)         elapsed: 102.156297 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod \"pvc-99641f64-a03a-4962-86cc-f98be1494941-jiva-ctrl-778bfd5ldnrn\" -n openebs --no-headers -o jsonpath='{.spec.containers[*].env[*].value}'", "delta": "0:00:01.150480", "end": "2020-01-23 10:00:49.157374", "failed_when_result": false, "rc": 0, "start": "2020-01-23 10:00:48.006894", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Recording the replica count of the persistent volume] ********************
2020-01-23T10:00:49.319603 (delta: 1.639376)         elapsed: 103.79578 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"rep_count": "3"}, "changed": false}

TASK [Verify the controller pod is running] ************************************
2020-01-23T10:00:49.564059 (delta: 0.244373)         elapsed: 104.040236 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/component=jiva-controller,openebs.io/persistent-volume=\"pvc-99641f64-a03a-4962-86cc-f98be1494941\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.998877", "end": "2020-01-23 10:00:51.017663", "failed_when_result": false, "rc": 0, "start": "2020-01-23 10:00:50.018786", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify all the replica-pod is running] ***********************************
2020-01-23T10:00:51.128492 (delta: 1.564347)         elapsed: 105.604669 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sts -n openebs -l openebs.io/component=jiva-replica,openebs.io/persistent-volume=\"pvc-99641f64-a03a-4962-86cc-f98be1494941\" --no-headers -o custom-columns=:.status.readyReplicas", "delta": "0:00:01.180516", "end": "2020-01-23 10:00:52.676613", "failed_when_result": false, "rc": 0, "start": "2020-01-23 10:00:51.496097", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Delete the application deployment] ***************************************
2020-01-23T10:00:52.790726 (delta: 1.662163)         elapsed: 107.266903 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
2020-01-23T10:00:52.946402 (delta: 0.155597)         elapsed: 107.422579 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the volume name] **************************************************
2020-01-23T10:00:53.080626 (delta: 0.134146)         elapsed: 107.556803 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the application pvc] **********************************************
2020-01-23T10:00:53.224030 (delta: 0.143312)         elapsed: 107.700207 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pvc is deleted] ********************************
2020-01-23T10:00:53.375246 (delta: 0.15114)         elapsed: 107.851423 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the controller pod is deleted] ************************************
2020-01-23T10:00:53.466671 (delta: 0.091372)         elapsed: 107.942848 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the replica-pod is deleted] ***************************************
2020-01-23T10:00:53.574005 (delta: 0.107271)         elapsed: 108.050182 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the application namespace] ****************************************
2020-01-23T10:00:53.690470 (delta: 0.11639)         elapsed: 108.166647 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-01-23T10:00:53.820719 (delta: 0.130181)         elapsed: 108.296896 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-01-23T10:00:54.004659 (delta: 0.183872)         elapsed: 108.480836 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-23T10:00:54.250356 (delta: 0.245593)         elapsed: 108.726533 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T10:00:54.322320 (delta: 0.07191)         elapsed: 108.798497 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T10:00:54.404425 (delta: 0.082051)         elapsed: 108.880602 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-23T10:00:54.505168 (delta: 0.100678)         elapsed: 108.981345 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "67470bfee53044f291d92df7b4e6ccc84185d121", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4ccf0fbb1009f2010a3badedc54f1aed", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1579773654.6-156391562256441/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T10:00:57.189551 (delta: 2.684311)         elapsed: 111.665728 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.965281", "end": "2020-01-23 10:00:58.591104", "rc": 0, "start": "2020-01-23 10:00:57.625823", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-busybox \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-busybox ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T10:00:58.658576 (delta: 1.468947)         elapsed: 113.134753 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-23T05:26:35Z", "generation": 30, "name": "jiva-csi-busybox", "resourceVersion": "330983", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-busybox", "uid": "ed2f5eff-019b-4d1b-b532-18e3eb74cd69"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=28   changed=19   unreachable=0    failed=0   

2020-01-23T10:00:59.728342 (delta: 1.069719)         elapsed: 114.204519 ****** 
=============================================================================== 
```

logs for deprovisioning of jiva-csi-volume
```
PLAY [localhost] ***************************************************************
2020-01-23T09:42:05.433920 (delta: 0.064854)         elapsed: 0.064854 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-01-23T09:42:05.448235 (delta: 0.014275)         elapsed: 0.079169 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-01-23T09:42:15.020164 (delta: 9.571909)         elapsed: 9.651098 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-01-23T09:42:15.139206 (delta: 0.118991)         elapsed: 9.77014 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-01-23T09:42:15.229097 (delta: 0.089838)         elapsed: 9.860031 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-01-23T09:42:15.329207 (delta: 0.100055)         elapsed: 9.960141 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-23T09:42:15.567309 (delta: 0.23803)         elapsed: 10.198243 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d642b0604da4041b7b89e45064fbc4c19185ac73", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "e5d0f9fd49c829bf7a4ffc59d2451254", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1579772535.68-223590685752552/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T09:42:16.795288 (delta: 1.2279)         elapsed: 11.426222 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.003818", "end": "2020-01-23 09:42:18.255584", "rc": 0, "start": "2020-01-23 09:42:17.251766", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-busybox \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-busybox ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T09:42:18.354834 (delta: 1.55947)         elapsed: 12.985768 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-23T05:26:35Z", "generation": 27, "name": "jiva-csi-busybox", "resourceVersion": "325574", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-busybox", "uid": "ed2f5eff-019b-4d1b-b532-18e3eb74cd69"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-23T09:42:19.920511 (delta: 1.565605)         elapsed: 14.551445 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T09:42:20.051609 (delta: 0.130625)         elapsed: 14.682543 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T09:42:20.189236 (delta: 0.137545)         elapsed: 14.82017 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-01-23T09:42:20.318546 (delta: 0.129222)         elapsed: 14.94948 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the provider storage class is present] *************************
2020-01-23T09:42:20.469849 (delta: 0.151168)         elapsed: 15.100783 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the pvc template with the variables.] *****************************
2020-01-23T09:42:20.634658 (delta: 0.164728)         elapsed: 15.265592 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Create Persistent Volume Claim] ******************************************
2020-01-23T09:42:20.736492 (delta: 0.101727)         elapsed: 15.367426 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the busybox app template with the variables.] *********************
2020-01-23T09:42:20.830637 (delta: 0.09409)         elapsed: 15.461571 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy busybox application on top of the created pvc] ********************
2020-01-23T09:42:20.924706 (delta: 0.094004)         elapsed: 15.55564 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the application pod status] ***************************************
2020-01-23T09:42:21.033948 (delta: 0.109184)         elapsed: 15.664882 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the volume name] **************************************************
2020-01-23T09:42:21.186125 (delta: 0.152119)         elapsed: 15.817059 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the controller pod name in operator namespace] ********************
2020-01-23T09:42:21.337637 (delta: 0.151431)         elapsed: 15.968571 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the replica count of the persistent volume] ***********************
2020-01-23T09:42:21.501528 (delta: 0.163803)         elapsed: 16.132462 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Recording the replica count of the persistent volume] ********************
2020-01-23T09:42:21.661261 (delta: 0.159643)         elapsed: 16.292195 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the controller pod is running] ************************************
2020-01-23T09:42:21.824429 (delta: 0.163081)         elapsed: 16.455363 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify all the replica-pod is running] ***********************************
2020-01-23T09:42:21.988860 (delta: 0.164011)         elapsed: 16.619794 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the application deployment] ***************************************
2020-01-23T09:42:22.144129 (delta: 0.155192)         elapsed: 16.775063 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete deployment busybox -n sam", "delta": "0:00:01.253614", "end": "2020-01-23 09:42:23.870049", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:42:22.616435", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"busybox\" deleted", "stdout_lines": ["deployment.apps \"busybox\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
2020-01-23T09:42:24.021139 (delta: 1.876928)         elapsed: 18.652073 ******* 
FAILED - RETRYING: Verify if the application pod is deleted (30 retries left).
FAILED - RETRYING: Verify if the application pod is deleted (29 retries left).
FAILED - RETRYING: Verify if the application pod is deleted (28 retries left).
FAILED - RETRYING: Verify if the application pod is deleted (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pod -n sam -l app=jiva-csi --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.091411", "end": "2020-01-23 09:43:10.794406", "rc": 0, "start": "2020-01-23 09:43:09.702995", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the volume name] **************************************************
2020-01-23T09:43:10.878845 (delta: 46.857624)         elapsed: 65.509779 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi -n sam --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.872597", "end": "2020-01-23 09:43:12.071231", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:43:11.198634", "stderr": "", "stderr_lines": [], "stdout": "pvc-51c535a1-bfd2-4caa-a387-7407936c3c6e", "stdout_lines": ["pvc-51c535a1-bfd2-4caa-a387-7407936c3c6e"]}

TASK [Delete the application pvc] **********************************************
2020-01-23T09:43:12.174114 (delta: 1.295209)         elapsed: 66.805048 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc csi -n sam", "delta": "0:00:00.969514", "end": "2020-01-23 09:43:13.531972", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:43:12.562458", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"csi\" deleted", "stdout_lines": ["persistentvolumeclaim \"csi\" deleted"]}

TASK [Verify if the application pvc is deleted] ********************************
2020-01-23T09:43:13.643417 (delta: 1.469251)         elapsed: 68.274351 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc csi -n sam", "delta": "0:00:00.979186", "end": "2020-01-23 09:43:14.851330", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2020-01-23 09:43:13.872144", "stderr": "Error from server (NotFound): persistentvolumeclaims \"csi\" not found", "stderr_lines": ["Error from server (NotFound): persistentvolumeclaims \"csi\" not found"], "stdout": "", "stdout_lines": []}

TASK [Verify the controller pod is deleted] ************************************
2020-01-23T09:43:14.954798 (delta: 1.311243)         elapsed: 69.585732 ******* 
FAILED - RETRYING: Verify the controller pod is deleted (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/component=jiva-controller,openebs.io/persistent-volume=\"pvc-51c535a1-bfd2-4caa-a387-7407936c3c6e\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.064118", "end": "2020-01-23 09:43:27.655900", "rc": 0, "start": "2020-01-23 09:43:26.591782", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify the replica-pod is deleted] ***************************************
2020-01-23T09:43:27.739340 (delta: 12.784486)         elapsed: 82.370274 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/component=jiva-replica,openebs.io/persistent-volume=\"pvc-51c535a1-bfd2-4caa-a387-7407936c3c6e\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.027258", "end": "2020-01-23 09:43:28.998142", "rc": 0, "start": "2020-01-23 09:43:27.970884", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Delete the application namespace] ****************************************
2020-01-23T09:43:29.090179 (delta: 1.350783)         elapsed: 83.721113 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete namespace sam", "delta": "0:00:06.576075", "end": "2020-01-23 09:43:36.045382", "failed_when_result": false, "rc": 0, "start": "2020-01-23 09:43:29.469307", "stderr": "", "stderr_lines": [], "stdout": "namespace \"sam\" deleted", "stdout_lines": ["namespace \"sam\" deleted"]}

TASK [set_fact] ****************************************************************
2020-01-23T09:43:36.186275 (delta: 7.096033)         elapsed: 90.817209 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-01-23T09:43:36.287624 (delta: 0.101273)         elapsed: 90.918558 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-01-23T09:43:36.450058 (delta: 0.162384)         elapsed: 91.080992 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T09:43:36.519844 (delta: 0.06973)         elapsed: 91.150778 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T09:43:36.594701 (delta: 0.074808)         elapsed: 91.225635 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-01-23T09:43:36.698118 (delta: 0.103322)         elapsed: 91.329052 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "67470bfee53044f291d92df7b4e6ccc84185d121", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4ccf0fbb1009f2010a3badedc54f1aed", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1579772616.79-231160434676089/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-01-23T09:43:39.013034 (delta: 2.314852)         elapsed: 93.643968 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.745232", "end": "2020-01-23 09:43:40.022833", "rc": 0, "start": "2020-01-23 09:43:39.277601", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-csi-busybox \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-csi-busybox ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-01-23T09:43:40.091502 (delta: 1.078194)         elapsed: 94.722436 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-23T05:26:35Z", "generation": 28, "name": "jiva-csi-busybox", "resourceVersion": "326095", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-csi-busybox", "uid": "ed2f5eff-019b-4d1b-b532-18e3eb74cd69"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=19   changed=14   unreachable=0    failed=0   

2020-01-23T09:43:41.199151 (delta: 1.107593)         elapsed: 95.830085 ******* 
=============================================================================== 
```