### PR TITLE
feat[script]: Implemented the functional test jiva volume resize

### DIFF
--- a/experiments/functional/jiva-volume-resize/README.md
+++ b/experiments/functional/jiva-volume-resize/README.md
@@ -1,0 +1,36 @@
+## Experiment Metadata
+
+| Type       | Description                                                  | Storage | Applications | K8s Platform |
+| ---------- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Functional | Increase the storage capacity of jiva volumes. | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- K8s nodes should have ubuntu 18.04 installed.
+- Application should be deployed using 'openebs jiva default' storage class.
+
+## Exit-Criteria
+
+- Volume should be resized successfully and application should be accessible seamlessly.
+- Application should be able to use the new space.
+
+## Notes
+
+- This functional test checks if the Jiva volume can be resized.
+- This litmusbook accepts the parameters in form of job environmental variables.
+- This job updates the storage capacity of volume, you can verify the same by ssh into corresponding node on which application is deployed and use `lsblk`.
+- After the volume expansion, size will not be reflected on `kubectl get pv` for the corresponding volume.
+- It checks if the application is accessible and the corresponding file system is scaled up.
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| APP_NAMESPACE | Namespace where application and volume is deployed.    |
+| APP_PVC       | Name of PVC whose storage capacity has to be increased |
+| APP_LABEL     | Label of application pod                               |
+| PV_CAPACITY   | Current storage capacity of volume                     |
+| NEW_CAPACITY  | Desired storage capacity of volume                     |
+| OPERATOR_NS   | Namespace where OpenEBS is deployed                    |
+

--- a/experiments/functional/jiva-volume-resize/README.md
+++ b/experiments/functional/jiva-volume-resize/README.md
@@ -8,7 +8,7 @@
 
 - K8s nodes should be ready.
 - K8s nodes should have ubuntu 18.04 installed.
-- Application should be deployed using 'openebs jiva default' storage class.
+- Application should be deployed using 'jiva storage engine'.
 
 ## Exit-Criteria
 

--- a/experiments/functional/jiva-volume-resize/README.md
+++ b/experiments/functional/jiva-volume-resize/README.md
@@ -32,5 +32,3 @@
 | APP_LABEL     | Label of application pod                               |
 | PV_CAPACITY   | Current storage capacity of volume                     |
 | NEW_CAPACITY  | Desired storage capacity of volume                     |
-| OPERATOR_NS   | Namespace where OpenEBS is deployed                    |
-

