### PR TITLE
refactor(pool-create): Modified and updated the cspc pool creation litmus book

### DIFF
--- a/providers/cstor/cstor-cspc-pool/add_blockdevice.yml
+++ b/providers/cstor/cstor-cspc-pool/add_blockdevice.yml
@@ -1,6 +1,6 @@
 ---
     - name: Getting the Unclaimed block-device from each node 
-      shell: kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ outer_item }} -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n "{{ disk_count }}"
+      shell: kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ outer_item }} -o json | jq '.items[] | select(.status.claimState=="Unclaimed") | select(.status.state=="Active") | .metadata.name' | tr "\"" " " | grep -v sparse | head -n "{{ disk_count }}"
       register: blockDevice
 
     - name: Add the block devices

--- a/providers/cstor/cstor-cspc-pool/cspc.yml
+++ b/providers/cstor/cstor-cspc-pool/cspc.yml
@@ -12,6 +12,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: sc-name
+  annotations:
+    openebs.io/cas-type: cstor  
 provisioner: cstor.csi.openebs.io
 allowVolumeExpansion: true
 parameters:

--- a/providers/cstor/cstor-cspc-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-cspc-pool/run_litmus_test.yml
@@ -28,6 +28,7 @@ spec:
             value: cstor-cspc-disk-pool
 
            # Provide the value for POOL_TYPE 
+           # stripe, mirror, raidz, raidz2
           - name: POOL_TYPE
             value: stripe
             
@@ -35,11 +36,18 @@ spec:
           - name: STORAGE_CLASS
             value: openebs-cstor-cspc-disk
 
+           # Namespace where the OpenEBS components are deployed
           - name: OPERATOR_NS
             value: openebs
 
+           # For creating pools value is "create"
+           # For removing cstor pools value is "delete"
           - name: DEPLOY_MODE
             value: create
+
+           # Pool count to create the required number of pools
+          - name: POOL_COUNT
+            value: '3'
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/cstor/cstor-cspc-pool/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -17,8 +17,9 @@
             status: 'SOT'
 
         - name: Getting the compute node name
-          shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'}
+          shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -{{ pool_count }} 
           register: nodes
+          failed_when: "(nodes.stdout_lines|length) != pool_count|int"
 
         - name: Checking OpenEBS-CSPC-Operator is running
           shell: kubectl get pods -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.labels.name=="cspc-operator")].status.phase}'
@@ -131,25 +132,26 @@
               delay: 5
               retries: 30
 
-            - name: Verify if cStor Pool are Running
+            - name: Verify if the cStor Pool pods are Running
               shell: >
                 kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item }}
                 --no-headers -o custom-columns=:status.phase
               args:
                 executable: /bin/bash
-              register: pool_count
+              register: poolcount
               with_items: "{{ cspi_name.stdout_lines }}"
-              until: "((pool_count.stdout_lines|unique)|length) == 1 and 'Running' in pool_count.stdout"
+              until: "((poolcount.stdout_lines|unique)|length) == 1 and 'Running' in poolcount.stdout"
               retries: 30
               delay: 10
 
-            - name: Get cStor Pool names to verify the container statuses
+            - name: Get cStor Pool pod names to verify the container statuses and check the required number of pools created. 
               shell: >
                 kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
                 --no-headers -o=custom-columns=NAME:".metadata.name"
               args:
                 executable: /bin/bash
               register: cstor_pool_pod
+              failed_when: "(cstor_pool_pod.stdout_lines|length) != pool_count|int"
 
             - name: Get the runningStatus of pool pod
               shell: >

--- a/providers/cstor/cstor-cspc-pool/test_vars.yml
+++ b/providers/cstor/cstor-cspc-pool/test_vars.yml
@@ -6,6 +6,7 @@ pool_type: "{{ lookup('env','POOL_TYPE') }}"
 sc_name: "{{ lookup('env', 'STORAGE_CLASS') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
 deploy_mode: "{{ lookup('env','DEPLOY_MODE') }}"
+pool_count: "{{ lookup('env','POOL_COUNT') }}"
 
 bd_count:
    stripe:


