### PR TITLE
feat[yaml]: Implemented litmusbook to validate revision counter value for jiva

### DIFF
--- a/experiments/chaos/revision_counter/README.md
+++ b/experiments/chaos/revision_counter/README.md
@@ -1,0 +1,36 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | Storage | Applications | K8s Platform |
+| ----- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Chaos | Ensure that revision counter value does not change while dumping the data using jiva & ensure that all jiva replica consumes same amount of storage. | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- Application should be created using jiva volume and should be up.
+- Jiva volume should be created with three replica.
+
+## Exit-Criteria
+
+- Application and all three jiva replica should be up.
+- All three jiva replica should consume same amount of storage.
+
+## Procedure
+
+- Obtain the nodes on which jiva replica pod is scheduled.
+
+- Continuously delete jiva replica pod of one same node while dumping some data.
+
+- Verify revision counter value in other jiva replica pod while deleting one jiva replica pod.
+
+- After dumping the data verify all the three jiva replica is consuming same amount of storage.
+  
+## Environment Variables
+
+| Parameters        | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| APP_LABEL         | Namespace where OpenEBS components are deployed. |
+| APP_NAMESPACE     | Namespace where application is deployed.         |
+| BLOCK_COUNT       | Block Count to dump the data using dd.           |
+| BLOCK_SIZE        | Block Size to dump the data using dd.            |
+| FILE_NAME         | File Name to dump the data using dd.             |
+| MOUNT_PATH        | Mount path where volume is mounted.              |

--- a/experiments/chaos/revision_counter/delete_replica.yml
+++ b/experiments/chaos/revision_counter/delete_replica.yml
@@ -1,7 +1,7 @@
-- name: Obtain the replica pod of one node
+- name: Obtain the jiva replica pod scheduled on one node
   shell: >
     kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
-    -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node1")].metadata.name}'
+    -o jsonpath='{.items[?(@.spec.nodeName=="'{{ delete_rep_node }}'")].metadata.name}'
   args:
     executable: /bin/bash
   register: replica_pod
@@ -27,7 +27,7 @@
 - name: Obtain one replica pod to check the revision counter value
   shell: >
     kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
-    -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node2")].metadata.name}'
+    -o jsonpath='{.items[?(@.spec.nodeName=="'{{ test_rep_node }}'")].metadata.name}'
   args:
     executable: /bin/bash
   register: replica_pod

--- a/experiments/chaos/revision_counter/delete_replica.yml
+++ b/experiments/chaos/revision_counter/delete_replica.yml
@@ -1,0 +1,43 @@
+- name: Obtain the replica pod of one node
+  shell: >
+    kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+    -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node1")].metadata.name}'
+  args:
+    executable: /bin/bash
+  register: replica_pod
+  failed_when: "replica_pod.rc != 0"
+
+- name: Delete the replica pod of one node
+  shell: >
+    kubectl delete pod "{{ replica_pod.stdout }}" -n {{ app_ns }}
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "status.rc != 0"
+
+- name: Verify if all the replica pods are in running state
+  shell: >
+    kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+    --no-headers -o custom-columns=:status.phase
+  register: running_rep_status
+  until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
+  delay: 10
+  retries: 30
+
+- name: Obtain one replica pod to check the revision counter value
+  shell: >
+    kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+    -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node2")].metadata.name}'
+  args:
+    executable: /bin/bash
+  register: replica_pod
+  failed_when: "replica_pod.rc != 0"  
+
+- name: Verify the revision counter value
+  shell: >
+    kubectl exec -ti "{{ replica_pod.stdout }}" -n {{ app_ns }} 
+    -- bash -c "du -h /openebs/revision.counter"
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "'4.0K' not in status.stdout"

--- a/experiments/chaos/revision_counter/run_litmus_test.yml
+++ b/experiments/chaos/revision_counter/run_litmus_test.yml
@@ -22,20 +22,25 @@ spec:
             #value: log_plays
             value: default
 
+            # Application Label 
           - name: APP_LABEL
             value: ''
 
+            # Application Namespace
           - name: APP_NAMESPACE
             value: ''
 
