### PR TITLE
Refactor backup & restore to deprovision velero based on env

### DIFF
--- a/experiments/functional/backup_and_restore/run_litmus_test.yml
+++ b/experiments/functional/backup_and_restore/run_litmus_test.yml
@@ -55,6 +55,9 @@ spec:
           # supported values are: cstor, jiva, localpv
           - name: STORAGE_ENGINE
             value: "cstor"
+          # supported values are: true & false (Deprovision velero namespace after test completion)
+          - name: DEPROVISION_VELERO
+            value: "false"
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/backup_and_restore/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/backup_and_restore/setup_dependency.yml
+++ b/experiments/functional/backup_and_restore/setup_dependency.yml
@@ -120,6 +120,14 @@
   shell: velero plugin add {{ velero_plugin_name }}
   when: storage_engine == "cstor"
 
+#After installing pugin velero a new velero pod comes up with the older one in Running state which later terminates.  
+- name: Waiting for new velero server pod to come up
+  shell: kubectl get pod -n velero -l component=velero | grep Running | wc -l 
+  register: velero_pod_run
+  until: "'1' in velero_pod_run.stdout"
+  delay: 5
+  retries: 20
+
 - name: Checking for velero server status
   shell: kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'
   register: velero_status_post_update

--- a/experiments/functional/backup_and_restore/test.yml
+++ b/experiments/functional/backup_and_restore/test.yml
@@ -156,4 +156,5 @@
             status: 'EOT'    
 
         - name: Deprovisioning Velero server
-          shell: kubectl delete namespace velero    
+          shell: kubectl delete namespace velero 
+          when: lookup('env','DEPROVISION_VELERO') == 'true'


### PR DESCRIPTION
Signed-off-by: shashank855 <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Deprovision velero server based on env passed in litmus job.
- Waits for the single velero pod to be in running state after adding openebs plugin.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

**Optional feature to deprovision velero server is needed when debugging the cause for backup failure in log running Gitlab pipelines.**
