### PR TITLE
feat(experiment): Implemented litmus experiment to scaleup the cStor CSPC pool

### DIFF
--- a/experiments/functional/day2_ops/cspc_pool/pool_scaleup/add_blockdevice.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaleup/add_blockdevice.yml
@@ -1,0 +1,64 @@
+---
+    ## TODO: Obtain the blockdevice based on the state as Active and the disk size
+
+    - name: Getting the Unclaimed block-device from each node
+      shell: >
+        kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ outer_item }} 
+        -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n "{{ disk_count }}"
+      register: blockDevice
+      until: "((blockDevice.stdout_lines|unique)|length) == {{ disk_count }}"
+      delay: 5
+      retries: 10
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "stripe", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "stripe" }]}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "stripe"
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "mirror", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "mirror" }]}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "mirror"
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "raidz", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'", "capacity": "", "devLink": "" },,{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "raidz" }]}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "raidz1"
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "raidz2", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[3] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[4] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[5] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "raidz2" }]}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "raidz2"
+
+    - name: Check if the newly added Blockdevice is in Claimed state
+      shell: >
+        kubectl get blockdevice -n {{ operator_ns }} {{ item }}
+        --no-headers -o custom-columns=:.status.claimState
+      args:
+        executable: /bin/bash
+      register: bd_state
+      with_items:
+        - "{{ blockDevice.stdout_lines }}"
+      until: "'Claimed' in bd_state.stdout"
+      delay: 5
+      retries: 60

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaleup/run_litmus_test.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaleup/run_litmus_test.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-cspc-pool-scaleup-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cstor-cspc-pool-scaleup
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # Provide POOL_NAME to expand
+          - name: POOL_NAME
+            value: ""
+
+           # Provide the value for POOL_TYPE to expand
+           # stripe,mirror,raidz1,raidz2
+          - name: POOL_TYPE
+            value: ""
+
+           # Namespace where the OpenEBS components are deployed
+          - name: OPERATOR_NS
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/day2_ops/cspc_pool/pool_scaleup/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaleup/test.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaleup/test.yml
@@ -1,0 +1,119 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+         ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Obtain the kubernetes host names from cspc
+          shell: >
+            kubectl get cspc -n {{ operator_ns }}
+            -o jsonpath='{range .items[?(@.metadata.name=="{{ pool_name }}")]}{range .spec.pools[*].nodeSelector}{.kubernetes\.io\/hostname}{"\n"}{end}'
+          register: nodes
+
+        - name: Obtain the CSPI name to verify the status
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: cspi_name
+
+        - name: Verify the status of CSPI before the pool scaleup
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
+          args:
+            executable: /bin/bash
+          register: cspi_status
+          with_items: "{{ cspi_name.stdout_lines }}"
+          until: "'ONLINE' in cspi_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Obtain the names of the all nodes
+          shell: kubectl get nodes --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: node_name
+      
+        - name: Obtain the node which are free to create to pools
+          set_fact:
+             free_node: "{{ node_name.stdout_lines | difference(nodes.stdout_lines) }}"
+
+        - name: Select random node from the list of nodes as target node
+          set_fact:
+            target_node: "{{ item }}"
+          with_random_choice: "{{ free_node }}"              
+         
+        - name: set the value for the disk count to fetch the unclaimed blockDevice from each node
+          set_fact:
+             disk_count: "{{ item.value.count }}"
+          loop: "{{ lookup('dict', bd_count) }}"
+          when: "'{{ pool_type }}' in item.key"
+
+        - name: Add the block devices and patch the CSPC to scaleup the pool
+          include_tasks: add_blockdevice.yml
+          with_items: "{{ target_node }}"
+          loop_control:
+            loop_var: outer_item
+
+        - name: Verify the status of newly created CSPI
+          shell: kubectl get cspi -n {{ operator_ns }} -l 'kubernetes.io/hostname in ({{ item }}),openebs.io/cstor-pool-cluster in ({{ pool_name }})' --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: new_cspi_status
+          with_items: "{{ target_node }}"
+          until: "'ONLINE' in new_cspi_status.stdout"
+          delay: 5
+          retries: 30          
+
+        - name: Verify the status of existing CSPI after the pool scaleup
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
+          args:
+            executable: /bin/bash
+          register: cspi_status
+          with_items: "{{ cspi_name.stdout_lines }}"
+          until: "'ONLINE' in cspi_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Verify the status of newly created CSPI
+          shell: kubectl get cspi -n {{ operator_ns }} -l 'kubernetes.io/hostname in ({{ target_node }}),openebs.io/cstor-pool-cluster in ({{ pool_name }})' --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: new_cspi_name
+
+        - name: Verify if new cStor Pool pod is Running 
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l 'openebs.io/cstor-pool-instance in ({{ new_cspi_name.stdout }}),openebs.io/cstor-pool-cluster in ({{ pool_name }})' --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: new_pool_pod
+          until: "'Running' in new_pool_pod.stdout"
+          retries: 30
+          delay: 10
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+          - set_fact:
+              flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaleup/test_vars.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaleup/test_vars.yml
@@ -1,0 +1,16 @@
+# Test-specific parameters
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+test_name: cstor-cspc-pool-scaleup
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_type: "{{ lookup('env','POOL_TYPE') }}"
+
+bd_count:
+   stripe:
+      count: 1
+   mirror:
+      count: 2
+   raidz1:
+      count: 3
+   raidz2:
+      count: 6
+


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included the litmus experiment to scale up the pool
- Obtaining the host-name from the cspc spec.
- From the host name Obtaining the Node names where the pools are not created.
- Fetch the blockdevice from the node where to create the pool and patch the cspc  to scaleup the pool.

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
user@user-Lenovo-ideapad-320-15IKB:~/learn/sathya-pr/maya-io/litmus-1/experiments/functional/day2_ops/cspc_pool/pool_scaleup$ kubectl logs -f cstor-cspc-pool-scaleup-gkx29-nklt4 -n litmus