+            # Block Size to dump the data using dd 
           - name: BLOCK_SIZE
-            value: ''
+            value: '3000000'
 
+            # Block Count to dump the data using dd
           - name: BLOCK_COUNT
-            value: ''
+            value: '4k'
 
+            # File Name to dump the data using dd 
           - name: FILE_NAME
-            value: ''
+            value: 'abc.txt'
           
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/revision_counter/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/chaos/revision_counter/run_litmus_test.yml
+++ b/experiments/chaos/revision_counter/run_litmus_test.yml
@@ -41,6 +41,10 @@ spec:
             # File Name to dump the data using dd 
           - name: FILE_NAME
             value: 'abc.txt'
+
+            # Enter the mount path of application 
+          - name: MOUNT_PATH
+            value: ''
           
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/revision_counter/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/chaos/revision_counter/run_litmus_test.yml
+++ b/experiments/chaos/revision_counter/run_litmus_test.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-revision-counter-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: jiva-revision-counter
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: APP_LABEL
+            value: ''
+
+          - name: APP_NAMESPACE
+            value: ''
+
+          - name: BLOCK_SIZE
+            value: ''
+
+          - name: BLOCK_COUNT
+            value: ''
+
+          - name: FILE_NAME
+            value: ''
+          
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/revision_counter/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/chaos/revision_counter/test.yml
+++ b/experiments/chaos/revision_counter/test.yml
@@ -1,0 +1,120 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Verify that the AUT (Application Under Test) is running
+          shell: >
+            kubectl get pods -n "{{ app_ns }}" -l "{{ app_label }}" --no-headers 
+            -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "'Running' not in status.stdout"
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers 
+            -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: app_pod
+          failed_when: "app_pod.rc != 0"
+
+        - name: Check for all replicas to be in Running state
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            --no-headers -o custom-columns=:status.phase
+          register: running_rep_status
+          until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
+          delay: 10
+          retries: 30
+
+        - name: Load some data to perform chaos with dd
+          shell: >
+            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- bash 
+            -c "cd /var/lib/mysql && dd if=/dev/urandom of={{ file_name }} bs={{ block_size }} count={{ block_count }}" &
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Obtain the process ID for dumping data
+          shell: ps -aux | grep urandom | awk 'FNR==1{printf $2}'
+          args:
+            executable: /bin/bash
+          register: p_id
+          failed_when: "p_id.rc != 0"
+
+        # Delete the replica pod and verify the behaviour of revision counter
+        # while dumping the data 
+        - include_tasks: ./delete_replica.yml
+          loop: "{{ range(0, 10 | int, 1)|list }}"
+
+        - name: Wait until the dumping process is finished and pid was destroyed
+          wait_for:
+            path: /proc/{{ p_id.stdout }}/status
+            state: absent
+
+        # Verify that each replica consumes same storage
+
+        - name: Obtain one replica pod to verify consumed storage
+          shell: >
+            kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node2")].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: replica_pod
+          failed_when: "replica_pod.rc != 0"
+
+        - name: Obtain consumed storage size in one replica
+          shell: kubectl exec -ti {{ replica_pod.stdout }} -n {{ app_ns }} -- bash -c "du -h openebs"
+          args:
+            executable: /bin/bash
+          register: rep_pod_storage
+          failed_when: "rep_pod_storage.rc != 0"
+
+        - name: Obtain the replica pod which was being deleted
+          shell: >
+            kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node1")].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: replica_pod_chaos
+          failed_when: "replica_pod_chaos.rc != 0"
+                
+        - name: Verify consumed storage size in replica
+          shell: kubectl exec -ti {{ replica_pod_chaos.stdout }} -n {{ app_ns }} -- bash -c "du -h openebs"
+          args:
+            executable: /bin/bash
+          register: rep_size
+          until: "rep_pod_storage.stdout == rep_size.stdout"
+          delay: 60
+          retries: 60
+                        
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/chaos/revision_counter/test.yml
+++ b/experiments/chaos/revision_counter/test.yml
@@ -43,10 +43,24 @@
           delay: 10
           retries: 30
 
