### PR TITLE
feat[litmusbook]: Included a litmus experiment to perform the CSPC pool scaledown

### DIFF
--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/README.md
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/README.md
@@ -1,0 +1,35 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | Storage | K8s Platform |
+| ----- | ------------------------------------------------------------ | ------- | ------------ |
+| Day-2-ops |  Scale down the cstor CSPC pool and check if it scaled down successfully | OpenEBS | Any          |
+
+#### Description
+
+The goal of this test is to scale down the cstor CSPC pool and check if its successfully scaled down.
+
+#### Prerequisites
+
+- cStor based storage pool should have been available.
+- cStor CSI volumes shouldn't be available on the pool that needed to be scale down.
+
+#### Litmus experiment Environment Variables
+
+| Parameter        | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| POOL_NAME        | Names of CSPC pool name to scaledown the cspi pools          |
+| OPERATOR_NS      | Namespace where OpenEBS is installed                         |
+
+
+#### Procedure
+
+- Verify the CSPI are all in `ONLINE` state and  Check the Pool pods are all running
+- Select the pool [cspi] want to scale down.
+- Obtain the node name of the targeted CSPI for scaledown.
+- Remove the CSPI entry from the CSPC 
+
+#### Expected result
+
+- blockDevices of the scaled down CSPI should be in Unclaimed state.
+- CSPI and the pool pod corresponding to scaled down pool should be deleted
+

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/node_index_count
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/node_index_count
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+declare -i index=-1
+nodeName=$1
+while read i; do
+index=$(( index + 1 ))
+if [[ $i == *"$nodeName"* ]]; then
+  break
+fi
+done <<<$(jq -c '.spec.pools[]' $2)
+echo $index
+

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/pool_scaledown.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/pool_scaledown.yml
@@ -1,0 +1,45 @@
+---
+
+    - name: Getting the node name for the targeted cspi
+      shell: >
+        kubectl get cspi -n {{ operator_ns }} {{ targeted_cspi }} -o custom-columns=:.spec.hostName --no-headers
+      args:
+        executable: /bin/bash
+      register: node_name
+
+    - name: Getting the used block-device by CSPI
+      shell: >
+        kubectl get cspi -n {{ operator_ns }} {{ targeted_cspi }} 
+        -o custom-columns=:.spec.raidGroup[*].blockDevices[*].blockDeviceName --no-headers
+      register: blockDevice
+
+    - name: Obtain the cspc pool spec in json format
+      shell: kubectl get cspc -n {{ operator_ns }} {{ pool_name }} -o json > ./cspc-pool-scaledown.json
+      args:
+       executable: /bin/bash
+
+    - name: Obtain the index position of the nodes from cspc json spec
+      shell: ./node_index_count {{ node_name.stdout }} ./cspc-pool-scaledown.json
+      register: index_count
+
+    - name: Patch the CSPC to scaledown the pool
+      shell: >
+        kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' 
+        -p='[{"op": "remove", "path": "/spec/pools/{{ index_count.stdout }}"}]'
+      args:
+        executable: /bin/bash
+      register: patch_cspc
+      failed_when: "'patched' not in patch_cspc.stdout"
+
+    - name: Check if the Blockdevice is in UnClaimed state
+      shell: >
+        kubectl get blockdevice -n {{ operator_ns }} {{ item }}
+        --no-headers -o custom-columns=:.status.claimState
+      args:
+        executable: /bin/bash
+      register: bd_state
+      with_items:
+        - "{{ blockDevice.stdout_lines }}"
+      until: "'Unclaimed' in bd_state.stdout"
+      delay: 5
+      retries: 60

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/run_litmus_test.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/run_litmus_test.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-cspc-pool-scaledown-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cstor-cspc-pool-scaledown
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # Provide POOL_NAME to scaledown
+          - name: POOL_NAME
+            value: ""
+
+           # Namespace where the OpenEBS components are deployed
+          - name: OPERATOR_NS
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/day2_ops/cspc_pool/pool_scaledown/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/test.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/test.yml
@@ -1,0 +1,121 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+         ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Obtain the CSPI name to verify the status
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: cspi_name
+
+        - name: Verify the status of CSPI before the pool scaledown
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
+          args:
+            executable: /bin/bash
+          register: cspi_status
+          with_items: "{{ cspi_name.stdout_lines }}"
+          until: "'ONLINE' in cspi_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Select random cspi from the list of cspi as targeted cspi to scale down
+          set_fact:
+            targeted_cspi: "{{ item }}"
+          with_random_choice: "{{ cspi_name.stdout_lines }}"              
+
+        - name: Verify if the cStor Pool pod is Running for the targeted cspi
+          shell: >
+            kubectl get pods -n {{ operator_ns }} 
+            -l 'openebs.io/cstor-pool-instance in ({{ targeted_cspi }}),openebs.io/cstor-pool-cluster in ({{ pool_name }})' 
+            --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: cspi_pool_pod
+          until: "'Running' in cspi_pool_pod.stdout"
+          retries: 30
+          delay: 10
+          
+        - name: Obtain the cStor pool pod name for the targeted cspi
+          shell: >
+            kubectl get pods -n {{ operator_ns }} 
+            -l 'openebs.io/cstor-pool-instance in ({{ targeted_cspi }}),openebs.io/cstor-pool-cluster in ({{ pool_name }})' 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: pool_pod_name
+
+         ####################################################################################
+         # TODO:                                                                            #
+         # Include a task to verify the volumes status of the targeted pool                 #
+         # Include a task to scaledown the volume and verify pool scaledown                 #
+         # Task to verify the pool scaledown is blocked when the volume is created in pool  #
+         #                                                                                  #
+         ####################################################################################                                                                                  
+        - name: Patch the CSPC to scaledown the pool
+          include_tasks: pool_scaledown.yml
+          with_items: "{{ targeted_cspi }}"
+          loop_control:
+            loop_var: outer_item
+
+        - name: Obtain the CSPI name to verify the scaledown pool is removed
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: new_cspi_name
+          until: "'targeted_cspi' not in new_cspi_name.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Verify the status of CSPI after scaledown the pool
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
+          args:
+            executable: /bin/bash
+          register: cspi_status
+          with_items: "{{ new_cspi_name.stdout_lines }}"
+          until: "'ONLINE' in cspi_status.stdout"
+          delay: 5
+          retries: 30          
+
+        - name: Verify the cStor pool pod is removed for the targeted cspi
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }} 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: pod_name
+          until: "'pool_pod_name.stdout' not in pod_name.stdout"
+          delay: 5
+          retries: 30
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+          - set_fact:
+              flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'