--- a/experiments/functional/jiva-volume-resize/daemonset.j2
+++ b/experiments/functional/jiva-volume-resize/daemonset.j2
@@ -1,0 +1,85 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: jiva-resize
+spec:
+  selector:
+    matchLabels:
+      app: jiva-resize
+  template:
+    metadata:
+      labels:
+        app: jiva-resize
+    spec:
+      containers:
+      - name: jiva-resize
+        image: somesh2905/jiva-resize
+        command: ["/bin/bash"]
+        imagePullPolicy: Always
+        args: ["-c", "sleep 100000"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 5M
+          limits:
+            cpu: 100m
+            memory: 20M
+        volumeMounts:
+          - name: bus
+            mountPath: /var/run
+          - name: root
+            mountPath: /node
+          - name: disk-dir
+            mountPath: /dev
+          - name: diskmount
+            mountPath: /var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default
+            mountPropagation: Bidirectional
+          - name: podmount
+            mountPath: /var/lib/kubelet/pods
+            mountPropagation: Bidirectional
+          - name: root-dir
+            mountPath: /etc/iscsi
+          - name: iscsid-bin
+            mountPath: /usr/sbin/iscsid
+          - name: iscsiadm-bin
+            mountPath: /usr/bin/iscsiadm
+          - name: iscsiadm-lib-isns-nocrypto
+            mountPath: /lib/x86_64-linux-gnu/libisns-nocrypto.so.0
+        securityContext:
+          privileged: true
+        tty: true
+      hostNetwork: true
+      volumes:
+        - name: disk-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: root-dir
+          hostPath:
+            path: /etc/iscsi
+        - name: iscsid-bin
+          hostPath:
+            path: /usr/sbin/iscsid
+            type: File
+        - name: iscsiadm-bin
+          hostPath:
+            path: /usr/bin/iscsiadm
+            type: File
+        - name: iscsiadm-lib-isns-nocrypto
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libisns-nocrypto.so.0
+            type: File
+        - name: podmount
+          hostPath:
+            path: /var/lib/kubelet/pods
+        - name: diskmount
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default
+        - name: bus
+          hostPath:
+            path: /var/run
+        - name: root
+          hostPath:
+            path: /
+            type: ""

--- a/experiments/functional/jiva-volume-resize/daemonset.j2
+++ b/experiments/functional/jiva-volume-resize/daemonset.j2
@@ -26,8 +26,6 @@ spec:
             cpu: 100m
             memory: 20M
         volumeMounts:
-          - name: bus
-            mountPath: /var/run
           - name: root
             mountPath: /node
           - name: disk-dir
@@ -76,9 +74,6 @@ spec:
         - name: diskmount
           hostPath:
             path: /var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default
-        - name: bus
-          hostPath:
-            path: /var/run
         - name: root
           hostPath:
             path: /

--- a/experiments/functional/jiva-volume-resize/dockerfile
+++ b/experiments/functional/jiva-volume-resize/dockerfile
@@ -1,11 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update
 RUN apt-get install systemd -y
-#RUN apt-get install open-iscsi -y
 RUN apt-get install sudo
-#RUN sudo systemctl enable iscsid
 RUN sudo apt install curl -y
-#RUN sudo systemctl restart iscsid
-#RUN /etc/init.d/open-iscsi restart
-#RUN service open-iscsi restart
 CMD ["bash"]

--- a/experiments/functional/jiva-volume-resize/dockerfile
+++ b/experiments/functional/jiva-volume-resize/dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install systemd -y
+#RUN apt-get install open-iscsi -y
+RUN apt-get install sudo
+#RUN sudo systemctl enable iscsid
+RUN sudo apt install curl -y
+#RUN sudo systemctl restart iscsid
+#RUN /etc/init.d/open-iscsi restart
+#RUN service open-iscsi restart
+CMD ["bash"]

--- a/experiments/functional/jiva-volume-resize/run_litmus_test.yml
+++ b/experiments/functional/jiva-volume-resize/run_litmus_test.yml
@@ -1,0 +1,48 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-vol-resize-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-jiva-vol-resize
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: ''
+
+            # Application pvc
+          - name: APP_PVC
+            value: '' 
+
+          - name: APP_LABEL
+            value: ''
+          
+          - name: PV_CAPACITY
+            value: 5G
+          
+          - name: NEW_CAPACITY
+            value: 8G
+
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/jiva-volume-resize/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/jiva-volume-resize/run_litmus_test.yml
+++ b/experiments/functional/jiva-volume-resize/run_litmus_test.yml
@@ -40,9 +40,5 @@ spec:
           - name: NEW_CAPACITY
             value: 8G
 
-            #Target namespace
-          - name: OPERATOR_NS
-            value: openebs
-
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/jiva-volume-resize/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/jiva-volume-resize/run_litmus_test.yml
+++ b/experiments/functional/jiva-volume-resize/run_litmus_test.yml
@@ -31,12 +31,15 @@ spec:
           - name: APP_PVC
             value: '' 
 
+            # Application label
           - name: APP_LABEL
             value: ''
-          
+
+            # Current storage capacity of volume
           - name: PV_CAPACITY
             value: 5G
           
+            # Desired storage capacity of volume
           - name: NEW_CAPACITY
             value: 8G
 

--- a/experiments/functional/jiva-volume-resize/test.yml
+++ b/experiments/functional/jiva-volume-resize/test.yml
@@ -106,7 +106,7 @@
           register: ds_pod
           failed_when: "ds_pod.rc != 0"
         
-        - name: Obatin the Target Disk
+        - name: Obtain the Target Disk
           shell: >
             kubectl exec -ti "{{ ds_pod.stdout }}" -- bash 
             -c "lsblk | grep '{{ app_pv.stdout }}'" | awk '{print $1}'
@@ -136,11 +136,10 @@
         - name: Unmount the File System
           shell: >
             kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c 
-            "umount '{{ item }}'"
+            "umount -l '{{ item }}'"
           args:
             executable: /bin/bash
           with_items: "{{ mountpath.stdout_lines }}"
-          ignore_errors: yes
 
         - name: Logout from the particular iSCSI target
           shell: >
@@ -167,22 +166,14 @@
             executable: /bin/bash
           register: status
           failed_when: "status.rc != 0"
-
-        - name: Obtain the replica pods of jiva volume
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
-            --no-headers -o custom-columns=:.metadata.name
-          args:
-            executable: /bin/bash
-          register: replica_pod
-          failed_when: "replica_pod.rc != 0"
-
+        
         - name: Restart all the replica pods of jiva volume
           shell: >
-            kubectl delete pod "{{ item }}" -n {{ app_ns }}  
+            kubectl delete pods -n "{{ app_ns }}" -l openebs.io/replica=jiva-replica  
           args:
             executable: /bin/bash
-          with_items: "{{ replica_pod.stdout_lines }}"
+          register: status
+          failed_when: "status.rc != 0"
 
         - name: Checking for all replicas to be in Running state
           shell: >

--- a/experiments/functional/jiva-volume-resize/test.yml
+++ b/experiments/functional/jiva-volume-resize/test.yml
@@ -1,0 +1,328 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+        
+        - name: Update the DaemonSet template with the variables.
+          template:
+            src: daemonset.j2
+            dest: daemonset.yml
+
+        - name: Create the DaemonSet 
+          shell: kubectl apply -f daemonset.yml
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Obtain the application pod
+          shell: >
+            kubectl get po -n {{ app_ns }} -l {{ app_label }} 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: app_pod
+          failed_when: "app_pod.rc != 0"
+
+        - name: Record the application pod name
+          set_fact: 
+            application_pod: "{{ app_pod.stdout }}"
+
+        - name: Verify if the application pod is running
+          shell: >
+            kubectl get po -n {{ app_ns }} -l {{ app_label }} 
+            --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 15
+          retries: 60
+
+        - name: Obtain the node where application pod is scheduled
+          shell: >
+            kubectl get po "{{ app_pod.stdout }}" -n {{ app_ns }} 
+            --no-headers -o custom-columns=:.spec.nodeName
+          args:
+            executable: /bin/bash
+          register: app_node
+          failed_when: "app_node.rc != 0"
+
+        - name: Obtain the node IP where application pod is scheduled
+          shell: >
+            kubectl get node "{{ app_node.stdout }}" 
+            -o jsonpath='{.status.addresses[0].address}'
+          args:
+            executable: /bin/bash
+          register: node_ip
+          failed_when: "node_ip.rc != 0"
+
+        - name: Obtain the IP address of jiva controller pod
+          shell: >
+            kubectl get pod -n {{ app_ns }} -l openebs.io/controller=jiva-controller 
+            --no-headers -o custom-columns=:.status.podIP
+          args:
+            executable: /bin/bash
+          register: controller_ip
+          failed_when: "controller_ip.rc != 0"
+                  
+        - name: Getting PV name from the pvc
+          shell: >
+            kubectl get pvc {{ app_pvc }} -n {{ app_ns }} 
+            --no-headers -o custom-columns=:.spec.volumeName
+          args:
+            executable: /bin/bash
+          register: app_pv
+          failed_when: "app_pv.rc != 0"
+
+        - name: Obtain the ds pod corresponding to application pod
+          shell: >
+            kubectl get po -l app=jiva-resize -o wide --no-headers -o 
+            custom-columns=:.metadata.name,:.spec.nodeName | 
+            grep "{{ app_node.stdout }}" | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: ds_pod
+          failed_when: "ds_pod.rc != 0"
+
+        - name: Verify if corresponding daemonset pod is Running
+          shell: >
+            kubectl get po "{{ ds_pod.stdout }}" 
+            --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: status
+          until: "'Running' in status.stdout"
+          delay: 5
+          retries: 60
+
+        - name: Obatin the Target Disk
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash 
+            -c "lsblk | grep '{{ app_pv.stdout }}'" | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: target_disk
+          failed_when: "target_disk.rc != 0"
+
+        - name: Obtain the iSCSI target
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c 
+            "iscsiadm -m session" | grep "{{ app_pv.stdout }}" | awk '{print $4}'
+          args:
+            executable: /bin/bash
+          register: iscsi_target
+          failed_when: "iscsi_target.rc != 0"
+
+        - name: Obtain the mount path on disk "{{ target_disk.stdout }}"
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c "mount | 
+            grep /dev/'{{ target_disk.stdout }}'" | awk '{print $3}'
+          args:
+            executable: /bin/bash
+          register: mountpath
+          failed_when: "mountpath.rc != 0"
+
+        - name: Unmount the File System
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c 
+            "umount '{{ item }}'"
+          args:
+            executable: /bin/bash
+          with_items: "{{ mountpath.stdout_lines }}"
+          ignore_errors: yes
+
+        - name: Logout from the particular iSCSI target
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash 
+            -c "iscsiadm -m node -u -T '{{ iscsi_target.stdout }}'"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Get the volume ID using curl
+          shell: >
+            curl http://"{{ controller_ip.stdout }}":9501/v1/volumes -s | jq -r '.data[0].id'
+          args:
+            executable: /bin/bash
+          register: vol_id
+          failed_when: "vol_id.rc != 0"
+          
+        - name: Expand the volume to desired size
+          shell: >
+            curl -H "Content-Type: application/json" -X POST -d '{"name":"'{{ app_pv.stdout }}'","size":"{{ desired_size }}"}' 
+            http://"{{ controller_ip.stdout }}":9501/v1/volumes/"{{ vol_id.stdout }}"?action=resize
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Obtain the replica pods of jiva volume
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: replica_pod
+          failed_when: "replica_pod.rc != 0"
+
+        - name: Delete all the replica pods of jiva volume
+          shell: >
+            kubectl delete pod "{{ item }}" -n {{ app_ns }}  
+          args:
+            executable: /bin/bash
+          with_items: "{{ replica_pod.stdout_lines }}"
+
+        - name: Obtain the iSCSI Target IP (controller service IP address)
+          shell: >
+            kubectl get svc -n {{ app_ns }} -l openebs.io/controller-service=jiva-controller-svc 
+            --no-headers -o custom-columns=:.spec.clusterIP
+          args:
+            executable: /bin/bash
+          register: target_IP
+          failed_when: "target_IP.rc != 0"
+
+        - name: Login to iSCSI Target
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c "iscsiadm -m discovery -t st -p "{{ target_IP.stdout }}":3260 -l"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Obtain the remounted disk
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c "iscsiadm -m session -P3" | grep "{{ app_pv.stdout }}"  -A50 | egrep 'iqn|disk' | grep disk | awk {'print $4'}
+          args:
+            executable: /bin/bash
+          register: remount_disk
+          until: "remount_disk.stdout != ''"
+          delay: 2
+          retries: 30
+
+        - name: Check the file system consistency
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" 
+            -- bash -c "e2fsck -f /dev/'{{ remount_disk.stdout }}' -y"
+          args:
+            executable: /bin/bash
+          register: status
+          until: "status.rc == 0"
+          delay: 2
+          retries: 30
+          ignore_errors: yes
+
+        - name: Expand the file system
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" -- bash -c "resize2fs /dev/'{{ remount_disk.stdout }}'"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Mount the file system
+          shell: >
+            kubectl exec -ti "{{ ds_pod.stdout }}" 
+            -- bash -c "mount /dev/'{{ remount_disk.stdout }}' '{{ item }}'"
+          args:
+            executable: /bin/bash
+          with_items: "{{ mountpath.stdout_lines }}"
+          ignore_errors: yes
+
+        - name: Delete the application pod
+          shell: kubectl delete pod "{{ application_pod }}" -n "{{ app_ns }}"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Verify if the application pod is deleted
+          shell: >
+            kubectl get pods -n {{ app_ns }}
+          args:
+            executable: /bin/bash
+          register: podstatus
+          until: "'{{ application_pod }}' not in podstatus.stdout"
+          delay: 5
+          retries: 60
+          
+        - name: Obtain the new application pod name
+          shell: >
+            kubectl get pod -n {{ app_ns }} -l {{ app_label }} 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: newpod_name
+          failed_when: "newpod_name.rc !=0"
+
+        - name: Verify if the new application pod is running
+          shell: >
+            kubectl get pod "{{ newpod_name.stdout }}" -n {{ app_ns }} 
+            --no-headers -o custom-columns=:.status.phase
+          register: status
+          until: "'Running' in status.stdout"
+          delay: 5
+          retries: 60
+
+        - name : Obatin the node where new pod is scheduled
+          shell: >
+            kubectl get pod "{{ newpod_name.stdout }}" -n {{ app_ns }} 
+            --no-headers -o custom-columns=:.spec.nodeName
+          args:
+            executable: /bin/bash
+          register: newapp_node
+          failed_when: "newapp_node.rc != 0"
+
+        - name: Obtain the ds pod corresponding to new application pod
+          shell: >
+            kubectl get pod -l app=jiva-resize -o wide --no-headers -o 
+            custom-columns=:.metadata.name,:.spec.nodeName | 
+            grep "{{ newapp_node.stdout }}" | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: newds_pod
+          failed_when: "newds_pod.rc != 0"
+
+        - name: Verify the resized size of volume
+          shell: >
+            kubectl exec -ti "{{ newds_pod.stdout }}" 
+            -- bash -c "lsblk | grep '{{ remount_disk.stdout }}'" | awk '{print $4}'
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "'{{ desired_size }}' != status.stdout"
+
+        - name: Delete the DaemonSet 
+          shell: kubectl delete -f daemonset.yml
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/jiva-volume-resize/test.yml
+++ b/experiments/functional/jiva-volume-resize/test.yml
@@ -28,22 +28,30 @@
           register: status
           failed_when: "status.rc != 0"
 
+        - name: Confirm that the daemonset pods are running on all nodes
+          shell: >
+            kubectl get pod -l app=jiva-resize 
+            --no-headers -o custom-columns=:status.phase
+            -n litmus | sort | uniq
+          args:
+            executable: /bin/bash
+          register: result
+          until: "result.stdout == 'Running'"
+          delay: 5
+          retries: 60
+
         - name: Obtain the application pod
           shell: >
-            kubectl get po -n {{ app_ns }} -l {{ app_label }} 
+            kubectl get pod -n {{ app_ns }} -l {{ app_label }} 
             --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: app_pod
           failed_when: "app_pod.rc != 0"
-
-        - name: Record the application pod name
-          set_fact: 
-            application_pod: "{{ app_pod.stdout }}"
-
+        
         - name: Verify if the application pod is running
           shell: >
-            kubectl get po -n {{ app_ns }} -l {{ app_label }} 
+            kubectl get pod -n {{ app_ns }} -l {{ app_label }} 
             --no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash
@@ -54,7 +62,7 @@
 
         - name: Obtain the node where application pod is scheduled
           shell: >
-            kubectl get po "{{ app_pod.stdout }}" -n {{ app_ns }} 
+            kubectl get pod "{{ app_pod.stdout }}" -n {{ app_ns }} 
             --no-headers -o custom-columns=:.spec.nodeName
           args:
             executable: /bin/bash
@@ -88,27 +96,16 @@
           register: app_pv
           failed_when: "app_pv.rc != 0"
 
-        - name: Obtain the ds pod corresponding to application pod
+        - name: Obtain the daemonset pod corresponding to application pod
           shell: >
-            kubectl get po -l app=jiva-resize -o wide --no-headers -o 
+            kubectl get pod -l app=jiva-resize -o wide --no-headers -o 
             custom-columns=:.metadata.name,:.spec.nodeName | 
             grep "{{ app_node.stdout }}" | awk '{print $1}'
           args:
             executable: /bin/bash
           register: ds_pod
           failed_when: "ds_pod.rc != 0"
-
-        - name: Verify if corresponding daemonset pod is Running
-          shell: >
-            kubectl get po "{{ ds_pod.stdout }}" 
-            --no-headers -o custom-columns=:.status.phase
-          args:
-            executable: /bin/bash
-          register: status
-          until: "'Running' in status.stdout"
-          delay: 5
-          retries: 60
-
+        
         - name: Obatin the Target Disk
           shell: >
             kubectl exec -ti "{{ ds_pod.stdout }}" -- bash 
@@ -180,12 +177,21 @@
           register: replica_pod
           failed_when: "replica_pod.rc != 0"
 
-        - name: Delete all the replica pods of jiva volume
+        - name: Restart all the replica pods of jiva volume
           shell: >
             kubectl delete pod "{{ item }}" -n {{ app_ns }}  
           args:
             executable: /bin/bash
           with_items: "{{ replica_pod.stdout_lines }}"
+
+        - name: Checking for all replicas to be in Running state
+          shell: >
+            kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            --no-headers -o custom-columns=:status.phase
+          register: running_rep_status
+          until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
+          delay: 10
+          retries: 30
 
         - name: Obtain the iSCSI Target IP (controller service IP address)
           shell: >
@@ -244,7 +250,7 @@
           ignore_errors: yes
 
         - name: Delete the application pod
-          shell: kubectl delete pod "{{ application_pod }}" -n "{{ app_ns }}"
+          shell: kubectl delete pod "{{ app_pod.stdout }}" -n "{{ app_ns }}"
           args:
             executable: /bin/bash
           register: status
@@ -256,7 +262,7 @@
           args:
             executable: /bin/bash
           register: podstatus
-          until: "'{{ application_pod }}' not in podstatus.stdout"
+          until: "app_pod.stdout not in podstatus.stdout"
           delay: 5
           retries: 60
           
@@ -287,7 +293,7 @@
           register: newapp_node
           failed_when: "newapp_node.rc != 0"
 
-        - name: Obtain the ds pod corresponding to new application pod
+        - name: Obtain the daemonset pod corresponding to new application pod
           shell: >
             kubectl get pod -l app=jiva-resize -o wide --no-headers -o 
             custom-columns=:.metadata.name,:.spec.nodeName | 

--- a/experiments/functional/jiva-volume-resize/test_vars.yml
+++ b/experiments/functional/jiva-volume-resize/test_vars.yml
@@ -1,0 +1,14 @@
+---
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+desired_size: "{{ lookup('env','NEW_CAPACITY') }}"
+
+vol_size: "{{ lookup('env','PV_CAPACITY') }}"
+
+operator_ns: 'openebs'
+
+test_name: jiva-volume-resize

--- a/experiments/functional/jiva-volume-resize/test_vars.yml
+++ b/experiments/functional/jiva-volume-resize/test_vars.yml
@@ -9,6 +9,4 @@ desired_size: "{{ lookup('env','NEW_CAPACITY') }}"
 
 vol_size: "{{ lookup('env','PV_CAPACITY') }}"
 
-operator_ns: 'openebs'
-
 test_name: jiva-volume-resize


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented the functional test jiva volume resize, (this test can be used to resize jiva volume)
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #153 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2020-02-17T06:09:15.536625 (delta: 0.093531)         elapsed: 0.093531 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:2
2020-02-17T06:09:15.559215 (delta: 0.022364)         elapsed: 0.116121 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:12
2020-02-17T06:09:24.050666 (delta: 8.491431)         elapsed: 8.607572 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-02-17T06:09:24.173223 (delta: 0.12249)         elapsed: 8.730129 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-02-17T06:09:24.248043 (delta: 0.074733)         elapsed: 8.804949 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:15
2020-02-17T06:09:24.316773 (delta: 0.068428)         elapsed: 8.873679 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-02-17T06:09:24.434862 (delta: 0.118034)         elapsed: 8.991768 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2b398166b8e75c591d5d5c9dc2f98694365588e4", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "93eee17bff2a05646c5f7a6fef73caf3", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1581919764.52-27442059699457/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-02-17T06:09:25.440935 (delta: 1.006017)         elapsed: 9.997841 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.695619", "end": "2020-02-17 06:09:26.502640", "rc": 0, "start": "2020-02-17 06:09:25.807021", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-volume-resize \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-volume-resize ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-02-17T06:09:26.562256 (delta: 1.121264)         elapsed: 11.119162 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-14T11:06:25Z", "generation": 22, "name": "jiva-volume-resize", "resourceVersion": "349502", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-volume-resize", "uid": "2b99718c-9890-4617-a479-6b930965524d"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-02-17T06:09:27.940243 (delta: 1.377896)         elapsed: 12.497149 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-02-17T06:09:28.001644 (delta: 0.061349)         elapsed: 12.55855 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-02-17T06:09:28.061970 (delta: 0.060273)         elapsed: 12.618876 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the DaemonSet template with the variables.] ***********************
task path: /experiments/functional/jiva-volume-resize/test.yml:19
2020-02-17T06:09:28.137420 (delta: 0.075394)         elapsed: 12.694326 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8b32313e54b1b81e4483810f3964fa95c719962c", "dest": "./daemonset.yml", "gid": 0, "group": "root", "md5sum": "735457cccae11d8cba823bce39869c84", "mode": "0644", "owner": "root", "size": 2296, "src": "/root/.ansible/tmp/ansible-tmp-1581919768.22-206515893643127/source", "state": "file", "uid": 0}