### PR DESCRIPTION
- Modified and updated the cspc pool creation litmus experiment based on the pool count and the device status

Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-02-19T12:08:32.768190 (delta: 0.063893)         elapsed: 0.063893 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-02-19T12:08:32.783876 (delta: 0.015629)         elapsed: 0.079579 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-02-19T12:08:43.742492 (delta: 10.958584)         elapsed: 11.038195 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-02-19T12:08:43.858473 (delta: 0.115939)         elapsed: 11.154176 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-02-19T12:08:43.942476 (delta: 0.083941)         elapsed: 11.238179 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-02-19T12:08:44.023691 (delta: 0.081156)         elapsed: 11.319394 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-19T12:08:44.191624 (delta: 0.167867)         elapsed: 11.487327 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "035bacdb4b1fd8992a7683879a3fea2b885ee8ef", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "723a8fdf57f6efa3378c103e9eb54b09", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1582114124.27-178185788929630/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-19T12:08:45.131907 (delta: 0.9402)         elapsed: 12.42761 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.145256", "end": "2020-02-19 12:08:46.742852", "rc": 0, "start": "2020-02-19 12:08:45.597596", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-19T12:08:46.806868 (delta: 1.674893)         elapsed: 14.102571 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-19T09:49:30Z", "generation": 15, "name": "cstor-pool-provision", "resourceVersion": "797499", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "ae79c6ec-b95c-4031-8a4f-40d3b255abe9"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-19T12:08:48.168661 (delta: 1.361737)         elapsed: 15.464364 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-19T12:08:48.256132 (delta: 0.087363)         elapsed: 15.551835 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-19T12:08:48.356144 (delta: 0.099936)         elapsed: 15.651847 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-02-19T12:08:48.470925 (delta: 0.114689)         elapsed: 15.766628 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -3", "delta": "0:00:01.419876", "end": "2020-02-19 12:08:50.251022", "failed_when_result": false, "rc": 0, "start": "2020-02-19 12:08:48.831146", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node1.mayalabs.io\nd2iq-node2.mayalabs.io\nd2iq-node3.mayalabs.io", "stdout_lines": ["d2iq-node1.mayalabs.io", "d2iq-node2.mayalabs.io", "d2iq-node3.mayalabs.io"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2020-02-19T12:08:50.394535 (delta: 1.923516)         elapsed: 17.690238 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:01.293399", "end": "2020-02-19 12:08:51.989215", "failed_when_result": false, "rc": 0, "start": "2020-02-19 12:08:50.695816", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-02-19T12:08:52.103776 (delta: 1.709153)         elapsed: 19.399479 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}}) => {"ansible_facts": {"disk_count": "1"}, "changed": false, "item": {"key": "stripe", "value": {"count": 1}}}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Add node labels for each nodes and create blockdevice template] **********
2020-02-19T12:08:52.439973 (delta: 0.336103)         elapsed: 19.735676 ******* 
changed: [127.0.0.1] => (item=[u'd2iq-node1.mayalabs.io']) => {"changed": true, "checksum": "e1140a6168ed1d851262f40dda41e02868e3d66c", "dest": "./blockdevice-d2iq-node1.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["d2iq-node1.mayalabs.io"], "md5sum": "fbfc3556eb7e895e4033ec2088b540ab", "mode": "0644", "owner": "root", "size": 356, "src": "/root/.ansible/tmp/ansible-tmp-1582114132.52-133918871505981/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item=[u'd2iq-node2.mayalabs.io']) => {"changed": true, "checksum": "acf10cef7dc94e1f789ae93811c80233342cf3fe", "dest": "./blockdevice-d2iq-node2.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["d2iq-node2.mayalabs.io"], "md5sum": "5d26d84f3942f2ec7dcf43f7a5ad2531", "mode": "0644", "owner": "root", "size": 356, "src": "/root/.ansible/tmp/ansible-tmp-1582114132.9-201456507121257/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item=[u'd2iq-node3.mayalabs.io']) => {"changed": true, "checksum": "a83fcfc79fd5710a8aedb42283a5df13f9ff021d", "dest": "./blockdevice-d2iq-node3.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["d2iq-node3.mayalabs.io"], "md5sum": "a0aa217b41f50bf25147f2169fd6804e", "mode": "0644", "owner": "root", "size": 356, "src": "/root/.ansible/tmp/ansible-tmp-1582114133.32-224003470055950/source", "state": "file", "uid": 0}

TASK [Getting the Unclaimed block-device count] ********************************
2020-02-19T12:08:53.798179 (delta: 1.358148)         elapsed: 21.093882 ******* 
changed: [127.0.0.1] => (item=d2iq-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.383627", "end": "2020-02-19 12:08:55.455560", "item": "d2iq-node1.mayalabs.io", "rc": 0, "start": "2020-02-19 12:08:54.071933", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-6947a7d913e339c1b77fc6b656dcf2bf", "stdout_lines": ["blockdevice-6947a7d913e339c1b77fc6b656dcf2bf"]}
changed: [127.0.0.1] => (item=d2iq-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.247847", "end": "2020-02-19 12:08:56.984522", "item": "d2iq-node2.mayalabs.io", "rc": 0, "start": "2020-02-19 12:08:55.736675", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1658bfaa186fc9d981aef48f6b43d427", "stdout_lines": ["blockdevice-1658bfaa186fc9d981aef48f6b43d427"]}
changed: [127.0.0.1] => (item=d2iq-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.280786", "end": "2020-02-19 12:08:58.496875", "item": "d2iq-node3.mayalabs.io", "rc": 0, "start": "2020-02-19 12:08:57.216089", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-2db6873c2e66a898458efe38e12b9d49", "stdout_lines": ["blockdevice-2db6873c2e66a898458efe38e12b9d49"]}

TASK [set_fact] ****************************************************************
2020-02-19T12:08:58.593727 (delta: 4.795486)         elapsed: 25.88943 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Add the block devices for each node's block device template] *************
2020-02-19T12:08:58.720779 (delta: 0.126967)         elapsed: 26.016482 ******* 
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-02-19T12:08:58.922276 (delta: 0.201425)         elapsed: 26.217979 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.415084", "end": "2020-02-19 12:09:00.660673", "rc": 0, "start": "2020-02-19 12:08:59.245589", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-6947a7d913e339c1b77fc6b656dcf2bf ", "stdout_lines": [" blockdevice-6947a7d913e339c1b77fc6b656dcf2bf "]}

TASK [Add the block devices] ***************************************************
2020-02-19T12:09:00.729438 (delta: 1.807052)         elapsed: 28.025141 ******* 
changed: [127.0.0.1] => (item= blockdevice-6947a7d913e339c1b77fc6b656dcf2bf ) => {"backup": "", "changed": true, "item": " blockdevice-6947a7d913e339c1b77fc6b656dcf2bf ", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-02-19T12:09:01.368285 (delta: 0.63878)         elapsed: 28.663988 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.214985", "end": "2020-02-19 12:09:02.874098", "rc": 0, "start": "2020-02-19 12:09:01.659113", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-1658bfaa186fc9d981aef48f6b43d427 ", "stdout_lines": [" blockdevice-1658bfaa186fc9d981aef48f6b43d427 "]}

TASK [Add the block devices] ***************************************************
2020-02-19T12:09:02.992223 (delta: 1.62383)         elapsed: 30.287926 ******** 
changed: [127.0.0.1] => (item= blockdevice-1658bfaa186fc9d981aef48f6b43d427 ) => {"backup": "", "changed": true, "item": " blockdevice-1658bfaa186fc9d981aef48f6b43d427 ", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-02-19T12:09:03.352273 (delta: 0.359956)         elapsed: 30.647976 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.292708", "end": "2020-02-19 12:09:04.951710", "rc": 0, "start": "2020-02-19 12:09:03.659002", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-2db6873c2e66a898458efe38e12b9d49 ", "stdout_lines": [" blockdevice-2db6873c2e66a898458efe38e12b9d49 "]}

TASK [Add the block devices] ***************************************************
2020-02-19T12:09:05.020434 (delta: 1.6681)         elapsed: 32.316137 ********* 
changed: [127.0.0.1] => (item= blockdevice-2db6873c2e66a898458efe38e12b9d49 ) => {"backup": "", "changed": true, "item": " blockdevice-2db6873c2e66a898458efe38e12b9d49 ", "msg": "line added"}

TASK [Include the blockdevice template in the CSPC spec] ***********************
2020-02-19T12:09:05.410827 (delta: 0.390316)         elapsed: 32.70653 ******** 
changed: [127.0.0.1] => (item=d2iq-node1.mayalabs.io) => {"changed": true, "item": "d2iq-node1.mayalabs.io", "msg": "Block inserted"}
changed: [127.0.0.1] => (item=d2iq-node2.mayalabs.io) => {"changed": true, "item": "d2iq-node2.mayalabs.io", "msg": "Block inserted"}
changed: [127.0.0.1] => (item=d2iq-node3.mayalabs.io) => {"changed": true, "item": "d2iq-node3.mayalabs.io", "msg": "Block inserted"}

TASK [Replacing the pool group id in CSPC spec] ********************************
2020-02-19T12:09:06.645144 (delta: 1.234232)         elapsed: 33.940847 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replacing the storage class name in CSPC spec] ***************************
2020-02-19T12:09:07.193237 (delta: 0.548017)         elapsed: 34.48894 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the namespace in CSPC spec] ************************************
2020-02-19T12:09:07.596895 (delta: 0.403597)         elapsed: 34.892598 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the pool type in CSPC spec] ************************************
2020-02-19T12:09:07.938693 (delta: 0.341686)         elapsed: 35.234396 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "6 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2020-02-19T12:09:08.217033 (delta: 0.278279)         elapsed: 35.512736 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: CStorPoolCluster
metadata:
  name: cstor-cspc-disk-pool3
  namespace: openebs