--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/test_vars.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/test_vars.yml
@@ -1,0 +1,5 @@
+# Test-specific parameters
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+test_name: cstor-cspc-pool-scaledown
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Implemented a litmusbook to perform the pool scaledown.
- Verify the CSPI are all in `ONLINE` state and  Check the Pool pods are all running
- Select the pool [cspi] want to scale down.
- Obtain the node name of the targeted CSPI for scaledown.
- Removed the CSPI entry from the CSPC 

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
user@user-Lenovo-ideapad-320-15IKB:~/learn/sathya-pr/maya-io/litmus-1/experiments/functional/day2_ops/cspc_pool/pool_scaleup$ kubectl logs -f cstor-cspc-pool-scaledown-lzxrk-kkt2m -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-02-27T08:59:03.227678 (delta: 0.041487)         elapsed: 0.041487 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-02-27T08:59:03.236099 (delta: 0.008392)         elapsed: 0.049908 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-02-27T08:59:08.615183 (delta: 5.37904)         elapsed: 5.428992 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-02-27T08:59:08.691593 (delta: 0.076376)         elapsed: 5.505402 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-02-27T08:59:08.762019 (delta: 0.070392)         elapsed: 5.575828 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-02-27T08:59:08.885213 (delta: 0.123161)         elapsed: 5.699022 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-27T08:59:09.035243 (delta: 0.14998)         elapsed: 5.849052 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "fe67e96c1a67f24e55732d4b2f803ebcc87a8327", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "873012e3dd97a26a1417291eee0f0f0f", "mode": "0644", "owner": "root", "size": 426, "src": "/root/.ansible/tmp/ansible-tmp-1582793949.1-200213950054523/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-27T08:59:09.602640 (delta: 0.567351)         elapsed: 6.416449 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.592266", "end": "2020-02-27 08:59:10.444061", "rc": 0, "start": "2020-02-27 08:59:09.851795", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-cspc-pool-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-cspc-pool-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-27T08:59:10.484694 (delta: 0.882003)         elapsed: 7.298503 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-27T08:19:21Z", "generation": 10, "name": "cstor-cspc-pool-scaledown", "resourceVersion": "36550", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-cspc-pool-scaledown", "uid": "ce8806fc-4a69-4be6-beb3-ef6c6f9e865b"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-27T08:59:11.384530 (delta: 0.899799)         elapsed: 8.198339 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-27T08:59:11.423255 (delta: 0.038691)         elapsed: 8.237064 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-27T08:59:11.463507 (delta: 0.040216)         elapsed: 8.277316 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-02-27T08:59:11.507893 (delta: 0.044346)         elapsed: 8.321702 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.958576", "end": "2020-02-27 08:59:12.607886", "rc": 0, "start": "2020-02-27 08:59:11.649310", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-2pz5\ncstor-cspc-disk-pool-c6x8\ncstor-cspc-disk-pool-mjhh", "stdout_lines": ["cstor-cspc-disk-pool-2pz5", "cstor-cspc-disk-pool-c6x8", "cstor-cspc-disk-pool-mjhh"]}