+        - name: Obtain the nodes on which jiva replica pods are scheduled 
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica
+            --no-headers -o custom-columns=:.spec.nodeName
+          args:
+            executable: /bin/bash
+          register: replica_nodes
+          failed_when: "replica_nodes.rc != 0"
+
+        - name: Store the nodes on which jiva replica pods are scheduled
+          set_fact: 
+            delete_rep_node: "{{ replica_nodes.stdout_lines[0] }}"
+            test_rep_node: "{{ replica_nodes.stdout_lines[1] }}"
+
         - name: Load some data to perform chaos with dd
           shell: >
             kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- bash 
-            -c "cd /var/lib/mysql && dd if=/dev/urandom of={{ file_name }} bs={{ block_size }} count={{ block_count }}" &
+            -c "dd if=/dev/urandom of={{ mount_path }}/{{ file_name }} bs={{ block_size }} count={{ block_count }}" &
           args:
             executable: /bin/bash
           register: status
@@ -74,7 +88,7 @@
         - name: Obtain one replica pod to verify consumed storage
           shell: >
             kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
-            -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node2")].metadata.name}'
+            -o jsonpath='{.items[?(@.spec.nodeName=="'{{ test_rep_node }}'")].metadata.name}'
           args:
             executable: /bin/bash
           register: replica_pod
@@ -90,7 +104,7 @@
         - name: Obtain the replica pod which was being deleted
           shell: >
             kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
-            -o jsonpath='{.items[?(@.spec.nodeName=="e2e2-dev-node1")].metadata.name}'
+            -o jsonpath='{.items[?(@.spec.nodeName=="'{{ delete_rep_node }}'")].metadata.name}'
           args:
             executable: /bin/bash
           register: replica_pod_chaos

--- a/experiments/chaos/revision_counter/test_vars.yml
+++ b/experiments/chaos/revision_counter/test_vars.yml
@@ -1,0 +1,15 @@
+---
+
+# Test specific parameters
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+block_size: "{{ lookup('env','BLOCK_SIZE') }}"
+
+block_count: "{{ lookup('env','BLOCK_COUNT') }}"
+
+file_name: "{{ lookup('env','FILE_NAME') }}"
+
+test_name: "jiva-revision-counter"

--- a/experiments/chaos/revision_counter/test_vars.yml
+++ b/experiments/chaos/revision_counter/test_vars.yml
@@ -12,4 +12,6 @@ block_count: "{{ lookup('env','BLOCK_COUNT') }}"
 
 file_name: "{{ lookup('env','FILE_NAME') }}"
 
+mount_path: "{{ lookup('env','MOUNT_PATH') }}"
+
 test_name: "jiva-revision-counter"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented litmusbook to validate revision counter value for jiva. This litmusbook deletes one replica some reasonable number of times and validate the value of revision counter in other replica, while dumping some data into it, later it validates the consumption of storage in both of the replica. 
**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2020-02-28T11:30:30.865866 (delta: 0.051753)         elapsed: 0.051753 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-02-28T11:30:30.877441 (delta: 0.011527)         elapsed: 0.063328 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-02-28T11:30:38.543891 (delta: 7.666429)         elapsed: 7.729778 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-02-28T11:30:38.617718 (delta: 0.073789)         elapsed: 7.803605 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-02-28T11:30:38.682234 (delta: 0.064477)         elapsed: 7.868121 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-02-28T11:30:38.743552 (delta: 0.061279)         elapsed: 7.929439 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-28T11:30:38.831993 (delta: 0.088402)         elapsed: 8.01788 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8547cdfbcbe6f4961a11da2034dd0716c0b1849d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "db5e5822c56e2db4a14a7729e0f7c8d2", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1582889438.88-22661256365639/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-28T11:30:39.474857 (delta: 0.642827)         elapsed: 8.660744 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.728309", "end": "2020-02-28 11:30:40.496765", "rc": 0, "start": "2020-02-28 11:30:39.768456", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-revision-counter \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-revision-counter ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-28T11:30:40.548979 (delta: 1.074082)         elapsed: 9.734866 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-28T10:58:39Z", "generation": 3, "name": "jiva-revision-counter", "resourceVersion": "34052", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-revision-counter", "uid": "bce77ed3-ee78-460f-afcf-afa412c1f03a"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-28T11:30:41.552758 (delta: 1.003735)         elapsed: 10.738645 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-28T11:30:41.605305 (delta: 0.052399)         elapsed: 10.791192 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-28T11:30:41.656716 (delta: 0.051371)         elapsed: 10.842603 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT (Application Under Test) is running] *****************
2020-02-28T11:30:41.708938 (delta: 0.052177)         elapsed: 10.894825 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n \"percona\" -l \"name=percona\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.865158", "end": "2020-02-28 11:30:42.773184", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:30:41.908026", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
2020-02-28T11:30:42.830050 (delta: 1.121055)         elapsed: 12.015937 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona -l name=percona --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.787723", "end": "2020-02-28 11:30:43.786952", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:30:42.999229", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-xqr7q", "stdout_lines": ["percona-8568b6cc96-xqr7q"]}