spec:
  pools:
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: d2iq-node3.mayalabs.io
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
      raidGroups:
      - type: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
        blockDevices:
        - blockDeviceName:  blockdevice-2db6873c2e66a898458efe38e12b9d49
# ## d2iq-node3.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: d2iq-node2.mayalabs.io
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
      raidGroups:
      - type: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
        blockDevices:
        - blockDeviceName:  blockdevice-1658bfaa186fc9d981aef48f6b43d427
# ## d2iq-node2.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: d2iq-node1.mayalabs.io
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
      raidGroups:
      - type: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
        blockDevices:
        - blockDeviceName:  blockdevice-6947a7d913e339c1b77fc6b656dcf2bf
# ## d2iq-node1.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK

---

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-cspc-disk3
provisioner: cstor.csi.openebs.io
allowVolumeExpansion: true
parameters:
  cas-type: cstor
  cstorPoolCluster: cstor-cspc-disk-pool3
  replicaCount: "3") => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: CStorPoolCluster\nmetadata:\n  name: cstor-cspc-disk-pool3\n  namespace: openebs\nspec:\n  pools:\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: d2iq-node3.mayalabs.io\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n      raidGroups:\n      - type: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n        blockDevices:\n        - blockDeviceName:  blockdevice-2db6873c2e66a898458efe38e12b9d49\n# ## d2iq-node3.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: d2iq-node2.mayalabs.io\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n      raidGroups:\n      - type: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n        blockDevices:\n        - blockDeviceName:  blockdevice-1658bfaa186fc9d981aef48f6b43d427\n# ## d2iq-node2.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: d2iq-node1.mayalabs.io\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n      raidGroups:\n      - type: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n        blockDevices:\n        - blockDeviceName:  blockdevice-6947a7d913e339c1b77fc6b656dcf2bf\n# ## d2iq-node1.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK\n\n---\n\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-cspc-disk3\nprovisioner: cstor.csi.openebs.io\nallowVolumeExpansion: true\nparameters:\n  cas-type: cstor\n  cstorPoolCluster: cstor-cspc-disk-pool3\n  replicaCount: \"3\""
}