TASK [Create the DaemonSet] ****************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:24
2020-02-17T06:09:28.677397 (delta: 0.53991)         elapsed: 13.234303 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f daemonset.yml", "delta": "0:00:01.421099", "end": "2020-02-17 06:09:30.292589", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:28.871490", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/jiva-resize unchanged", "stdout_lines": ["daemonset.apps/jiva-resize unchanged"]}

TASK [Obtain the application pod] **********************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:31
2020-02-17T06:09:30.397478 (delta: 1.720017)         elapsed: 14.954384 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n sam -l app=busybox-sts --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.790529", "end": "2020-02-17 06:09:31.550456", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:30.759927", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-99klw", "stdout_lines": ["app-busybox-85d45b855f-99klw"]}

TASK [Record the application pod name] *****************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:40
2020-02-17T06:09:31.624961 (delta: 1.227421)         elapsed: 16.181867 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"application_pod": "app-busybox-85d45b855f-99klw"}, "changed": false}

TASK [Verify if the application pod is running] ********************************
task path: /experiments/functional/jiva-volume-resize/test.yml:44
2020-02-17T06:09:31.756107 (delta: 0.13109)         elapsed: 16.313013 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get po -n sam -l app=busybox-sts --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.066849", "end": "2020-02-17 06:09:33.060711", "rc": 0, "start": "2020-02-17 06:09:31.993862", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the node where application pod is scheduled] **********************
task path: /experiments/functional/jiva-volume-resize/test.yml:55
2020-02-17T06:09:33.139507 (delta: 1.383291)         elapsed: 17.696413 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po \"app-busybox-85d45b855f-99klw\" -n sam --no-headers -o custom-columns=:.spec.nodeName", "delta": "0:00:01.195899", "end": "2020-02-17 06:09:34.630992", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:33.435093", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node2", "stdout_lines": ["e2e1-node2"]}