TASK [Check for all replicas to be in Running state] ***************************
2020-02-28T11:30:43.851816 (delta: 1.021723)         elapsed: 13.037703 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.847860", "end": "2020-02-28 11:30:44.877358", "rc": 0, "start": "2020-02-28 11:30:44.029498", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Load some data to perform chaos with dd] *********************************
2020-02-28T11:30:44.945377 (delta: 1.093515)         elapsed: 14.131264 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"percona-8568b6cc96-xqr7q\" -n \"percona\" -- bash -c \"cd /var/lib/mysql && dd if=/dev/urandom of=abcd.txt bs=4k count=3000000\" &", "delta": "0:00:01.815248", "end": "2020-02-28 11:30:46.939651", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:30:45.124403", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Obtain the process ID for dumping data] **********************************
2020-02-28T11:30:47.004271 (delta: 2.058819)         elapsed: 16.190158 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "ps -aux | grep urandom | awk 'FNR==1{printf $2}'", "delta": "0:00:00.707074", "end": "2020-02-28 11:30:47.865224", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:30:47.158150", "stderr": "", "stderr_lines": [], "stdout": "274", "stdout_lines": ["274"]}

TASK [include_tasks] ***********************************************************
2020-02-28T11:30:47.931217 (delta: 0.926901)         elapsed: 17.117104 ******* 
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=0)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=1)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=2)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=3)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=4)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=5)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=6)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=7)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=8)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=9)

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:30:48.136646 (delta: 0.205383)         elapsed: 17.322533 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.809649", "end": "2020-02-28 11:30:49.117434", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:30:48.307785", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-9fxj8", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-9fxj8"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:30:49.176953 (delta: 1.040118)         elapsed: 18.36284 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-9fxj8\" -n percona", "delta": "0:00:09.935572", "end": "2020-02-28 11:30:59.314045", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:30:49.378473", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-9fxj8\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-9fxj8\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:30:59.399304 (delta: 10.222306)         elapsed: 28.585191 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.857607", "end": "2020-02-28 11:31:11.560696", "rc": 0, "start": "2020-02-28 11:31:10.703089", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:31:11.617235 (delta: 12.217887)         elapsed: 40.803122 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.807872", "end": "2020-02-28 11:31:12.652321", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:11.844449", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:31:12.714376 (delta: 1.097094)         elapsed: 41.900263 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.046358", "end": "2020-02-28 11:31:13.934014", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:12.887656", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:31:13.994828 (delta: 1.280382)         elapsed: 43.180715 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.888669", "end": "2020-02-28 11:31:15.053988", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:14.165319", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-jp6rf", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-jp6rf"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:31:15.118263 (delta: 1.12336)         elapsed: 44.30415 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-jp6rf\" -n percona", "delta": "0:00:02.511257", "end": "2020-02-28 11:31:17.804429", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:15.293172", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-jp6rf\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-jp6rf\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:31:17.869640 (delta: 2.751332)         elapsed: 47.055527 ******* 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.836146", "end": "2020-02-28 11:31:29.911147", "rc": 0, "start": "2020-02-28 11:31:29.075001", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:31:29.972348 (delta: 12.102664)         elapsed: 59.158235 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.810882", "end": "2020-02-28 11:31:30.960868", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:30.149986", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:31:31.021229 (delta: 1.04879)         elapsed: 60.207116 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.071533", "end": "2020-02-28 11:31:32.301543", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:31.230010", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:31:32.360747 (delta: 1.339471)         elapsed: 61.546634 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.805040", "end": "2020-02-28 11:31:33.350355", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:32.545315", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-k7zcm", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-k7zcm"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:31:33.421231 (delta: 1.060409)         elapsed: 62.607118 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-k7zcm\" -n percona", "delta": "0:00:02.488258", "end": "2020-02-28 11:31:36.095331", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:33.607073", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-k7zcm\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-k7zcm\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:31:36.170819 (delta: 2.749541)         elapsed: 65.356706 ******* 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.829473", "end": "2020-02-28 11:31:48.324314", "rc": 0, "start": "2020-02-28 11:31:47.494841", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:31:48.389845 (delta: 12.218586)         elapsed: 77.575732 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.812824", "end": "2020-02-28 11:31:49.384604", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:48.571780", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:31:49.450078 (delta: 1.060161)         elapsed: 78.635965 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.059161", "end": "2020-02-28 11:31:50.695300", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:49.636139", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:31:50.753866 (delta: 1.303743)         elapsed: 79.939753 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.831955", "end": "2020-02-28 11:31:51.749355", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:50.917400", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-6s6qq", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-6s6qq"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:31:51.826574 (delta: 1.072663)         elapsed: 81.012461 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-6s6qq\" -n percona", "delta": "0:00:03.366940", "end": "2020-02-28 11:31:55.379849", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:31:52.012909", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-6s6qq\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-6s6qq\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:31:55.446559 (delta: 3.619932)         elapsed: 84.632446 ******* 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.836831", "end": "2020-02-28 11:32:07.533370", "rc": 0, "start": "2020-02-28 11:32:06.696539", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:32:07.599239 (delta: 12.152629)         elapsed: 96.785126 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.797040", "end": "2020-02-28 11:32:08.569612", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:07.772572", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:32:08.628702 (delta: 1.029418)         elapsed: 97.814589 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.034366", "end": "2020-02-28 11:32:09.837986", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:08.803620", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:32:09.906153 (delta: 1.277406)         elapsed: 99.09204 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.811578", "end": "2020-02-28 11:32:10.882486", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:10.070908", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-z8dm4", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-z8dm4"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:32:10.943259 (delta: 1.037027)         elapsed: 100.129146 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-z8dm4\" -n percona", "delta": "0:00:02.531068", "end": "2020-02-28 11:32:13.639729", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:11.108661", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-z8dm4\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-z8dm4\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:32:13.710064 (delta: 2.76676)         elapsed: 102.895951 ******* 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.839176", "end": "2020-02-28 11:32:25.794394", "rc": 0, "start": "2020-02-28 11:32:24.955218", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:32:25.852749 (delta: 12.142642)         elapsed: 115.038636 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.851432", "end": "2020-02-28 11:32:26.870084", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:26.018652", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:32:26.931850 (delta: 1.079055)         elapsed: 116.117737 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.082449", "end": "2020-02-28 11:32:28.197214", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:27.114765", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:32:28.266236 (delta: 1.334314)         elapsed: 117.452123 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.862499", "end": "2020-02-28 11:32:29.307499", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:28.445000", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-2xdgd", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-2xdgd"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:32:29.365307 (delta: 1.099002)         elapsed: 118.551194 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-2xdgd\" -n percona", "delta": "0:00:09.776694", "end": "2020-02-28 11:32:39.314856", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:29.538162", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-2xdgd\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-2xdgd\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:32:39.386117 (delta: 10.020762)         elapsed: 128.572004 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.820629", "end": "2020-02-28 11:32:51.437297", "rc": 0, "start": "2020-02-28 11:32:50.616668", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:32:51.495062 (delta: 12.108838)         elapsed: 140.680949 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.848950", "end": "2020-02-28 11:32:52.521275", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:51.672325", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:32:52.583804 (delta: 1.088697)         elapsed: 141.769691 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.025042", "end": "2020-02-28 11:32:53.776786", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:52.751744", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:32:53.836324 (delta: 1.252445)         elapsed: 143.022211 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.844424", "end": "2020-02-28 11:32:54.848143", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:54.003719", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-lpssq", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-lpssq"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:32:54.911795 (delta: 1.075421)         elapsed: 144.097682 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-lpssq\" -n percona", "delta": "0:00:14.233013", "end": "2020-02-28 11:33:09.311630", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:32:55.078617", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-lpssq\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-lpssq\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:33:09.391786 (delta: 14.479938)         elapsed: 158.577673 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.827062", "end": "2020-02-28 11:33:21.429863", "rc": 0, "start": "2020-02-28 11:33:20.602801", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:33:21.490174 (delta: 12.098321)         elapsed: 170.676061 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.833172", "end": "2020-02-28 11:33:22.508842", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:21.675670", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:33:22.575916 (delta: 1.085651)         elapsed: 171.761803 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.035365", "end": "2020-02-28 11:33:23.812529", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:22.777164", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:33:23.874439 (delta: 1.298478)         elapsed: 173.060326 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.867232", "end": "2020-02-28 11:33:24.916833", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:24.049601", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-gczkx", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-gczkx"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:33:24.978440 (delta: 1.10393)         elapsed: 174.164327 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-gczkx\" -n percona", "delta": "0:00:02.728277", "end": "2020-02-28 11:33:27.885184", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:25.156907", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-gczkx\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-gczkx\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:33:27.958416 (delta: 2.979836)         elapsed: 177.144303 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.832703", "end": "2020-02-28 11:33:40.074005", "rc": 0, "start": "2020-02-28 11:33:39.241302", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:33:40.151592 (delta: 12.193132)         elapsed: 189.337479 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.839229", "end": "2020-02-28 11:33:41.212322", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:40.373093", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:33:41.273954 (delta: 1.122313)         elapsed: 190.459841 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.030409", "end": "2020-02-28 11:33:42.479037", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:41.448628", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:33:42.540989 (delta: 1.266989)         elapsed: 191.726876 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.866565", "end": "2020-02-28 11:33:43.618575", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:42.752010", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-snxgj", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-snxgj"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:33:43.677313 (delta: 1.136257)         elapsed: 192.8632 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-snxgj\" -n percona", "delta": "0:00:03.494187", "end": "2020-02-28 11:33:47.354306", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:43.860119", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-snxgj\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-snxgj\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:33:47.415073 (delta: 3.737712)         elapsed: 196.60096 ******* 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.840803", "end": "2020-02-28 11:33:59.527768", "rc": 0, "start": "2020-02-28 11:33:58.686965", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:33:59.586778 (delta: 12.17167)         elapsed: 208.772665 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.821148", "end": "2020-02-28 11:34:00.591468", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:33:59.770320", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:34:00.650990 (delta: 1.064168)         elapsed: 209.836877 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.081822", "end": "2020-02-28 11:34:01.909822", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:00.828000", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the replica pod of one node] **************************************
2020-02-28T11:34:01.974905 (delta: 1.323868)         elapsed: 211.160792 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.815120", "end": "2020-02-28 11:34:02.979754", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:02.164634", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-ddqnn", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-ddqnn"]}