TASK [Create cstor disk pool] **************************************************
2020-02-19T12:09:08.349803 (delta: 0.132695)         elapsed: 35.645506 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc.yml", "delta": "0:00:01.577997", "end": "2020-02-19 12:09:10.256635", "rc": 0, "start": "2020-02-19 12:09:08.678638", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.openebs.io/cstor-cspc-disk-pool3 created\nstorageclass.storage.k8s.io/openebs-cstor-cspc-disk3 created", "stdout_lines": ["cstorpoolcluster.openebs.io/cstor-cspc-disk-pool3 created", "storageclass.storage.k8s.io/openebs-cstor-cspc-disk3 created"]}

TASK [Check whether cspc is created] *******************************************
2020-02-19T12:09:10.377905 (delta: 2.028036)         elapsed: 37.673608 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspc -n openebs -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.378309", "end": "2020-02-19 12:09:12.112515", "rc": 0, "start": "2020-02-19 12:09:10.734206", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool\ncstor-cspc-disk-pool2\ncstor-cspc-disk-pool3", "stdout_lines": ["cstor-cspc-disk-pool", "cstor-cspc-disk-pool2", "cstor-cspc-disk-pool3"]}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-02-19T12:09:12.200455 (delta: 1.82243)         elapsed: 39.496158 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool3 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:02.139702", "end": "2020-02-19 12:09:14.687722", "rc": 0, "start": "2020-02-19 12:09:12.548020", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool3-29mb\ncstor-cspc-disk-pool3-4phg\ncstor-cspc-disk-pool3-m85s", "stdout_lines": ["cstor-cspc-disk-pool3-29mb", "cstor-cspc-disk-pool3-4phg", "cstor-cspc-disk-pool3-m85s"]}

