### PR TITLE
refactor[yaml]: Implemented litmusbook for volume remount of jiva-csi volume

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/chaosutil.j2
+++ b/experiments/chaos/openebs_target_network_loss/chaosutil.j2
@@ -16,4 +16,10 @@
   {% endif %}
 {% endif %}
 
+{% if stg_prov is defined and stg_prov == 'jiva.csi.openebs.io' %}
+  {% if stg_engine is defined and stg_engine == 'jiva' %}
+    chaosutil: openebs/inject_packet_loss_tc.yml
+  {% endif %}
+{% endif %}
+
 

--- a/experiments/chaos/openebs_target_network_loss/jiva-csi-patch.j2
+++ b/experiments/chaos/openebs_target_network_loss/jiva-csi-patch.j2
@@ -1,0 +1,16 @@
+{
+ "spec": {
+  "template": {
+    "spec": {
+     "containers": [
+      {
+       "name": "jiva-controller",
+       "securityContext": {
+          "privileged": true
+       }
+      }
+     ]
+    }
+  }
+ }
+}

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -134,7 +134,52 @@
               delay: 3
               retries: 20
                                       
-          when: stg_engine == 'jiva'          
+          when: 
+            - stg_engine == 'jiva'
+            - stg_prov == 'openebs.io/provisioner-iscsi'          
+
+        - block:
+
+            - name: Identify the patch to be invoked
+              template:
+                src: jiva-csi-patch.j2
+                dest: jiva-csi-patch.yml
+
+            - name: Patching jiva controller deployment to allow security privileged
+              shell: >
+                kubectl patch deployment {{ pv.stdout }}-jiva-ctrl -n {{ operator_ns }}
+                --patch "$(cat jiva-csi-patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"
+            
+            - name: Wait for 10s post fault injection 
+              wait_for:
+                timeout: 10
+
+            - name: Identify the jiva controller pod belonging to the PV
+              shell: > 
+                kubectl get pods -l openebs.io/component=jiva-controller
+                -n {{ operator_ns }} --no-headers -o custom-columns=:.metadata.name
+                | grep {{ pv.stdout }} 
+              args:
+                executable: /bin/bash
+              register: controller_pod
+
+            - name: Check for the jiva controller container status
+              shell: >
+                kubectl get pods {{ controller_pod.stdout }} -n {{ operator_ns }} 
+                -o jsonpath='{.status.containerStatuses[?(@.name=="jiva-controller")].state}' | grep running
+              args:
+                executable: /bin/bash
+              register: container_status
+              until: "'running' in container_status.stdout"
+              delay: 3
+              retries: 20
+                                      
+          when: 
+            - stg_engine == 'jiva'
+            - stg_prov == 'jiva.csi.openebs.io'          
+    
 
         ## STORAGE FAULT INJECTION
 
@@ -144,7 +189,9 @@
             app_pvc: "{{ pvc }}"
             network_delay: "{{ n_delay }}"
             chaos_duration: "{{ c_duration }}"
-          when: cri == 'docker'
+          when: 
+            - cri == 'docker'
+            - stg_prov == 'openebs.io/provisioner-iscsi'
 
         - include: "{{ chaos_util_path }}"
           vars:
@@ -165,11 +212,23 @@
           when: 
             - cri == 'containerd' or cri =='cri-o'  
             - stg_engine == 'jiva'
+            - stg_prov == 'openebs.io/provisioner-iscsi'
+
+        - include: "{{ chaos_util_path }}"
+          vars:
+            status: "induce"
+            target_pod: "{{ controller_pod.stdout }}"
+            operator_namespace: "{{ operator_ns }}"
+            containername: "jiva-controller"
+          when:   
+            - stg_engine == 'jiva'
+            - stg_prov == 'jiva.csi.openebs.io'
+
 
         - name: Wait for 240s post fault injection 
           wait_for:
             timeout: 240
-          when: cri == 'containerd' or cri =='cri-o'
+          when: cri == 'containerd' or cri =='cri-o' or stg_prov == 'jiva.csi.openebs.io'
 
         - include: "{{ chaos_util_path }}"
           vars:
@@ -190,7 +249,18 @@
           when: 
             - cri == 'containerd' or cri =='cri-o'  
             - stg_engine == 'jiva'