TASK [Obtain the node IP where application pod is scheduled] *******************
task path: /experiments/functional/jiva-volume-resize/test.yml:64
2020-02-17T06:09:34.796513 (delta: 1.656944)         elapsed: 19.353419 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node \"e2e1-node2\" -o jsonpath='{.status.addresses[0].address}'", "delta": "0:00:00.995332", "end": "2020-02-17 06:09:36.077961", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:35.082629", "stderr": "", "stderr_lines": [], "stdout": "10.34.1.232", "stdout_lines": ["10.34.1.232"]}

TASK [Obtain the IP address of jiva controller pod] ****************************
task path: /experiments/functional/jiva-volume-resize/test.yml:73
2020-02-17T06:09:36.144756 (delta: 1.348142)         elapsed: 20.701662 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n sam -l openebs.io/controller=jiva-controller --no-headers -o custom-columns=:.status.podIP", "delta": "0:00:00.952679", "end": "2020-02-17 06:09:37.368222", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:36.415543", "stderr": "", "stderr_lines": [], "stdout": "192.168.202.202", "stdout_lines": ["192.168.202.202"]}

TASK [Getting PV name from the pvc] ********************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:82
2020-02-17T06:09:37.451735 (delta: 1.306899)         elapsed: 22.008641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n sam --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.926154", "end": "2020-02-17 06:09:38.609861", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:37.683707", "stderr": "", "stderr_lines": [], "stdout": "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "stdout_lines": ["pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c"]}