TASK [Verify the status of CSPI] ***********************************************
2020-02-19T12:09:14.814828 (delta: 2.614308)         elapsed: 42.110531 ******* 
FAILED - RETRYING: Verify the status of CSPI (30 retries left).
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-29mb) => {"attempts": 2, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool3-29mb\")].status.phase}'", "delta": "0:00:02.354018", "end": "2020-02-19 12:09:24.028922", "item": "cstor-cspc-disk-pool3-29mb", "rc": 0, "start": "2020-02-19 12:09:21.674904", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-4phg) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool3-4phg\")].status.phase}'", "delta": "0:00:01.255424", "end": "2020-02-19 12:09:25.491318", "item": "cstor-cspc-disk-pool3-4phg", "rc": 0, "start": "2020-02-19 12:09:24.235894", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-m85s) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool3-m85s\")].status.phase}'", "delta": "0:00:01.159912", "end": "2020-02-19 12:09:27.064973", "item": "cstor-cspc-disk-pool3-m85s", "rc": 0, "start": "2020-02-19 12:09:25.905061", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify if cStor Pool are Running] ****************************************
2020-02-19T12:09:27.137260 (delta: 12.322347)         elapsed: 54.432963 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-29mb) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool3-29mb --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.269807", "end": "2020-02-19 12:09:28.683605", "item": "cstor-cspc-disk-pool3-29mb", "rc": 0, "start": "2020-02-19 12:09:27.413798", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-4phg) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool3-4phg --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.277099", "end": "2020-02-19 12:09:30.249234", "item": "cstor-cspc-disk-pool3-4phg", "rc": 0, "start": "2020-02-19 12:09:28.972135", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-m85s) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool3-m85s --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.338054", "end": "2020-02-19 12:09:31.830190", "item": "cstor-cspc-disk-pool3-m85s", "rc": 0, "start": "2020-02-19 12:09:30.492136", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get cStor Pool names to verify the container statuses] *******************
2020-02-19T12:09:31.918983 (delta: 4.781666)         elapsed: 59.214686 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool3 --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.313637", "end": "2020-02-19 12:09:33.530503", "rc": 0, "start": "2020-02-19 12:09:32.216866", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool3-29mb-58c6f647f5-ncp24\ncstor-cspc-disk-pool3-4phg-6f8f8689f9-tqss2\ncstor-cspc-disk-pool3-m85s-6c59c9f56d-6pp94", "stdout_lines": ["cstor-cspc-disk-pool3-29mb-58c6f647f5-ncp24", "cstor-cspc-disk-pool3-4phg-6f8f8689f9-tqss2", "cstor-cspc-disk-pool3-m85s-6c59c9f56d-6pp94"]}