No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-02-03T04:03:32.387065 (delta: 0.051833)         elapsed: 0.051833 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-02-03T04:03:32.398471 (delta: 0.011351)         elapsed: 0.063239 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-02-03T04:03:38.588578 (delta: 6.190053)         elapsed: 6.253346 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-02-03T04:03:38.648481 (delta: 0.05987)         elapsed: 6.313249 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-02-03T04:03:38.698856 (delta: 0.050336)         elapsed: 6.363624 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-02-03T04:03:38.745027 (delta: 0.046136)         elapsed: 6.409795 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-03T04:03:38.811860 (delta: 0.066792)         elapsed: 6.476628 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "1a8e4b649a66b43e58d4fb09499ddb667a702d15", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b765ac0dd448c864e93bd7831aaeec84", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1580702618.91-120324715613699/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-03T04:03:39.476230 (delta: 0.664327)         elapsed: 7.140998 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.602340", "end": "2020-02-03 04:03:40.352193", "rc": 0, "start": "2020-02-03 04:03:39.749853", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-cspc-pool-scaleup \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-cspc-pool-scaleup ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-03T04:03:40.394560 (delta: 0.918287)         elapsed: 8.059328 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-31T05:22:06Z", "generation": 31, "name": "cstor-cspc-pool-scaleup", "resourceVersion": "1823088", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-cspc-pool-scaleup", "uid": "4d20e6f5-2cb7-4e6c-8348-3964a6f4cf87"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-03T04:03:41.619818 (delta: 1.225222)         elapsed: 9.284586 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-03T04:03:41.675523 (delta: 0.055645)         elapsed: 9.340291 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-03T04:03:41.716746 (delta: 0.041166)         elapsed: 9.381514 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the kubernetes host names from cspc] ******************************
2020-02-03T04:03:41.757837 (delta: 0.041052)         elapsed: 9.422605 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspc -n openebs -o jsonpath='{range .items[?(@.metadata.name==\"cstor-cspc-disk-pool\")]}{range .spec.pools[*].nodeSelector}{.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:00.974945", "end": "2020-02-03 04:03:42.887150", "rc": 0, "start": "2020-02-03 04:03:41.912205", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-test-default-pool-ec623215-fp6m\ngke-e2e-test-default-pool-ec623215-dc1j", "stdout_lines": ["gke-e2e-test-default-pool-ec623215-fp6m", "gke-e2e-test-default-pool-ec623215-dc1j"]}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-02-03T04:03:42.929264 (delta: 1.171387)         elapsed: 10.594032 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.767105", "end": "2020-02-03 04:03:43.870736", "rc": 0, "start": "2020-02-03 04:03:43.103631", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-hk99\ncstor-cspc-disk-pool-vvh6", "stdout_lines": ["cstor-cspc-disk-pool-hk99", "cstor-cspc-disk-pool-vvh6"]}