TASK [Delete the replica pod of one node] **************************************
2020-02-28T11:34:03.043302 (delta: 1.068354)         elapsed: 212.229189 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-ddqnn\" -n percona", "delta": "0:00:06.103576", "end": "2020-02-28 11:34:09.328685", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:03.225109", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-ddqnn\" deleted", "stdout_lines": ["pod \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-ddqnn\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-02-28T11:34:09.392320 (delta: 6.348954)         elapsed: 218.578207 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n percona -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.809130", "end": "2020-02-28 11:34:21.476345", "rc": 0, "start": "2020-02-28 11:34:20.667215", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-02-28T11:34:21.534555 (delta: 12.142155)         elapsed: 230.720442 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.840941", "end": "2020-02-28 11:34:22.545397", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:21.704456", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Verify the revision counter value] ***************************************
2020-02-28T11:34:22.604945 (delta: 1.070345)         elapsed: 231.790832 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td\" -n percona -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.085800", "end": "2020-02-28 11:34:23.888629", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:22.802829", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Wait until the dumping process is finished and pid was destroyed] ********
2020-02-28T11:34:23.946319 (delta: 1.34133)         elapsed: 233.132206 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 0, "path": "/proc/274/status", "port": null, "search_regex": null, "state": "absent"}

TASK [Obtain one replica pod to verify consumed storage] ***********************
2020-02-28T11:34:24.354658 (delta: 0.408294)         elapsed: 233.540545 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node2\")].metadata.name}'", "delta": "0:00:00.854594", "end": "2020-02-28 11:34:25.397904", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:24.543310", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td"]}