-          
+            - stg_prov == 'openebs.io/provisioner-iscsi'
+
+        - include: "{{ chaos_util_path }}"
+          vars:
+            status: "remove"
+            target_pod: "{{ controller_pod.stdout }}"
+            operator_namespace: "{{ operator_ns }}"
+            containername: "jiva-controller"
+          when:   
+            - stg_engine == 'jiva'
+            - stg_prov == 'jiva.csi.openebs.io'
+
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - block:
@@ -255,6 +325,37 @@
                 pod_name: "{{ app_pod_name.stdout }}"
               when: data_persistence != '' 
           when: stg_prov == 'cstor.csi.openebs.io'
+        
+        - block:
+
+            - name: Verify that the volume is healthy
+              shell: >
+                kubectl get jivavolume {{ pv.stdout }} -n {{ operator_ns }} 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: Status
+              until: "'Ready' in Status.stdout"
+              delay: 5
+              retries: 60
+
+            - name: Verify that the AUT (Application Under Test) is running
+              include_tasks: "/utils/k8s/status_app_pod.yml"
+              vars:
+                app_ns: "{{namespace}}" 
+                app_lkey: "{{ label.split('=')[0] }}"
+                app_lvalue: "{{ label.split('=')[1] }}"       
+                delay: 5
+                retries: 60
+
+            - name: Verify test data
+              include: "{{ data_consistency_util_path }}"
+              vars:
+                status: 'VERIFY'
+                ns: "{{ namespace }}"
+                pod_name: "{{ app_pod_name.stdout }}"
+              when: data_persistence != '' 
+          when: stg_prov == 'jiva.csi.openebs.io'
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
+++ b/experiments/chaos/openebs_target_network_loss/test_prerequisites.yml
@@ -56,6 +56,28 @@
 
     - name: Check for presence & value of cas type annotation
       shell: >
+        kubectl get sc {{ sc }} --no-headers
+        -o jsonpath='{.parameters.cas-type}'
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "jiva.csi.openebs.io"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
         kubectl get pv {{ pv.stdout }} --no-headers
         -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
       args:

--- a/experiments/functional/jiva-csi/jiva-csi-deploy-busybox/jiva-csi-busybox-sc.j2
+++ b/experiments/functional/jiva-csi/jiva-csi-deploy-busybox/jiva-csi-busybox-sc.j2
@@ -4,6 +4,7 @@ kind: StorageClass
 metadata:
   name: "{{ storage_class }}"
 provisioner: jiva.csi.openebs.io
+allowVolumeExpansion: true
 parameters:
   cas-type: "jiva"
   replicaCount: "{{ replica_count }}"

--- a/experiments/functional/jiva-csi/jiva-csi-deploy-busybox/run_litmus_test.yml
+++ b/experiments/functional/jiva-csi/jiva-csi-deploy-busybox/run_litmus_test.yml
@@ -48,4 +48,4 @@ spec:
             value: provision  
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./providers/jiva-csi-provisioner/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/functional/jiva-csi/jiva-csi-deploy-busybox/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/jiva-csi-provisioner/csi-jiva-sc.j2
+++ b/providers/jiva-csi-provisioner/csi-jiva-sc.j2
@@ -4,6 +4,7 @@ kind: StorageClass
 metadata:
   name: "{{ storage_class }}"
 provisioner: jiva.csi.openebs.io
+allowVolumeExpansion: true
 parameters:
   cas-type: "jiva"
   replicaCount: "{{ replica_count }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1. Implemented litmusbook for volume remount of jiva-csi volume.
2. Modified Path/Directory for jiva-csi deploy busybox.
3. Allowed volume expansions in storage class created by jiva-csi provisioner and 
    jiva-csi deploy busybox.
**Special notes for your reviewer**:

```
PLAY [localhost] ***************************************************************
2020-02-06T09:09:18.858275 (delta: 0.065405)         elapsed: 0.065405 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:2
2020-02-06T09:09:18.868563 (delta: 0.01026)         elapsed: 0.075693 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:12
2020-02-06T09:09:24.448417 (delta: 5.579806)         elapsed: 5.655547 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:2
2020-02-06T09:09:24.504300 (delta: 0.055845)         elapsed: 5.71143 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc jiva-csi-pvc -n default --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.106335", "end": "2020-02-06 09:09:25.910864", "rc": 0, "start": "2020-02-06 09:09:24.804529", "stderr": "", "stderr_lines": [], "stdout": "jiva-csi-sc", "stdout_lines": ["jiva-csi-sc"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:10
2020-02-06T09:09:25.954293 (delta: 1.44995)         elapsed: 7.161423 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc jiva-csi-sc --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.744454", "end": "2020-02-06 09:09:26.850276", "rc": 0, "start": "2020-02-06 09:09:26.105822", "stderr": "", "stderr_lines": [], "stdout": "jiva.csi.openebs.io", "stdout_lines": ["jiva.csi.openebs.io"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:18
2020-02-06T09:09:26.942725 (delta: 0.988395)         elapsed: 8.149855 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "jiva-csi-sc"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:22
2020-02-06T09:09:27.047727 (delta: 0.104966)         elapsed: 8.254857 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "jiva.csi.openebs.io"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:27
2020-02-06T09:09:27.111424 (delta: 0.063659)         elapsed: 8.318554 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:35
2020-02-06T09:09:27.154893 (delta: 0.043431)         elapsed: 8.362023 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:43
2020-02-06T09:09:27.213954 (delta: 0.059015)         elapsed: 8.421084 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:49
2020-02-06T09:09:27.257472 (delta: 0.043475)         elapsed: 8.464602 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc jiva-csi-pvc -n default --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.931411", "end": "2020-02-06 09:09:28.364171", "rc": 0, "start": "2020-02-06 09:09:27.432760", "stderr": "", "stderr_lines": [], "stdout": "pvc-738a076c-ba5f-4ee2-98af-102932806025", "stdout_lines": ["pvc-738a076c-ba5f-4ee2-98af-102932806025"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:57
2020-02-06T09:09:28.404954 (delta: 1.147439)         elapsed: 9.612084 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc jiva-csi-sc --no-headers -o jsonpath='{.parameters.cas-type}'", "delta": "0:00:00.700463", "end": "2020-02-06 09:09:29.266919", "rc": 0, "start": "2020-02-06 09:09:28.566456", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:65
2020-02-06T09:09:29.321307 (delta: 0.91631)         elapsed: 10.528437 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:71
2020-02-06T09:09:29.386703 (delta: 0.065356)         elapsed: 10.593833 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:79
2020-02-06T09:09:29.431528 (delta: 0.044783)         elapsed: 10.638658 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:87
2020-02-06T09:09:29.473828 (delta: 0.042258)         elapsed: 10.680958 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:92
2020-02-06T09:09:29.516559 (delta: 0.042689)         elapsed: 10.723689 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "99e75e9ccc211d23bbbd67958b12095304d4b2d7", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "0f8d4cd907e0a338d408264d8ae843c4", "mode": "0644", "owner": "root", "size": 58, "src": "/root/.ansible/tmp/ansible-tmp-1580980169.56-219229734888594/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_loss/test_prerequisites.yml:97
2020-02-06T09:09:30.397661 (delta: 0.881058)         elapsed: 11.604791 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1580980170.44-94723317620469/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:19
2020-02-06T09:09:30.719543 (delta: 0.321844)         elapsed: 11.926673 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:22
2020-02-06T09:09:30.781794 (delta: 0.062208)         elapsed: 11.988924 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/inject_packet_loss_tc.yml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:25
2020-02-06T09:09:30.842100 (delta: 0.060267)         elapsed: 12.04923 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/inject_packet_loss_tc.yml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:29
2020-02-06T09:09:30.905255 (delta: 0.063118)         elapsed: 12.112385 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:36
2020-02-06T09:09:30.980099 (delta: 0.074776)         elapsed: 12.187229 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-02-06T09:09:31.045095 (delta: 0.064958)         elapsed: 12.252225 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-02-06T09:09:31.091312 (delta: 0.046178)         elapsed: 12.298442 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:38
2020-02-06T09:09:31.145539 (delta: 0.054189)         elapsed: 12.352669 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-02-06T09:09:31.323870 (delta: 0.178294)         elapsed: 12.531 ********** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b4a6399a25fbae045154f4a5fa4895e0315d7e06", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0a4d87a3064f79e6407f3c30711a53e4", "mode": "0644", "owner": "root", "size": 457, "src": "/root/.ansible/tmp/ansible-tmp-1580980171.39-2056454201167/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-02-06T09:09:31.678689 (delta: 0.354774)         elapsed: 12.885819 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.605972", "end": "2020-02-06 09:09:32.442477", "rc": 0, "start": "2020-02-06 09:09:31.836505", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/inject_packet_loss_tc \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/inject_packet_loss_tc ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-02-06T09:09:32.482698 (delta: 0.803971)         elapsed: 13.689828 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-06T08:44:03Z", "generation": 5, "name": "openebs-target-network-loss", "resourceVersion": "61632", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-network-loss", "uid": "e7c34926-7dff-4c90-bcb6-431b1b431bb4"}, "spec": {"testMetadata": {"chaostype": "openebs/inject_packet_loss_tc"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-02-06T09:09:33.433092 (delta: 0.950356)         elapsed: 14.640222 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-02-06T09:09:33.501286 (delta: 0.068155)         elapsed: 14.708416 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-02-06T09:09:33.544079 (delta: 0.042754)         elapsed: 14.751209 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:45
2020-02-06T09:09:33.587233 (delta: 0.043113)         elapsed: 14.794363 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : default", 
        "Label        : app=bb", 
        "PVC          : jiva-csi-pvc", 
        "StorageClass : jiva-csi-sc"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:55
2020-02-06T09:09:33.693611 (delta: 0.106341)         elapsed: 14.900741 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-02-06T09:09:33.764162 (delta: 0.070506)         elapsed: 14.971292 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n default -l app=\"bb\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.767630", "end": "2020-02-06 09:09:34.693537", "rc": 0, "start": "2020-02-06 09:09:33.925907", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-02-06T09:04:01Z]]", "stdout_lines": ["map[running:map[startedAt:2020-02-06T09:04:01Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-02-06T09:09:34.740617 (delta: 0.976412)         elapsed: 15.947747 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n default -o jsonpath='{.items[?(@.metadata.labels.app==\"bb\")].status.phase}'", "delta": "0:00:00.707431", "end": "2020-02-06 09:09:35.611448", "rc": 0, "start": "2020-02-06 09:09:34.904017", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:64
2020-02-06T09:09:35.681423 (delta: 0.940773)         elapsed: 16.888553 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n default -l app=bb --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.720627", "end": "2020-02-06 09:09:36.561771", "rc": 0, "start": "2020-02-06 09:09:35.841144", "stderr": "", "stderr_lines": [], "stdout": "busybox-55cd75666c-fmkbg", "stdout_lines": ["busybox-55cd75666c-fmkbg"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:72
2020-02-06T09:09:36.605906 (delta: 0.924416)         elapsed: 17.813036 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2020-02-06T09:09:36.761873 (delta: 0.155927)         elapsed: 17.969003 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/remount bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec busybox-55cd75666c-fmkbg -n default -- sh -c \"dd if=/dev/urandom of=/busybox/remount bs=4k count=1024\"", "delta": "0:00:01.143788", "end": "2020-02-06 09:09:38.081019", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/remount bs=4k count=1024", "rc": 0, "start": "2020-02-06 09:09:36.937231", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.089206 seconds, 44.8MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.089206 seconds, 44.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/remount > /busybox/remount-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec busybox-55cd75666c-fmkbg -n default -- sh -c \"md5sum /busybox/remount > /busybox/remount-pre-chaos-md5\"", "delta": "0:00:00.905973", "end": "2020-02-06 09:09:39.134860", "failed_when_result": false, "item": "md5sum /busybox/remount > /busybox/remount-pre-chaos-md5", "rc": 0, "start": "2020-02-06 09:09:38.228887", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=sync;sync;sync) => {"changed": true, "cmd": "kubectl exec busybox-55cd75666c-fmkbg -n default -- sh -c \"sync;sync;sync\"", "delta": "0:00:00.924247", "end": "2020-02-06 09:09:40.201397", "failed_when_result": false, "item": "sync;sync;sync", "rc": 0, "start": "2020-02-06 09:09:39.277150", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:21
2020-02-06T09:09:40.248703 (delta: 3.486796)         elapsed: 21.455833 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:27
2020-02-06T09:09:40.299377 (delta: 0.050635)         elapsed: 21.506507 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:37
2020-02-06T09:09:40.352338 (delta: 0.052923)         elapsed: 21.559468 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:44
2020-02-06T09:09:40.396637 (delta: 0.044262)         elapsed: 21.603767 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:51
2020-02-06T09:09:40.438144 (delta: 0.041469)         elapsed: 21.645274 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:61
2020-02-06T09:09:40.479961 (delta: 0.041758)         elapsed: 21.687091 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:70
2020-02-06T09:09:40.526111 (delta: 0.046109)         elapsed: 21.733241 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for application] *****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:83
2020-02-06T09:09:40.572098 (delta: 0.045947)         elapsed: 21.779228 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:90
2020-02-06T09:09:40.614969 (delta: 0.042832)         elapsed: 21.822099 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:98
2020-02-06T09:09:40.700600 (delta: 0.08559)         elapsed: 21.90773 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV from application PVC] ******************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:80
2020-02-06T09:09:40.745929 (delta: 0.04529)         elapsed: 21.953059 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc jiva-csi-pvc -o custom-columns=:spec.volumeName -n default --no-headers", "delta": "0:00:00.749231", "end": "2020-02-06 09:09:41.647784", "rc": 0, "start": "2020-02-06 09:09:40.898553", "stderr": "", "stderr_lines": [], "stdout": "pvc-738a076c-ba5f-4ee2-98af-102932806025", "stdout_lines": ["pvc-738a076c-ba5f-4ee2-98af-102932806025"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:89
2020-02-06T09:09:41.711542 (delta: 0.965565)         elapsed: 22.918672 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the patch to be invoked] ****************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:101
2020-02-06T09:09:41.767740 (delta: 0.056155)         elapsed: 22.97487 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching jiva controller deployment to allow security privileged] ********
task path: /experiments/chaos/openebs_target_network_loss/test.yml:106
2020-02-06T09:09:41.826165 (delta: 0.058382)         elapsed: 23.033295 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for 10s post fault injection] ***************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:113
2020-02-06T09:09:41.886468 (delta: 0.060262)         elapsed: 23.093598 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:117
2020-02-06T09:09:41.969004 (delta: 0.08246)         elapsed: 23.176134 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for the jiva controller container status] **************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:126
2020-02-06T09:09:42.043518 (delta: 0.074472)         elapsed: 23.250648 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the patch to be invoked] ****************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:143
2020-02-06T09:09:42.122631 (delta: 0.079068)         elapsed: 23.329761 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "a791369271c58b3354b3747a9291e82742d0542b", "dest": "./jiva-csi-patch.yml", "gid": 0, "group": "root", "md5sum": "3363a61a81defcfb4846834ac64bb686", "mode": "0644", "owner": "root", "size": 202, "src": "/root/.ansible/tmp/ansible-tmp-1580980182.18-63421726685452/source", "state": "file", "uid": 0}

TASK [Patching jiva controller deployment to allow security privileged] ********
task path: /experiments/chaos/openebs_target_network_loss/test.yml:148
2020-02-06T09:09:42.467548 (delta: 0.344876)         elapsed: 23.674678 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch deployment pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl -n openebs --patch \"$(cat jiva-csi-patch.yml)\"", "delta": "0:00:00.819408", "end": "2020-02-06 09:09:43.463135", "failed_when_result": false, "rc": 0, "start": "2020-02-06 09:09:42.643727", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions/pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl patched (no change)", "stdout_lines": ["deployment.extensions/pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl patched (no change)"]}

TASK [Wait for 10s post fault injection] ***************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:155
2020-02-06T09:09:43.557293 (delta: 1.089706)         elapsed: 24.764423 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:159
2020-02-06T09:09:53.967310 (delta: 10.409975)         elapsed: 35.17444 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/component=jiva-controller -n openebs --no-headers -o custom-columns=:.metadata.name | grep pvc-738a076c-ba5f-4ee2-98af-102932806025", "delta": "0:00:00.820387", "end": "2020-02-06 09:09:54.960937", "rc": 0, "start": "2020-02-06 09:09:54.140550", "stderr": "", "stderr_lines": [], "stdout": "pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl-566cfbfcmkmd", "stdout_lines": ["pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl-566cfbfcmkmd"]}

TASK [Check for the jiva controller container status] **************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:168
2020-02-06T09:09:55.024387 (delta: 1.057032)         elapsed: 36.231517 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl-566cfbfcmkmd -n openebs -o jsonpath='{.status.containerStatuses[?(@.name==\"jiva-controller\")].state}' | grep running", "delta": "0:00:00.746000", "end": "2020-02-06 09:09:55.939295", "rc": 0, "start": "2020-02-06 09:09:55.193295", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-02-06T08:44:18Z]]", "stdout_lines": ["map[running:map[startedAt:2020-02-06T08:44:18Z]]"]}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:186
2020-02-06T09:09:56.008621 (delta: 0.984187)         elapsed: 37.215751 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:196
2020-02-06T09:09:56.073134 (delta: 0.06447)         elapsed: 37.280264 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:206
2020-02-06T09:09:56.139605 (delta: 0.066425)         elapsed: 37.346735 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:217
2020-02-06T09:09:56.200690 (delta: 0.060888)         elapsed: 37.40782 ******** 
included: /chaoslib/openebs/inject_packet_loss_tc.yml for 127.0.0.1

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:14
2020-02-06T09:09:56.325534 (delta: 0.124798)         elapsed: 37.532664 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl-566cfbfcmkmd -n openebs --container jiva-controller -- bash -c \"which tc\"", "delta": "0:00:01.111921", "end": "2020-02-06 09:09:57.624668", "rc": 0, "start": "2020-02-06 09:09:56.512747", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "/sbin/tc", "stdout_lines": ["/sbin/tc"]}

TASK [Install tc command on targeted pod] **************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:20
2020-02-06T09:09:57.721843 (delta: 1.396257)         elapsed: 38.928973 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on target] ********************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:27
2020-02-06T09:09:57.820106 (delta: 0.098226)         elapsed: 39.027236 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl-566cfbfcmkmd -n openebs --container jiva-controller -- bash -c \"tc qdisc add dev eth0 root netem loss 100.00\"", "delta": "0:00:01.676628", "end": "2020-02-06 09:09:59.864595", "rc": 0, "start": "2020-02-06 09:09:58.187967", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove packet loss rule from targeted pod] *******************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:37
2020-02-06T09:09:59.954633 (delta: 2.13449)         elapsed: 41.161763 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for 240s post fault injection] **************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:228
2020-02-06T09:10:00.044706 (delta: 0.090035)         elapsed: 41.251836 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 240, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:233
2020-02-06T09:14:00.379797 (delta: 240.335051)         elapsed: 281.586927 **** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:243
2020-02-06T09:14:00.445480 (delta: 0.065633)         elapsed: 281.65261 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:254
2020-02-06T09:14:00.508257 (delta: 0.06273)         elapsed: 281.715387 ******* 
included: /chaoslib/openebs/inject_packet_loss_tc.yml for 127.0.0.1

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:14
2020-02-06T09:14:00.631563 (delta: 0.123259)         elapsed: 281.838693 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install tc command on targeted pod] **************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:20
2020-02-06T09:14:00.695435 (delta: 0.06383)         elapsed: 281.902565 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on target] ********************************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:27
2020-02-06T09:14:00.761939 (delta: 0.066461)         elapsed: 281.969069 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove packet loss rule from targeted pod] *******************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:37
2020-02-06T09:14:00.822649 (delta: 0.060661)         elapsed: 282.029779 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-738a076c-ba5f-4ee2-98af-102932806025-jiva-ctrl-566cfbfcmkmd -n openebs --container jiva-controller -- bash -c \"tc qdisc del dev eth0 root netem loss 100.00\"", "delta": "0:00:01.017271", "end": "2020-02-06 09:14:02.024129", "rc": 0, "start": "2020-02-06 09:14:01.006858", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:267
2020-02-06T09:14:02.111098 (delta: 1.288404)         elapsed: 283.318228 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:273
2020-02-06T09:14:02.209823 (delta: 0.098688)         elapsed: 283.416953 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:283
2020-02-06T09:14:02.268521 (delta: 0.058662)         elapsed: 283.475651 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod not in running state] ***************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:290
2020-02-06T09:14:02.344573 (delta: 0.076)         elapsed: 283.551703 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the volume is healthy] ***************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:300
2020-02-06T09:14:02.423687 (delta: 0.079067)         elapsed: 283.630817 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:311
2020-02-06T09:14:02.475779 (delta: 0.052047)         elapsed: 283.682909 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify test data] ********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:320
2020-02-06T09:14:02.529981 (delta: 0.05416)         elapsed: 283.737111 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the volume is healthy] ***************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:331
2020-02-06T09:14:02.584397 (delta: 0.05437)         elapsed: 283.791527 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get jivavolume pvc-738a076c-ba5f-4ee2-98af-102932806025 -n openebs --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.700292", "end": "2020-02-06 09:14:03.485674", "rc": 0, "start": "2020-02-06 09:14:02.785382", "stderr": "", "stderr_lines": [], "stdout": "Ready", "stdout_lines": ["Ready"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:342
2020-02-06T09:14:03.554228 (delta: 0.969783)         elapsed: 284.761358 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-02-06T09:14:03.663367 (delta: 0.109098)         elapsed: 284.870497 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n default -l app=\"bb\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.708175", "end": "2020-02-06 09:14:04.553290", "rc": 0, "start": "2020-02-06 09:14:03.845115", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-02-06T09:04:01Z]]", "stdout_lines": ["map[running:map[startedAt:2020-02-06T09:04:01Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-02-06T09:14:04.609162 (delta: 0.945751)         elapsed: 285.816292 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n default -o jsonpath='{.items[?(@.metadata.labels.app==\"bb\")].status.phase}'", "delta": "0:00:00.724662", "end": "2020-02-06 09:14:05.544829", "rc": 0, "start": "2020-02-06 09:14:04.820167", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify test data] ********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:351
2020-02-06T09:14:05.608074 (delta: 0.998745)         elapsed: 286.815204 ****** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2020-02-06T09:14:05.738477 (delta: 0.130361)         elapsed: 286.945607 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/remount bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/remount bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/remount > /busybox/remount-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/remount > /busybox/remount-pre-chaos-md5", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=sync;sync;sync)  => {"changed": false, "item": "sync;sync;sync", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:21
2020-02-06T09:14:05.845907 (delta: 0.107376)         elapsed: 287.053037 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod busybox-55cd75666c-fmkbg -n default", "delta": "0:00:43.922230", "end": "2020-02-06 09:14:49.964783", "rc": 0, "start": "2020-02-06 09:14:06.042553", "stderr": "", "stderr_lines": [], "stdout": "pod \"busybox-55cd75666c-fmkbg\" deleted", "stdout_lines": ["pod \"busybox-55cd75666c-fmkbg\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:27
2020-02-06T09:14:50.044552 (delta: 44.1986)         elapsed: 331.251682 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n default", "delta": "0:00:00.676516", "end": "2020-02-06 09:14:50.895549", "rc": 0, "start": "2020-02-06 09:14:50.219033", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS              RESTARTS   AGE\nbusybox-55cd75666c-rlhn7   0/1     ContainerCreating   0          44s", "stdout_lines": ["NAME                       READY   STATUS              RESTARTS   AGE", "busybox-55cd75666c-rlhn7   0/1     ContainerCreating   0          44s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:37
2020-02-06T09:14:50.977737 (delta: 0.933138)         elapsed: 332.184867 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n default -l app=bb -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:00.727107", "end": "2020-02-06 09:14:51.886433", "rc": 0, "start": "2020-02-06 09:14:51.159326", "stderr": "", "stderr_lines": [], "stdout": "busybox-55cd75666c-rlhn7", "stdout_lines": ["busybox-55cd75666c-rlhn7"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:44
2020-02-06T09:14:51.935374 (delta: 0.957583)         elapsed: 333.142504 ****** 
FAILED - RETRYING: Checking application pod is in running state (150 retries left).
FAILED - RETRYING: Checking application pod is in running state (149 retries left).
FAILED - RETRYING: Checking application pod is in running state (148 retries left).
FAILED - RETRYING: Checking application pod is in running state (147 retries left).
FAILED - RETRYING: Checking application pod is in running state (146 retries left).
FAILED - RETRYING: Checking application pod is in running state (145 retries left).
FAILED - RETRYING: Checking application pod is in running state (144 retries left).
FAILED - RETRYING: Checking application pod is in running state (143 retries left).
FAILED - RETRYING: Checking application pod is in running state (142 retries left).
FAILED - RETRYING: Checking application pod is in running state (141 retries left).
FAILED - RETRYING: Checking application pod is in running state (140 retries left).
FAILED - RETRYING: Checking application pod is in running state (139 retries left).
FAILED - RETRYING: Checking application pod is in running state (138 retries left).
FAILED - RETRYING: Checking application pod is in running state (137 retries left).
FAILED - RETRYING: Checking application pod is in running state (136 retries left).
FAILED - RETRYING: Checking application pod is in running state (135 retries left).
FAILED - RETRYING: Checking application pod is in running state (134 retries left).
FAILED - RETRYING: Checking application pod is in running state (133 retries left).
FAILED - RETRYING: Checking application pod is in running state (132 retries left).
FAILED - RETRYING: Checking application pod is in running state (131 retries left).
FAILED - RETRYING: Checking application pod is in running state (130 retries left).
FAILED - RETRYING: Checking application pod is in running state (129 retries left).
FAILED - RETRYING: Checking application pod is in running state (128 retries left).
FAILED - RETRYING: Checking application pod is in running state (127 retries left).
FAILED - RETRYING: Checking application pod is in running state (126 retries left).
FAILED - RETRYING: Checking application pod is in running state (125 retries left).
FAILED - RETRYING: Checking application pod is in running state (124 retries left).
FAILED - RETRYING: Checking application pod is in running state (123 retries left).
FAILED - RETRYING: Checking application pod is in running state (122 retries left).
FAILED - RETRYING: Checking application pod is in running state (121 retries left).
FAILED - RETRYING: Checking application pod is in running state (120 retries left).
FAILED - RETRYING: Checking application pod is in running state (119 retries left).
FAILED - RETRYING: Checking application pod is in running state (118 retries left).
changed: [127.0.0.1] => {"attempts": 34, "changed": true, "cmd": "kubectl get pods -n default -o jsonpath='{.items[?(@.metadata.name==\"busybox-55cd75666c-rlhn7\")].status.phase}'", "delta": "0:00:01.270035", "end": "2020-02-06 09:16:30.380758", "rc": 0, "start": "2020-02-06 09:16:29.110723", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:51
2020-02-06T09:16:30.433834 (delta: 98.498415)         elapsed: 431.640964 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n default -o jsonpath='{.items[?(@.metadata.name==\"busybox-55cd75666c-rlhn7\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.833189", "end": "2020-02-06 09:16:31.443619", "rc": 0, "start": "2020-02-06 09:16:30.610430", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-02-06T09:16:29Z]]", "stdout_lines": ["map[running:map[startedAt:2020-02-06T09:16:29Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:61
2020-02-06T09:16:31.505283 (delta: 1.071407)         elapsed: 432.712413 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busybox-55cd75666c-rlhn7 -n default -- sh -c \"md5sum /busybox/remount > /busybox/remount-post-chaos-md5\"", "delta": "0:00:01.210379", "end": "2020-02-06 09:16:32.915983", "failed_when_result": false, "rc": 0, "start": "2020-02-06 09:16:31.705604", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:70
2020-02-06T09:16:33.013638 (delta: 1.508311)         elapsed: 434.220768 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busybox-55cd75666c-rlhn7 -n default -- sh -c \"diff /busybox/remount-pre-chaos-md5 /busybox/remount-post-chaos-md5\"", "delta": "0:00:00.920552", "end": "2020-02-06 09:16:34.125813", "failed_when_result": false, "rc": 0, "start": "2020-02-06 09:16:33.205261", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for application] *****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:83
2020-02-06T09:16:34.232903 (delta: 1.219225)         elapsed: 435.440033 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:90
2020-02-06T09:16:34.299710 (delta: 0.066761)         elapsed: 435.50684 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:98
2020-02-06T09:16:34.366009 (delta: 0.066252)         elapsed: 435.573139 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:360
2020-02-06T09:16:34.427217 (delta: 0.061162)         elapsed: 435.634347 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_loss/test.yml:371
2020-02-06T09:16:34.505210 (delta: 0.077951)         elapsed: 435.71234 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-02-06T09:16:34.593325 (delta: 0.088065)         elapsed: 435.800455 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-02-06T09:16:34.649028 (delta: 0.055658)         elapsed: 435.856158 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-02-06T09:16:34.705325 (delta: 0.056254)         elapsed: 435.912455 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-02-06T09:16:34.763791 (delta: 0.058423)         elapsed: 435.970921 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "758d3b8e4d8f9b67957aa16b7f592dc929872911", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4468d8d3a7d480bbec78a3546de12401", "mode": "0644", "owner": "root", "size": 455, "src": "/root/.ansible/tmp/ansible-tmp-1580980594.84-236357770482681/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-02-06T09:16:36.379211 (delta: 1.615378)         elapsed: 437.586341 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.596296", "end": "2020-02-06 09:16:37.145733", "rc": 0, "start": "2020-02-06 09:16:36.549437", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/inject_packet_loss_tc \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/inject_packet_loss_tc ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-02-06T09:16:37.194672 (delta: 0.815416)         elapsed: 438.401802 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-06T08:44:03Z", "generation": 6, "name": "openebs-target-network-loss", "resourceVersion": "64127", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-network-loss", "uid": "e7c34926-7dff-4c90-bcb6-431b1b431bb4"}, "spec": {"testMetadata": {"chaostype": "openebs/inject_packet_loss_tc"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=55   changed=34   unreachable=0    failed=0   

2020-02-06T09:16:38.279251 (delta: 1.084531)         elapsed: 439.486381 ****** 
=============================================================================== 
```