TASK [Verify the status of CSPI before the pool scaledown] *********************
2020-02-27T08:59:12.662199 (delta: 1.154269)         elapsed: 9.476008 ******** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-2pz5) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-2pz5\")].status.phase}'", "delta": "0:00:00.745919", "end": "2020-02-27 08:59:13.561586", "item": "cstor-cspc-disk-pool-2pz5", "rc": 0, "start": "2020-02-27 08:59:12.815667", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-c6x8) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-c6x8\")].status.phase}'", "delta": "0:00:00.696731", "end": "2020-02-27 08:59:14.386057", "item": "cstor-cspc-disk-pool-c6x8", "rc": 0, "start": "2020-02-27 08:59:13.689326", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-mjhh) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-mjhh\")].status.phase}'", "delta": "0:00:00.824569", "end": "2020-02-27 08:59:15.339357", "item": "cstor-cspc-disk-pool-mjhh", "rc": 0, "start": "2020-02-27 08:59:14.514788", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Select random cspi from the list of cspi as targeted cspi to scale down] ***
2020-02-27T08:59:15.383262 (delta: 2.721022)         elapsed: 12.197071 ******* 
ok: [127.0.0.1] => (item=cstor-cspc-disk-pool-mjhh) => {"ansible_facts": {"targeted_cspi": "cstor-cspc-disk-pool-mjhh"}, "changed": false, "item": "cstor-cspc-disk-pool-mjhh"}