TASK [Obtain the ds pod corresponding to application pod] **********************
task path: /experiments/functional/jiva-volume-resize/test.yml:91
2020-02-17T06:09:38.699509 (delta: 1.247715)         elapsed: 23.256415 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -l app=jiva-resize -o wide --no-headers -o custom-columns=:.metadata.name,:.spec.nodeName | grep \"e2e1-node2\" | awk '{print $1}'", "delta": "0:00:00.790358", "end": "2020-02-17 06:09:39.692956", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:38.902598", "stderr": "", "stderr_lines": [], "stdout": "jiva-resize-c8569", "stdout_lines": ["jiva-resize-c8569"]}

TASK [Verify if corresponding daemonset pod is Running] ************************
task path: /experiments/functional/jiva-volume-resize/test.yml:101
2020-02-17T06:09:39.809346 (delta: 1.109782)         elapsed: 24.366252 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get po \"jiva-resize-c8569\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.024789", "end": "2020-02-17 06:09:41.096553", "rc": 0, "start": "2020-02-17 06:09:40.071764", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obatin the Target Disk] **************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:112
2020-02-17T06:09:41.175424 (delta: 1.366018)         elapsed: 25.73233 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"lsblk | grep 'pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\" | awk '{print $1}'", "delta": "0:00:01.330978", "end": "2020-02-17 06:09:42.759825", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:41.428847", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "sde", "stdout_lines": ["sde"]}