TASK [Verify the status of CSPI before the pool scaleup] ***********************
2020-02-03T04:03:43.918364 (delta: 0.989033)         elapsed: 11.583132 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-hk99) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-hk99\")].status.phase}'", "delta": "0:00:00.671751", "end": "2020-02-03 04:03:44.764937", "item": "cstor-cspc-disk-pool-hk99", "rc": 0, "start": "2020-02-03 04:03:44.093186", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-vvh6) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-vvh6\")].status.phase}'", "delta": "0:00:00.955539", "end": "2020-02-03 04:03:45.866848", "item": "cstor-cspc-disk-pool-vvh6", "rc": 0, "start": "2020-02-03 04:03:44.911309", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Obtain the names of the all nodes] ***************************************
2020-02-03T04:03:45.916801 (delta: 1.998381)         elapsed: 13.581569 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.719746", "end": "2020-02-03 04:03:46.792035", "rc": 0, "start": "2020-02-03 04:03:46.072289", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-test-default-pool-ec623215-dc1j\ngke-e2e-test-default-pool-ec623215-fp6m\ngke-e2e-test-default-pool-ec623215-pbhc", "stdout_lines": ["gke-e2e-test-default-pool-ec623215-dc1j", "gke-e2e-test-default-pool-ec623215-fp6m", "gke-e2e-test-default-pool-ec623215-pbhc"]}

TASK [Obtain the node which are free to create to pools] ***********************
2020-02-03T04:03:46.834956 (delta: 0.918114)         elapsed: 14.499724 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"free_node": ["gke-e2e-test-default-pool-ec623215-pbhc"]}, "changed": false}

TASK [Select random node from the list of nodes as target node] ****************
2020-02-03T04:03:46.903079 (delta: 0.068084)         elapsed: 14.567847 ******* 
ok: [127.0.0.1] => (item=gke-e2e-test-default-pool-ec623215-pbhc) => {"ansible_facts": {"target_node": "gke-e2e-test-default-pool-ec623215-pbhc"}, "changed": false, "item": "gke-e2e-test-default-pool-ec623215-pbhc"}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-02-03T04:03:46.980140 (delta: 0.077021)         elapsed: 14.644908 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz1', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz1", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}}) => {"ansible_facts": {"disk_count": "1"}, "changed": false, "item": {"key": "stripe", "value": {"count": 1}}}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}

TASK [Add the block devices and patch the CSPC to scaleup the pool] ************
2020-02-03T04:03:47.168994 (delta: 0.188814)         elapsed: 14.833762 ******* 
included: /experiments/functional/day2_ops/cspc_pool/pool_scaleup/add_blockdevice.yml for 127.0.0.1

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-02-03T04:03:47.296284 (delta: 0.12724)         elapsed: 14.961052 ******** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: ((blockDevice.stdout_lines|unique)|length) == {{
disk_count }}
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=gke-e2e-test-default-pool-ec623215-pbhc -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:00.871350", "end": "2020-02-03 04:03:48.320053", "rc": 0, "start": "2020-02-03 04:03:47.448703", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-236bed7a1d220710a066a9d2111ffc6a", "stdout_lines": ["blockdevice-236bed7a1d220710a066a9d2111ffc6a"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-02-03T04:03:48.369308 (delta: 1.072982)         elapsed: 16.034076 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cspc -n openebs cstor-cspc-disk-pool --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/pools/0\", \"value\": {\"nodeSelector\": {\"kubernetes.io/hostname\": \"'gke-e2e-test-default-pool-ec623215-pbhc'\"},   \"poolConfig\": {\"cacheFile\": \"\", \"compression\": \"off\", \"defaultRaidGroupType\": \"stripe\", \"overProvisioning\": false, \"priorityClassName\": \"\"}, \"raidGroups\": [{\"blockDevices\": [{\"blockDeviceName\": \"'blockdevice-236bed7a1d220710a066a9d2111ffc6a'\", \"capacity\": \"\", \"devLink\": \"\" }], \"isReadCache\": false, \"isSpare\": false, \"isWriteCache\": false, \"type\": \"stripe\" }]}}]'", "delta": "0:00:00.867723", "end": "2020-02-03 04:03:49.406528", "failed_when_result": false, "rc": 0, "start": "2020-02-03 04:03:48.538805", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.openebs.io/cstor-cspc-disk-pool patched", "stdout_lines": ["cstorpoolcluster.openebs.io/cstor-cspc-disk-pool patched"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-02-03T04:03:49.471581 (delta: 1.102234)         elapsed: 17.136349 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-02-03T04:03:49.520168 (delta: 0.048549)         elapsed: 17.184936 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-02-03T04:03:49.568916 (delta: 0.048702)         elapsed: 17.233684 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the newly added Blockdevice is in Claimed state] ****************
2020-02-03T04:03:49.616343 (delta: 0.047389)         elapsed: 17.281111 ******* 
changed: [127.0.0.1] => (item=blockdevice-236bed7a1d220710a066a9d2111ffc6a) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-236bed7a1d220710a066a9d2111ffc6a --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.749012", "end": "2020-02-03 04:03:50.530042", "item": "blockdevice-236bed7a1d220710a066a9d2111ffc6a", "rc": 0, "start": "2020-02-03 04:03:49.781030", "stderr": "", "stderr_lines": [], "stdout": "Claimed", "stdout_lines": ["Claimed"]}

TASK [Verify the status of newly created CSPI] *********************************
2020-02-03T04:03:50.583274 (delta: 0.966891)         elapsed: 18.248042 ******* 
FAILED - RETRYING: Verify the status of newly created CSPI (30 retries left).
FAILED - RETRYING: Verify the status of newly created CSPI (29 retries left).
changed: [127.0.0.1] => (item=gke-e2e-test-default-pool-ec623215-pbhc) => {"attempts": 3, "changed": true, "cmd": "kubectl get cspi -n openebs -l 'kubernetes.io/hostname in (gke-e2e-test-default-pool-ec623215-pbhc),openebs.io/cstor-pool-cluster in (cstor-cspc-disk-pool)' --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.789285", "end": "2020-02-03 04:04:04.403173", "item": "gke-e2e-test-default-pool-ec623215-pbhc", "rc": 0, "start": "2020-02-03 04:04:03.613888", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify the status of existing CSPI after the pool scaleup] ***************
2020-02-03T04:04:04.453575 (delta: 13.870258)         elapsed: 32.118343 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-hk99) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-hk99\")].status.phase}'", "delta": "0:00:01.014180", "end": "2020-02-03 04:04:05.637926", "item": "cstor-cspc-disk-pool-hk99", "rc": 0, "start": "2020-02-03 04:04:04.623746", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-vvh6) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-vvh6\")].status.phase}'", "delta": "0:00:00.766011", "end": "2020-02-03 04:04:06.552150", "item": "cstor-cspc-disk-pool-vvh6", "rc": 0, "start": "2020-02-03 04:04:05.786139", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify the status of newly created CSPI] *********************************
2020-02-03T04:04:06.601010 (delta: 2.147393)         elapsed: 34.265778 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l 'kubernetes.io/hostname in (gke-e2e-test-default-pool-ec623215-pbhc),openebs.io/cstor-pool-cluster in (cstor-cspc-disk-pool)' --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.763869", "end": "2020-02-03 04:04:07.530685", "rc": 0, "start": "2020-02-03 04:04:06.766816", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-fl2b", "stdout_lines": ["cstor-cspc-disk-pool-fl2b"]}