TASK [Get the runningStatus of pool pod] ***************************************
2020-02-19T12:09:33.645135 (delta: 1.726089)         elapsed: 60.940838 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-29mb-58c6f647f5-ncp24) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool3-29mb-58c6f647f5-ncp24 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.294041", "end": "2020-02-19 12:09:35.291967", "item": "cstor-cspc-disk-pool3-29mb-58c6f647f5-ncp24", "rc": 0, "start": "2020-02-19 12:09:33.997926", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-4phg-6f8f8689f9-tqss2) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool3-4phg-6f8f8689f9-tqss2 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.289458", "end": "2020-02-19 12:09:36.929380", "item": "cstor-cspc-disk-pool3-4phg-6f8f8689f9-tqss2", "rc": 0, "start": "2020-02-19 12:09:35.639922", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool3-m85s-6c59c9f56d-6pp94) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool3-m85s-6c59c9f56d-6pp94 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.295072", "end": "2020-02-19 12:09:38.479652", "item": "cstor-cspc-disk-pool3-m85s-6c59c9f56d-6pp94", "rc": 0, "start": "2020-02-19 12:09:37.184580", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if the storage class is created] ***********************************
2020-02-19T12:09:38.598751 (delta: 4.95351)         elapsed: 65.894454 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc", "delta": "0:00:02.236194", "end": "2020-02-19 12:09:41.095806", "failed_when_result": false, "rc": 0, "start": "2020-02-19 12:09:38.859612", "stderr": "", "stderr_lines": [], "stdout": "NAME                        PROVISIONER                                                AGE\nopenebs-cstor-cspc-disk     cstor.csi.openebs.io                                       77m\nopenebs-cstor-cspc-disk2    cstor.csi.openebs.io                                       9m40s\nopenebs-cstor-cspc-disk3    cstor.csi.openebs.io                                       30s\nopenebs-device              openebs.io/local                                           3h43m\nopenebs-hostpath            openebs.io/local                                           3h43m\nopenebs-jiva-default        openebs.io/provisioner-iscsi                               3h43m\nopenebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   3h43m", "stdout_lines": ["NAME                        PROVISIONER                                                AGE", "openebs-cstor-cspc-disk     cstor.csi.openebs.io                                       77m", "openebs-cstor-cspc-disk2    cstor.csi.openebs.io                                       9m40s", "openebs-cstor-cspc-disk3    cstor.csi.openebs.io                                       30s", "openebs-device              openebs.io/local                                           3h43m", "openebs-hostpath            openebs.io/local                                           3h43m", "openebs-jiva-default        openebs.io/provisioner-iscsi                               3h43m", "openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   3h43m"]}

TASK [Remove the CStor Pool Cluster] *******************************************
2020-02-19T12:09:41.238879 (delta: 2.640047)         elapsed: 68.534582 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CStor Pool Cluster is deleted] *****************************
2020-02-19T12:09:41.363575 (delta: 0.12461)         elapsed: 68.659278 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CSPI is getting removed] ***********************************
2020-02-19T12:09:41.485797 (delta: 0.122131)         elapsed: 68.7815 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor pool pods are deleted] *******************************
2020-02-19T12:09:41.624261 (delta: 0.138374)         elapsed: 68.919964 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-02-19T12:09:41.731138 (delta: 0.106784)         elapsed: 69.026841 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-02-19T12:09:41.848768 (delta: 0.117546)         elapsed: 69.144471 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-19T12:09:41.988901 (delta: 0.14005)         elapsed: 69.284604 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-19T12:09:42.053251 (delta: 0.064285)         elapsed: 69.348954 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-19T12:09:42.137669 (delta: 0.084362)         elapsed: 69.433372 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-19T12:09:42.209911 (delta: 0.072184)         elapsed: 69.505614 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "501786648ab66e7fc2a021e95e8fcc53f8ff4f77", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "23c79b43245ac077305a179ea8f3e971", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1582114182.28-5199988590680/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-19T12:09:44.776907 (delta: 2.566932)         elapsed: 72.07261 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.056582", "end": "2020-02-19 12:09:46.064055", "rc": 0, "start": "2020-02-19 12:09:45.007473", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-19T12:09:46.130380 (delta: 1.353382)         elapsed: 73.426083 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-19T09:49:30Z", "generation": 16, "name": "cstor-pool-provision", "resourceVersion": "797935", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "ae79c6ec-b95c-4031-8a4f-40d3b255abe9"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=40   changed=29   unreachable=0    failed=0   

2020-02-19T12:09:47.324106 (delta: 1.193673)         elapsed: 74.619809 ******* 
=============================================================================== 
```