TASK [Obtain consumed storage size in one replica] *****************************
2020-02-28T11:34:25.456371 (delta: 1.101645)         elapsed: 234.642258 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-s46td -n percona -- bash -c \"du -h openebs\"", "delta": "0:00:01.045456", "end": "2020-02-28 11:34:26.683369", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:25.637913", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "23G\topenebs", "stdout_lines": ["23G\topenebs"]}

TASK [Obtain the replica pod which was being deleted] **************************
2020-02-28T11:34:26.743378 (delta: 1.286961)         elapsed: 235.929265 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n percona -l openebs.io/replica=jiva-replica -o jsonpath='{.items[?(@.spec.nodeName==\"e2e2-dev-node1\")].metadata.name}'", "delta": "0:00:00.833275", "end": "2020-02-28 11:34:27.751692", "failed_when_result": false, "rc": 0, "start": "2020-02-28 11:34:26.918417", "stderr": "", "stderr_lines": [], "stdout": "pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-qf88w", "stdout_lines": ["pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-qf88w"]}

TASK [Verify consumed storage size in replica] *********************************
2020-02-28T11:34:27.813547 (delta: 1.070094)         elapsed: 236.999434 ****** 
FAILED - RETRYING: Verify consumed storage size in replica (60 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (59 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (58 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (57 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl exec -ti pvc-cd6cdd72-89ab-44a2-a5c1-f99bcb5f2892-rep-556cbdddcf-qf88w -n percona -- bash -c \"du -h openebs\"", "delta": "0:00:01.389076", "end": "2020-02-28 11:38:34.677543", "rc": 0, "start": "2020-02-28 11:38:33.288467", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "23G\topenebs", "stdout_lines": ["23G\topenebs"]}

TASK [set_fact] ****************************************************************
2020-02-28T11:38:34.758396 (delta: 246.944801)         elapsed: 483.944283 **** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-02-28T11:38:34.859457 (delta: 0.10005)         elapsed: 484.045344 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-02-28T11:38:34.968726 (delta: 0.108991)         elapsed: 484.154613 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-02-28T11:38:35.030383 (delta: 0.061566)         elapsed: 484.21627 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-02-28T11:38:35.100260 (delta: 0.069792)         elapsed: 484.286147 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-02-28T11:38:35.165380 (delta: 0.06504)         elapsed: 484.351267 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "c7bb453ba95ef8088d0ef7c98077677950db905c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f84c1414b1d6a85910ec1a182e205f1f", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1582889915.23-180000556543098/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-02-28T11:38:37.473529 (delta: 2.308058)         elapsed: 486.659416 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.980483", "end": "2020-02-28 11:38:38.665630", "rc": 0, "start": "2020-02-28 11:38:37.685147", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-revision-counter \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-revision-counter ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-02-28T11:38:38.727817 (delta: 1.254198)         elapsed: 487.913704 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-02-28T10:58:39Z", "generation": 4, "name": "jiva-revision-counter", "resourceVersion": "36250", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-revision-counter", "uid": "bce77ed3-ee78-460f-afcf-afa412c1f03a"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=81   changed=65   unreachable=0    failed=0   

2020-02-28T11:38:39.695172 (delta: 0.967215)         elapsed: 488.881059 ****** 
=============================================================================== 
```