TASK [Verify if new cStor Pool pod is Running] *********************************
2020-02-03T04:04:07.607901 (delta: 1.00685)         elapsed: 35.272669 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l 'openebs.io/cstor-pool-instance in (cstor-cspc-disk-pool-fl2b),openebs.io/cstor-pool-cluster in (cstor-cspc-disk-pool)' --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.834536", "end": "2020-02-03 04:04:08.949043", "rc": 0, "start": "2020-02-03 04:04:08.114507", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
2020-02-03T04:04:08.997675 (delta: 1.389722)         elapsed: 36.662443 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-02-03T04:04:09.072223 (delta: 0.074507)         elapsed: 36.736991 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-03T04:04:09.143559 (delta: 0.071296)         elapsed: 36.808327 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-03T04:04:09.208477 (delta: 0.064856)         elapsed: 36.873245 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-03T04:04:09.255932 (delta: 0.047413)         elapsed: 36.9207 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-03T04:04:09.304085 (delta: 0.048107)         elapsed: 36.968853 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7b1b3e752388005f23033adc0db74776272988bf", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8f82d853ba1845163a00d1c341fc9226", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1580702649.36-279627308285560/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-03T04:04:10.860314 (delta: 1.556186)         elapsed: 38.525082 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.665988", "end": "2020-02-03 04:04:11.692867", "rc": 0, "start": "2020-02-03 04:04:11.026879", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-cspc-pool-scaleup \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-cspc-pool-scaleup ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-03T04:04:11.739851 (delta: 0.879499)         elapsed: 39.404619 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-01-31T05:22:06Z", "generation": 32, "name": "cstor-cspc-pool-scaleup", "resourceVersion": "1823281", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-cspc-pool-scaleup", "uid": "4d20e6f5-2cb7-4e6c-8348-3964a6f4cf87"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=26   changed=17   unreachable=0    failed=0   

2020-02-03T04:04:12.661503 (delta: 0.921608)         elapsed: 40.326271 ******* 
=============================================================================== 
```