TASK [Obtain the iSCSI target] *************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:121
2020-02-17T06:09:42.877757 (delta: 1.701843)         elapsed: 27.434663 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"iscsiadm -m session\" | grep \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c\" | awk '{print $4}'", "delta": "0:00:01.231592", "end": "2020-02-17 06:09:44.367689", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:43.136097", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "stdout_lines": ["iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c"]}

TASK [Obtain the mount path on disk "sde"] *************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:130
2020-02-17T06:09:44.512406 (delta: 1.634571)         elapsed: 29.069312 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"mount |  grep /dev/'sde'\" | awk '{print $3}'", "delta": "0:00:01.473681", "end": "2020-02-17 06:09:46.250710", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:44.777029", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0\n/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0\n/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c\n/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "stdout_lines": ["/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0", "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0", "/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c"]}

TASK [Unmount the File System] *************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:139
2020-02-17T06:09:46.320223 (delta: 1.807724)         elapsed: 30.877129 ******* 
changed: [127.0.0.1] => (item=/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"umount '/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0'\"", "delta": "0:00:01.098420", "end": "2020-02-17 06:09:47.665184", "item": "/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0", "rc": 0, "start": "2020-02-17 06:09:46.566764", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"umount '/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0'\"", "delta": "0:00:01.253986", "end": "2020-02-17 06:09:49.087062", "item": "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0", "rc": 0, "start": "2020-02-17 06:09:47.833076", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"umount '/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\"", "delta": "0:00:01.296749", "end": "2020-02-17 06:09:50.600871", "item": "/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "rc": 0, "start": "2020-02-17 06:09:49.304122", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"umount '/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\"", "delta": "0:00:01.316164", "end": "2020-02-17 06:09:52.200302", "item": "/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "rc": 0, "start": "2020-02-17 06:09:50.884138", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Logout from the particular iSCSI target] *********************************
task path: /experiments/functional/jiva-volume-resize/test.yml:148
2020-02-17T06:09:52.392028 (delta: 6.071671)         elapsed: 36.948934 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"iscsiadm -m node -u -T 'iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\"", "delta": "0:00:01.553582", "end": "2020-02-17 06:09:54.175295", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:52.621713", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Logging out of session [sid: 5, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260]\nLogout of [sid: 5, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260] successful.", "stdout_lines": ["Logging out of session [sid: 5, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260]", "Logout of [sid: 5, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260] successful."]}

TASK [Get the volume ID using curl] ********************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:157
2020-02-17T06:09:54.321307 (delta: 1.929211)         elapsed: 38.878213 ******* 
 [WARNING]: Consider using the get_url or uri module rather than running curl.
If you need to use command because get_url or uri is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "curl http://\"192.168.202.202\":9501/v1/volumes -s | jq -r '.data[0].id'", "delta": "0:00:00.821975", "end": "2020-02-17 06:09:55.367935", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:54.545960", "stderr": "", "stderr_lines": [], "stdout": "cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==", "stdout_lines": ["cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw=="]}

TASK [Expand the volume to desired size] ***************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:165
2020-02-17T06:09:55.451607 (delta: 1.130165)         elapsed: 40.008513 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "curl -H \"Content-Type: application/json\" -X POST -d '{\"name\":\"'pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\",\"size\":\"10G\"}' http://\"192.168.202.202\":9501/v1/volumes/\"cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==\"?action=resize", "delta": "0:00:00.657005", "end": "2020-02-17 06:09:56.314219", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:55.657214", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   988  100   924  100    64  57750   4000 --:--:-- --:--:-- --:--:-- 65866", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   988  100   924  100    64  57750   4000 --:--:-- --:--:-- --:--:-- 65866"], "stdout": "{\"actions\":{\"deleteSnapshot\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=deleteSnapshot\",\"resize\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=resize\",\"revert\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=revert\",\"shutdown\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=shutdown\",\"snapshot\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=snapshot\"},\"id\":\"cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==\",\"links\":{\"self\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==\"},\"name\":\"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}", "stdout_lines": ["{\"actions\":{\"deleteSnapshot\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=deleteSnapshot\",\"resize\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=resize\",\"revert\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=revert\",\"shutdown\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=shutdown\",\"snapshot\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==?action=snapshot\"},\"id\":\"cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==\",\"links\":{\"self\":\"http://192.168.202.202:9501/v1/volumes/cHZjLTdiNGI0MWQ4LTU1ZGYtNDc3Mi1hNmM1LWQ4OWJhYWQxNzYwYw==\"},\"name\":\"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}"]}

TASK [Obtain the replica pods of jiva volume] **********************************
task path: /experiments/functional/jiva-volume-resize/test.yml:174
2020-02-17T06:09:56.383726 (delta: 0.931876)         elapsed: 40.940632 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.900504", "end": "2020-02-17 06:09:57.490842", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:09:56.590338", "stderr": "", "stderr_lines": [], "stdout": "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6\npvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4\npvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz", "stdout_lines": ["pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6", "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4", "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz"]}