TASK [Verify if the cStor Pool pod is Running for the targeted cspi] ***********
2020-02-27T08:59:15.452163 (delta: 0.068866)         elapsed: 12.265972 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l 'openebs.io/cstor-pool-instance in (cstor-cspc-disk-pool-mjhh),openebs.io/cstor-pool-cluster in (cstor-cspc-disk-pool)' --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.690721", "end": "2020-02-27 08:59:16.289102", "rc": 0, "start": "2020-02-27 08:59:15.598381", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the cStor pool pod name for the targeted cspi] ********************
2020-02-27T08:59:16.330725 (delta: 0.878519)         elapsed: 13.144534 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l 'openebs.io/cstor-pool-instance in (cstor-cspc-disk-pool-mjhh),openebs.io/cstor-pool-cluster in (cstor-cspc-disk-pool)' --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.687349", "end": "2020-02-27 08:59:17.164342", "rc": 0, "start": "2020-02-27 08:59:16.476993", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-mjhh-69dfdfbb86-8gx9q", "stdout_lines": ["cstor-cspc-disk-pool-mjhh-69dfdfbb86-8gx9q"]}

TASK [Patch the CSPC to scaledown the pool] ************************************
2020-02-27T08:59:17.230510 (delta: 0.899748)         elapsed: 14.044319 ******* 
included: /experiments/functional/day2_ops/cspc_pool/pool_scaledown/pool_scaledown.yml for 127.0.0.1

TASK [Getting the node name for the targeted cspi] *****************************
2020-02-27T08:59:17.305615 (delta: 0.075045)         elapsed: 14.119424 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-mjhh -o custom-columns=:.spec.hostName --no-headers", "delta": "0:00:00.661015", "end": "2020-02-27 08:59:18.112567", "rc": 0, "start": "2020-02-27 08:59:17.451552", "stderr": "", "stderr_lines": [], "stdout": "gke-sathya-test-default-pool-34db3653-qx74", "stdout_lines": ["gke-sathya-test-default-pool-34db3653-qx74"]}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-02-27T08:59:18.159223 (delta: 0.853553)         elapsed: 14.973032 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-mjhh -o custom-columns=:.spec.raidGroup[*].blockDevices[*].blockDeviceName --no-headers", "delta": "0:00:00.682929", "end": "2020-02-27 08:59:19.013308", "rc": 0, "start": "2020-02-27 08:59:18.330379", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-d581b916d014fd06f841b31681533b18", "stdout_lines": ["blockdevice-d581b916d014fd06f841b31681533b18"]}

TASK [Obtain the cspc pool spec in json format] ********************************
2020-02-27T08:59:19.052467 (delta: 0.893198)         elapsed: 15.866276 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspc -n openebs cstor-cspc-disk-pool -o json > ./cspc-pool-scaledown.json", "delta": "0:00:00.693626", "end": "2020-02-27 08:59:19.888099", "rc": 0, "start": "2020-02-27 08:59:19.194473", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the index position of the nodes from cspc json spec] **************
2020-02-27T08:59:19.925120 (delta: 0.872618)         elapsed: 16.738929 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "./node_index_count gke-sathya-test-default-pool-34db3653-qx74 ./cspc-pool-scaledown.json", "delta": "0:00:00.606391", "end": "2020-02-27 08:59:20.673138", "rc": 0, "start": "2020-02-27 08:59:20.066747", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Patch the CSPC to scaledown the pool] ************************************
2020-02-27T08:59:20.711468 (delta: 0.786298)         elapsed: 17.525277 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cspc -n openebs cstor-cspc-disk-pool --type='json' -p='[{\"op\": \"remove\", \"path\": \"/spec/pools/1\"}]'", "delta": "0:00:00.783287", "end": "2020-02-27 08:59:21.623117", "failed_when_result": false, "rc": 0, "start": "2020-02-27 08:59:20.839830", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.openebs.io/cstor-cspc-disk-pool patched", "stdout_lines": ["cstorpoolcluster.openebs.io/cstor-cspc-disk-pool patched"]}

