### PR TITLE
refactor[litmusbook]: Modified and Included a Readme for openebs provision litmusbook

### DIFF
--- a/providers/openebs/installers/operator/openebs-provision/README.md
+++ b/providers/openebs/installers/operator/openebs-provision/README.md
@@ -1,0 +1,112 @@
+## litmus job for Provisioning OpenEBS
+
+This litmus job installs OpenEBS on a litmus enabled cluster. This job first scans the environment variables for explicitly passed image names of OpenEBS and then downloads the openebs-operator.yaml. After that it applies the operator and waits for all the pods to get into running state before exiting. 
+
+### Prerequisites
+
+- The cluster should be litmus enabled. To enable the litmus apply the `rbac.yaml` and `crds.yaml` from [here](https://github.com/mayadata-io/litmus/tree/master/hack), using the following commands:
+
+  ```
+    kubectl apply -f rbac.yaml
+  ```
+  ```
+    kubectl apply -f crds.yaml
+  ```
+
+### Steps to Install OpenEBS:
+
+ - Create Litmus Job to deploy the OpenEBS.
+  
+  ```
+  kubectl create -f run_litmus_test.yml
+  ```
+
+ - Check the status of Job pod created in Litmus namesapce.
+
+    ```
+     kubectl get pod -n litmus
+    ```
+
+ - Once the litmus pod status is completed check the OpenEBS components are installed successfully in openebs namespace.
+     
+    ```
+     kubectl get pods -n openebs
+    ```
+    ```
+     user@user-Lenovo-ideapad-320-15IKB:~$ kubectl get pods -n openebs
+     NAME                                                              READY   STATUS      RESTARTS   AGE
+     cspc-operator-5dd4b95486-4v4nt                                    1/1     Running     0          135m
+     cvc-operator-6d9dfff6d7-t5dfp                                     1/1     Running     0          135m
+     maya-apiserver-6df9b6cfb4-7dztx                                   1/1     Running     0          135m
+     openebs-admission-server-76b94d8895-9jh87                         1/1     Running     0          135m
+     openebs-localpv-provisioner-7b75dcb8df-ptvll                      1/1     Running     0          135m
+     openebs-ndm-627nk                                                 1/1     Running     0          134m
+     openebs-ndm-88dvx                                                 1/1     Running     0          135m
+     openebs-ndm-operator-99cbdf5dc-wp7kw                              1/1     Running     0          135m
+     openebs-ndm-p7n9w                                                 1/1     Running     0          135m
+     openebs-provisioner-9568498d9-xc45v                               1/1     Running     0          135m
+     openebs-snapshot-operator-66479cf4-twfl2                          2/2     Running     0          135m
+
+   ```
+  
+### Note:
+
+Image names for openebs-operator can be explicitly passed by environment variable in the run_litmus_test.yml .
+
+Example:
+
+```yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-openebs-provision-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: openebs-provision
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # OpenEBS Version
+          - name: RELEASE_VERSION
+            value: 1.6.0
+            
+            # Namespace where OpenEBS is deployed
+          - name: OPERATOR_NS
+            value: openebs
+
+            #  Image tag for NDM (optional)
+          - name: NDM_TAG
+            value: ""
+ 
+            # Mode the deploy the OpenEBS (operator or helm)
+          - name: DEPLOY_TYPE
+            value: operator
+
+          - name: ACTION
+            value: provision 
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/openebs/installers/operator/openebs-provision/test.yml -i /etc/ansible/hosts -v; exit 0"]
+```
+
+### Troubleshooting
+- In case of unsuccessful/incomplete installation view the logs of the litmus job.
+   ```
+    kubectl logs -f <litmus_job_pod_name> -n litmus
+   ```
+

--- a/providers/openebs/installers/operator/openebs-provision/run_litmus_test.yml
+++ b/providers/openebs/installers/operator/openebs-provision/run_litmus_test.yml
@@ -29,15 +29,18 @@ spec:
             
             # Namespace where OpenEBS is deployed
           - name: OPERATOR_NS
-            value: ""
+            value: openebs
 
-            #  Image tag for NDM
+            #  Image tag for NDM (optional)
           - name: NDM_TAG
             value: ""
 
+            # Mode of the Deploy (operator or helm)
           - name: DEPLOY_TYPE
             value: ""
 
+            # To deploy OpenEBS components ACTION could be 'provision'
+            # To remove the OpenEBS ACTION could be 'deprovision'
           - name: ACTION
             value: provision 
 

--- a/providers/openebs/installers/operator/openebs-provision/test.yml
+++ b/providers/openebs/installers/operator/openebs-provision/test.yml
@@ -310,6 +310,27 @@
           when: lookup('env','ACTION') == "provision"
 
         - block:
+
+            - name: Downloading openebs cspc-operator.yaml
+              get_url:
+                url: "{{ cspc_operator_link }}"
+                dest: "{{ playbook_dir }}/{{ cspc_operator }}"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3                
+
+            - name: Downloading openebs-operator.yaml
+              get_url:
+                url: "{{ openebs_operator_link }}"
+                dest: "{{ playbook_dir }}/{{ openebs_operator }}"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3
+
             - name: Cleaning cspc operator
               shell: kubectl delete -f {{ cspc_operator }}
               args:


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the tasks to deprovision openebs
- Included Readme file for openebs provision litmusbook

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