TASK [Delete all the replica pods of jiva volume] ******************************
task path: /experiments/functional/jiva-volume-resize/test.yml:183
2020-02-17T06:09:57.566110 (delta: 1.182306)         elapsed: 42.123016 ******* 
changed: [127.0.0.1] => (item=pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6) => {"changed": true, "cmd": "kubectl delete pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6\" -n sam", "delta": "0:00:03.174137", "end": "2020-02-17 06:10:01.015524", "item": "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6", "rc": 0, "start": "2020-02-17 06:09:57.841387", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6\" deleted", "stdout_lines": ["pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-b9pt6\" deleted"]}
changed: [127.0.0.1] => (item=pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4) => {"changed": true, "cmd": "kubectl delete pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4\" -n sam", "delta": "0:00:10.880232", "end": "2020-02-17 06:10:12.112438", "item": "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4", "rc": 0, "start": "2020-02-17 06:10:01.232206", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4\" deleted", "stdout_lines": ["pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-jwpk4\" deleted"]}
changed: [127.0.0.1] => (item=pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz) => {"changed": true, "cmd": "kubectl delete pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz\" -n sam", "delta": "0:00:09.221978", "end": "2020-02-17 06:10:21.717638", "item": "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz", "rc": 0, "start": "2020-02-17 06:10:12.495660", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz\" deleted", "stdout_lines": ["pod \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-x86fz\" deleted"]}

TASK [Obtain the iSCSI Target IP (controller service IP address)] **************
task path: /experiments/functional/jiva-volume-resize/test.yml:190
2020-02-17T06:10:21.889630 (delta: 24.323364)         elapsed: 66.446536 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -n sam -l openebs.io/controller-service=jiva-controller-svc --no-headers -o custom-columns=:.spec.clusterIP", "delta": "0:00:01.524835", "end": "2020-02-17 06:10:23.667982", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:10:22.143147", "stderr": "", "stderr_lines": [], "stdout": "10.104.77.132", "stdout_lines": ["10.104.77.132"]}

TASK [Login to iSCSI Target] ***************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:199
2020-02-17T06:10:23.803632 (delta: 1.913951)         elapsed: 68.360538 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"iscsiadm -m discovery -t st -p \"10.104.77.132\":3260 -l\"", "delta": "0:00:01.437509", "end": "2020-02-17 06:10:25.540082", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:10:24.102573", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "10.104.77.132:3260,1 iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c\nLogging in to [iface: default, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260] (multiple)\nLogin to [iface: default, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260] successful.", "stdout_lines": ["10.104.77.132:3260,1 iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "Logging in to [iface: default, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260] (multiple)", "Login to [iface: default, target: iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c, portal: 10.104.77.132,3260] successful."]}

TASK [Obtain the remounted disk] ***********************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:207
2020-02-17T06:10:25.704046 (delta: 1.900309)         elapsed: 70.260952 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"iscsiadm -m session -P3\" | grep \"pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c\" -A50 | egrep 'iqn|disk' | grep disk | awk {'print $4'}", "delta": "0:00:01.379705", "end": "2020-02-17 06:10:27.360560", "rc": 0, "start": "2020-02-17 06:10:25.980855", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "sdf", "stdout_lines": ["sdf"]}

TASK [Check the file system consistency] ***************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:217
2020-02-17T06:10:27.446273 (delta: 1.742134)         elapsed: 72.003179 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"e2fsck -f /dev/'sdf' -y\"", "delta": "0:00:01.438501", "end": "2020-02-17 06:10:29.087908", "rc": 0, "start": "2020-02-17 06:10:27.649407", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ne2fsck 1.44.1 (24-Mar-2018)", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "e2fsck 1.44.1 (24-Mar-2018)"], "stdout": "/dev/sdf: recovering journal\nPass 1: Checking inodes, blocks, and sizes\nPass 2: Checking directory structure\nPass 3: Checking directory connectivity\nPass 4: Checking reference counts\nPass 5: Checking group summary information\n/dev/sdf: 11/327680 files (0.0% non-contiguous), 42078/1310720 blocks", "stdout_lines": ["/dev/sdf: recovering journal", "Pass 1: Checking inodes, blocks, and sizes", "Pass 2: Checking directory structure", "Pass 3: Checking directory connectivity", "Pass 4: Checking reference counts", "Pass 5: Checking group summary information", "/dev/sdf: 11/327680 files (0.0% non-contiguous), 42078/1310720 blocks"]}

TASK [Expand the file system] **************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:229
2020-02-17T06:10:29.165365 (delta: 1.71901)         elapsed: 73.722271 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"resize2fs /dev/'sdf'\"", "delta": "0:00:02.989464", "end": "2020-02-17 06:10:32.407370", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:10:29.417906", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nresize2fs 1.44.1 (24-Mar-2018)", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "resize2fs 1.44.1 (24-Mar-2018)"], "stdout": "Resizing the filesystem on /dev/sdf to 2621440 (4k) blocks.\nThe filesystem on /dev/sdf is now 2621440 (4k) blocks long.", "stdout_lines": ["Resizing the filesystem on /dev/sdf to 2621440 (4k) blocks.", "The filesystem on /dev/sdf is now 2621440 (4k) blocks long."]}