TASK [Check if the Blockdevice is in UnClaimed state] **************************
2020-02-27T08:59:21.663544 (delta: 0.952045)         elapsed: 18.477353 ******* 
FAILED - RETRYING: Check if the Blockdevice is in UnClaimed state (60 retries left).
FAILED - RETRYING: Check if the Blockdevice is in UnClaimed state (59 retries left).
FAILED - RETRYING: Check if the Blockdevice is in UnClaimed state (58 retries left).
FAILED - RETRYING: Check if the Blockdevice is in UnClaimed state (57 retries left).
changed: [127.0.0.1] => (item=blockdevice-d581b916d014fd06f841b31681533b18) => {"attempts": 5, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-d581b916d014fd06f841b31681533b18 --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.683489", "end": "2020-02-27 08:59:46.167366", "item": "blockdevice-d581b916d014fd06f841b31681533b18", "rc": 0, "start": "2020-02-27 08:59:45.483877", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}

TASK [Obtain the CSPI name to verify the scaledown pool is removed] ************
2020-02-27T08:59:46.211399 (delta: 24.54782)         elapsed: 43.025208 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.703012", "end": "2020-02-27 08:59:47.069205", "rc": 0, "start": "2020-02-27 08:59:46.366193", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-2pz5\ncstor-cspc-disk-pool-c6x8", "stdout_lines": ["cstor-cspc-disk-pool-2pz5", "cstor-cspc-disk-pool-c6x8"]}

TASK [Verify the status od CSPI after scaledown the pool] **********************
2020-02-27T08:59:47.120161 (delta: 0.908718)         elapsed: 43.93397 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.668572", "end": "2020-02-27 08:59:47.960041", "rc": 0, "start": "2020-02-27 08:59:47.291469", "stderr": "", "stderr_lines": [], "stdout": "ONLINE\nONLINE", "stdout_lines": ["ONLINE", "ONLINE"]}

TASK [Verify the cStor pool pod is removed for the targeted cspi] **************
2020-02-27T08:59:48.007289 (delta: 0.885008)         elapsed: 44.821098 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.724241", "end": "2020-02-27 08:59:48.899340", "rc": 0, "start": "2020-02-27 08:59:48.175099", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-2pz5-7c5b89669c-fwl4p\ncstor-cspc-disk-pool-c6x8-766b9cb66c-g9qpm\ncstor-cspc-disk-pool-mjhh-69dfdfbb86-8gx9q", "stdout_lines": ["cstor-cspc-disk-pool-2pz5-7c5b89669c-fwl4p", "cstor-cspc-disk-pool-c6x8-766b9cb66c-g9qpm", "cstor-cspc-disk-pool-mjhh-69dfdfbb86-8gx9q"]}

TASK [set_fact] ****************************************************************
2020-02-27T08:59:48.951925 (delta: 0.94128)         elapsed: 45.765734 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-02-27T08:59:49.022655 (delta: 0.067412)         elapsed: 45.836464 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-27T08:59:49.105323 (delta: 0.082631)         elapsed: 45.919132 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-27T08:59:49.154670 (delta: 0.049308)         elapsed: 45.968479 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-27T08:59:49.212183 (delta: 0.055452)         elapsed: 46.025992 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-27T08:59:49.283345 (delta: 0.071085)         elapsed: 46.097154 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ff121d812f6b8a7dfd99702a9965809b6e1895ad", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "46106ec3e59a6ee8cb3de2de9b2056c2", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1582793989.33-246152705470885/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-27T08:59:50.794277 (delta: 1.510894)         elapsed: 47.608086 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.798659", "end": "2020-02-27 08:59:51.976672", "rc": 0, "start": "2020-02-27 08:59:51.178013", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-cspc-pool-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-cspc-pool-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-27T08:59:52.018716 (delta: 1.220366)         elapsed: 48.832525 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-27T08:19:21Z", "generation": 11, "name": "cstor-cspc-pool-scaledown", "resourceVersion": "36826", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-cspc-pool-scaledown", "uid": "ce8806fc-4a69-4be6-beb3-ef6c6f9e865b"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=26   changed=19   unreachable=0    failed=0   

2020-02-27T08:59:52.764877 (delta: 0.742716)         elapsed: 49.578686 ******* 
=============================================================================== 
```