TASK [Mount the file system] ***************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:237
2020-02-17T06:10:32.484712 (delta: 3.319072)         elapsed: 77.041618 ******* 
changed: [127.0.0.1] => (item=/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"mount /dev/'sdf' '/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0'\"", "delta": "0:00:01.631826", "end": "2020-02-17 06:10:34.356840", "item": "/node/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0", "rc": 0, "start": "2020-02-17 06:10:32.725014", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"mount /dev/'sdf' '/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0'\"", "delta": "0:00:01.504709", "end": "2020-02-17 06:10:36.145648", "item": "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.77.132:3260-iqn.2016-09.com.openebs.jiva:pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-lun-0", "rc": 0, "start": "2020-02-17 06:10:34.640939", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"mount /dev/'sdf' '/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\"", "delta": "0:00:01.337199", "end": "2020-02-17 06:10:37.649699", "item": "/node/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "rc": 0, "start": "2020-02-17 06:10:36.312500", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c) => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"mount /dev/'sdf' '/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c'\"", "delta": "0:00:01.479071", "end": "2020-02-17 06:10:39.373229", "item": "/var/lib/kubelet/pods/f3717488-96fe-47af-a859-d8097975d1dc/volumes/kubernetes.io~iscsi/pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c", "rc": 0, "start": "2020-02-17 06:10:37.894158", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Delete the application pod] **********************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:246
2020-02-17T06:10:39.549244 (delta: 7.06443)         elapsed: 84.10615 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"app-busybox-85d45b855f-99klw\" -n \"sam\"", "delta": "0:00:42.141892", "end": "2020-02-17 06:11:22.105438", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:10:39.963546", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-85d45b855f-99klw\" deleted", "stdout_lines": ["pod \"app-busybox-85d45b855f-99klw\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /experiments/functional/jiva-volume-resize/test.yml:253
2020-02-17T06:11:22.249278 (delta: 42.699849)         elapsed: 126.806184 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ application_pod }}' not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam", "delta": "0:00:01.228555", "end": "2020-02-17 06:11:23.771915", "rc": 0, "start": "2020-02-17 06:11:22.543360", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                            READY   STATUS    RESTARTS   AGE\napp-busybox-85d45b855f-6pqcl                                    1/1     Running   0          43s\npvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-ctrl-88bcd6dcb-hhmzn   2/2     Running   0          3m31s\npvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-bxbs8   1/1     Running   0          85s\npvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-gszqw   1/1     Running   0          81s\npvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-nhkbc   1/1     Running   0          70s", "stdout_lines": ["NAME                                                            READY   STATUS    RESTARTS   AGE", "app-busybox-85d45b855f-6pqcl                                    1/1     Running   0          43s", "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-ctrl-88bcd6dcb-hhmzn   2/2     Running   0          3m31s", "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-bxbs8   1/1     Running   0          85s", "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-gszqw   1/1     Running   0          81s", "pvc-7b4b41d8-55df-4772-a6c5-d89baad1760c-rep-84c798c8d7-nhkbc   1/1     Running   0          70s"]}

TASK [Obtain the new application pod name] *************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:263
2020-02-17T06:11:23.846352 (delta: 1.596985)         elapsed: 128.403258 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n sam -l app=busybox-sts --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.897389", "end": "2020-02-17 06:11:25.017395", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:11:24.120006", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-6pqcl", "stdout_lines": ["app-busybox-85d45b855f-6pqcl"]}

TASK [Verify if the new application pod is running] ****************************
task path: /experiments/functional/jiva-volume-resize/test.yml:272
2020-02-17T06:11:25.105224 (delta: 1.258821)         elapsed: 129.66213 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod \"app-busybox-85d45b855f-6pqcl\" -n sam --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.134212", "end": "2020-02-17 06:11:26.607428", "rc": 0, "start": "2020-02-17 06:11:25.473216", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obatin the node where new pod is scheduled] ******************************
task path: /experiments/functional/jiva-volume-resize/test.yml:281
2020-02-17T06:11:26.710738 (delta: 1.605456)         elapsed: 131.267644 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod \"app-busybox-85d45b855f-6pqcl\" -n sam --no-headers -o custom-columns=:.spec.nodeName", "delta": "0:00:00.929826", "end": "2020-02-17 06:11:27.938165", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:11:27.008339", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node2", "stdout_lines": ["e2e1-node2"]}

TASK [Obtain the  ds pod corresponding to new application pod] *****************
task path: /experiments/functional/jiva-volume-resize/test.yml:290
2020-02-17T06:11:28.030032 (delta: 1.318793)         elapsed: 132.586938 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=jiva-resize -o wide --no-headers -o custom-columns=:.metadata.name,:.spec.nodeName | grep \"e2e1-node2\" | awk '{print $1}'", "delta": "0:00:00.946765", "end": "2020-02-17 06:11:29.256146", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:11:28.309381", "stderr": "", "stderr_lines": [], "stdout": "jiva-resize-c8569", "stdout_lines": ["jiva-resize-c8569"]}

TASK [Verify the resized size of volume] ***************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:300
2020-02-17T06:11:29.374208 (delta: 1.344111)         elapsed: 133.931114 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ desired_size }}' != status.stdout
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"jiva-resize-c8569\" -- bash -c \"lsblk | grep 'sdf'\" | awk '{print $4}'", "delta": "0:00:01.577712", "end": "2020-02-17 06:11:31.348117", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:11:29.770405", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "10G", "stdout_lines": ["10G"]}

TASK [Delete the DaemonSet] ****************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:309
2020-02-17T06:11:31.520368 (delta: 2.146043)         elapsed: 136.077274 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f daemonset.yml", "delta": "0:00:00.907270", "end": "2020-02-17 06:11:32.701973", "failed_when_result": false, "rc": 0, "start": "2020-02-17 06:11:31.794703", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps \"jiva-resize\" deleted", "stdout_lines": ["daemonset.apps \"jiva-resize\" deleted"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:316
2020-02-17T06:11:32.796304 (delta: 1.275847)         elapsed: 137.35321 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-volume-resize/test.yml:326
2020-02-17T06:11:32.929656 (delta: 0.133292)         elapsed: 137.486562 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-02-17T06:11:33.068070 (delta: 0.138352)         elapsed: 137.624976 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-02-17T06:11:33.146014 (delta: 0.077856)         elapsed: 137.70292 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-02-17T06:11:33.220100 (delta: 0.074024)         elapsed: 137.777006 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-02-17T06:11:33.310418 (delta: 0.09023)         elapsed: 137.867324 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "3e8b96c3bf226ea983974c29c40ac85bfd2918c0", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3a0561547b153652c150a02d6cb33dfb", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1581919893.39-64091709427500/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-02-17T06:11:35.567820 (delta: 2.25735)         elapsed: 140.124726 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.717011", "end": "2020-02-17 06:11:36.571295", "rc": 0, "start": "2020-02-17 06:11:35.854284", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-volume-resize \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-volume-resize ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-02-17T06:11:36.641061 (delta: 1.073103)         elapsed: 141.197967 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-14T11:06:25Z", "generation": 23, "name": "jiva-volume-resize", "resourceVersion": "350247", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-volume-resize", "uid": "2b99718c-9890-4617-a479-6b930965524d"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=45   changed=39   unreachable=0    failed=0   

2020-02-17T06:11:37.645365 (delta: 1.004219)         elapsed: 142.202271 ****** 
=============================================================================== 
```
