### PR TITLE
refactor(experiment,cspc):Update replica count in storage class to match the pool count

### DIFF
--- a/providers/cstor/cstor-cspc-pool/cspc.yml
+++ b/providers/cstor/cstor-cspc-pool/cspc.yml
@@ -19,4 +19,4 @@ allowVolumeExpansion: true
 parameters:
   cas-type: cstor
   cstorPoolCluster: pool-name
-  replicaCount: "3"
+  replicaCount: "replica-count"

--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -69,11 +69,17 @@
               with_items:
                 - "{{ nodes.stdout_lines }}"
 
-            - name: Replacing the pool group id in CSPC spec
+            - name: Replacing the pool name in CSPC spec
               replace:
                 path: ./cspc.yml
                 regexp: "pool-name"
                 replace: "{{ pool_name }}"
+
+            - name: Update replica count matching pool count in storage class spec
+              replace:
+                path: ./cspc.yml
+                regexp: "replica-count"
+                replace: "{{ pool_count }}"
 
             - name: Replacing the storage class name in CSPC spec
               replace:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- In storage class definition, updating the replica count parameter according to cspi count.

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
PLAY [localhost] ***************************************************************
2020-03-18T04:38:48.652673 (delta: 0.053432)         elapsed: 0.053432 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-03-18T04:38:48.665429 (delta: 0.012718)         elapsed: 0.066188 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-03-18T04:38:56.517219 (delta: 7.851764)         elapsed: 7.917978 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-03-18T04:38:56.603881 (delta: 0.086525)         elapsed: 8.00464 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-03-18T04:38:56.664014 (delta: 0.060097)         elapsed: 8.064773 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-03-18T04:38:56.735945 (delta: 0.071886)         elapsed: 8.136704 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-03-18T04:38:56.853219 (delta: 0.117216)         elapsed: 8.253978 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "035bacdb4b1fd8992a7683879a3fea2b885ee8ef", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "723a8fdf57f6efa3378c103e9eb54b09", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1584506336.91-178453463921457/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-03-18T04:38:57.528343 (delta: 0.675068)         elapsed: 8.929102 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.717296", "end": "2020-03-18 04:38:58.569934", "rc": 0, "start": "2020-03-18 04:38:57.852638", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-03-18T04:38:58.631994 (delta: 1.103605)         elapsed: 10.032753 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-03-18T04:03:09Z", "generation": 7, "name": "cstor-pool-provision", "resourceVersion": "2915355", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "155db1e2-28f7-47d1-a92b-515c5eee0f13"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-03-18T04:38:59.652527 (delta: 1.020487)         elapsed: 11.053286 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-03-18T04:38:59.707141 (delta: 0.054567)         elapsed: 11.1079 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-03-18T04:38:59.764178 (delta: 0.056995)         elapsed: 11.164937 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-03-18T04:38:59.822843 (delta: 0.058625)         elapsed: 11.223602 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -1", "delta": "0:00:01.165110", "end": "2020-03-18 04:39:01.169176", "failed_when_result": false, "rc": 0, "start": "2020-03-18 04:39:00.004066", "stderr": "", "stderr_lines": [], "stdout": "giri-node1", "stdout_lines": ["giri-node1"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2020-03-18T04:39:01.242000 (delta: 1.419069)         elapsed: 12.642759 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:00.891025", "end": "2020-03-18 04:39:02.317543", "failed_when_result": false, "rc": 0, "start": "2020-03-18 04:39:01.426518", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-03-18T04:39:02.389682 (delta: 1.147637)         elapsed: 13.790441 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}}) => {"ansible_facts": {"disk_count": "1"}, "changed": false, "item": {"key": "stripe", "value": {"count": 1}}}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Add node labels for each nodes and create blockdevice template] **********
2020-03-18T04:39:02.552472 (delta: 0.162711)         elapsed: 13.953231 ******* 
changed: [127.0.0.1] => (item=[u'giri-node1']) => {"changed": true, "checksum": "73086c75ef92a716cad00ab422d8f96105cd0343", "dest": "./blockdevice-giri-node1.yml", "gid": 0, "group": "root", "item": ["giri-node1"], "md5sum": "0519085acf9eb5bab6974a3aa1d86212", "mode": "0644", "owner": "root", "size": 344, "src": "/root/.ansible/tmp/ansible-tmp-1584506342.61-73490784391536/source", "state": "file", "uid": 0}

TASK [Getting the Unclaimed block-device count] ********************************
2020-03-18T04:39:02.954375 (delta: 0.401417)         elapsed: 14.355134 ******* 
changed: [127.0.0.1] => (item=giri-node1) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:00.839028", "end": "2020-03-18 04:39:03.998688", "item": "giri-node1", "rc": 0, "start": "2020-03-18 04:39:03.159660", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-31e0768585cb80ed2352affa73ec94e2", "stdout_lines": ["blockdevice-31e0768585cb80ed2352affa73ec94e2"]}

TASK [set_fact] ****************************************************************
2020-03-18T04:39:04.066568 (delta: 1.112142)         elapsed: 15.467327 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Add the block devices for each node's block device template] *************
2020-03-18T04:39:04.162137 (delta: 0.095524)         elapsed: 15.562896 ******* 
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-03-18T04:39:04.274067 (delta: 0.111885)         elapsed: 15.674826 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:00.853470", "end": "2020-03-18 04:39:05.314562", "rc": 0, "start": "2020-03-18 04:39:04.461092", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-31e0768585cb80ed2352affa73ec94e2 ", "stdout_lines": [" blockdevice-31e0768585cb80ed2352affa73ec94e2 "]}

TASK [Add the block devices] ***************************************************
2020-03-18T04:39:05.381296 (delta: 1.106814)         elapsed: 16.782055 ******* 
changed: [127.0.0.1] => (item= blockdevice-31e0768585cb80ed2352affa73ec94e2 ) => {"backup": "", "changed": true, "item": " blockdevice-31e0768585cb80ed2352affa73ec94e2 ", "msg": "line added"}

TASK [Include the blockdevice template in the CSPC spec] ***********************
2020-03-18T04:39:05.825442 (delta: 0.444095)         elapsed: 17.226201 ******* 
changed: [127.0.0.1] => (item=giri-node1) => {"changed": true, "item": "giri-node1", "msg": "Block inserted"}

TASK [Replacing the pool name in CSPC spec] ************************************
2020-03-18T04:39:06.252845 (delta: 0.42735)         elapsed: 17.653604 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Update replica count matching pool count in storage class spec] **********
2020-03-18T04:39:06.701439 (delta: 0.448543)         elapsed: 18.102198 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the storage class name in CSPC spec] ***************************
2020-03-18T04:39:06.975517 (delta: 0.273918)         elapsed: 18.376276 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the namespace in CSPC spec] ************************************
2020-03-18T04:39:07.224191 (delta: 0.248602)         elapsed: 18.62495 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the pool type in CSPC spec] ************************************
2020-03-18T04:39:07.473506 (delta: 0.249269)         elapsed: 18.874265 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2020-03-18T04:39:07.728030 (delta: 0.254476)         elapsed: 19.128789 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: CStorPoolCluster
metadata:
  name: cstor
  namespace: openebs
spec:
  pools:
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: giri-node1
      poolConfig:
        cacheFile: ""
        defaultRaidGroupType: stripe
        overProvisioning: false
        compression: "off"
      raidGroups:
      - type: stripe
        isWriteCache: false
        isSpare: false
        isReadCache: false
        blockDevices:
        - blockDeviceName:  blockdevice-31e0768585cb80ed2352affa73ec94e2
# ## giri-node1 Ansible Config ## ANSIBLE MANAGED BLOCK

---

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: stg
  annotations:
    openebs.io/cas-type: cstor  
provisioner: cstor.csi.openebs.io
allowVolumeExpansion: true
parameters:
  cas-type: cstor
  cstorPoolCluster: cstor
  replicaCount: "1") => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: CStorPoolCluster\nmetadata:\n  name: cstor\n  namespace: openebs\nspec:\n  pools:\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: giri-node1\n      poolConfig:\n        cacheFile: \"\"\n        defaultRaidGroupType: stripe\n        overProvisioning: false\n        compression: \"off\"\n      raidGroups:\n      - type: stripe\n        isWriteCache: false\n        isSpare: false\n        isReadCache: false\n        blockDevices:\n        - blockDeviceName:  blockdevice-31e0768585cb80ed2352affa73ec94e2\n# ## giri-node1 Ansible Config ## ANSIBLE MANAGED BLOCK\n\n---\n\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: stg\n  annotations:\n    openebs.io/cas-type: cstor  \nprovisioner: cstor.csi.openebs.io\nallowVolumeExpansion: true\nparameters:\n  cas-type: cstor\n  cstorPoolCluster: cstor\n  replicaCount: \"1\""
}

TASK [Create cstor disk pool] **************************************************
2020-03-18T04:39:07.830292 (delta: 0.102216)         elapsed: 19.231051 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc.yml", "delta": "0:00:01.092734", "end": "2020-03-18 04:39:09.104006", "rc": 0, "start": "2020-03-18 04:39:08.011272", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.openebs.io/cstor created\nstorageclass.storage.k8s.io/stg created", "stdout_lines": ["cstorpoolcluster.openebs.io/cstor created", "storageclass.storage.k8s.io/stg created"]}

TASK [Check whether cspc is created] *******************************************
2020-03-18T04:39:09.164956 (delta: 1.334612)         elapsed: 20.565715 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspc -n openebs -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.817905", "end": "2020-03-18 04:39:10.168294", "rc": 0, "start": "2020-03-18 04:39:09.350389", "stderr": "", "stderr_lines": [], "stdout": "cstor\ncstor-cspc-pool", "stdout_lines": ["cstor", "cstor-cspc-pool"]}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-03-18T04:39:10.237867 (delta: 1.072865)         elapsed: 21.638626 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.825547", "end": "2020-03-18 04:39:11.259282", "rc": 0, "start": "2020-03-18 04:39:10.433735", "stderr": "", "stderr_lines": [], "stdout": "cstor-q5f4", "stdout_lines": ["cstor-q5f4"]}

TASK [Verify the status of CSPI] ***********************************************
2020-03-18T04:39:11.325285 (delta: 1.087372)         elapsed: 22.726044 ******* 
FAILED - RETRYING: Verify the status of CSPI (30 retries left).
changed: [127.0.0.1] => (item=cstor-q5f4) => {"attempts": 2, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-q5f4\")].status.phase}'", "delta": "0:00:00.940757", "end": "2020-03-18 04:39:18.469602", "item": "cstor-q5f4", "rc": 0, "start": "2020-03-18 04:39:17.528845", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify if the cStor Pool pods are Running] *******************************
2020-03-18T04:39:18.543820 (delta: 7.21849)         elapsed: 29.944579 ******** 
changed: [127.0.0.1] => (item=cstor-q5f4) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-q5f4 --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.846223", "end": "2020-03-18 04:39:19.590920", "item": "cstor-q5f4", "rc": 0, "start": "2020-03-18 04:39:18.744697", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get cStor Pool pod names to verify the container statuses and check the required number of pools created.] ***
2020-03-18T04:39:19.670042 (delta: 1.126175)         elapsed: 31.070801 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.832370", "end": "2020-03-18 04:39:20.688767", "failed_when_result": false, "rc": 0, "start": "2020-03-18 04:39:19.856397", "stderr": "", "stderr_lines": [], "stdout": "cstor-q5f4-679d74b956-dvrfp", "stdout_lines": ["cstor-q5f4-679d74b956-dvrfp"]}

TASK [Get the runningStatus of pool pod] ***************************************
2020-03-18T04:39:20.763825 (delta: 1.093115)         elapsed: 32.164584 ******* 
changed: [127.0.0.1] => (item=cstor-q5f4-679d74b956-dvrfp) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-q5f4-679d74b956-dvrfp -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.861469", "end": "2020-03-18 04:39:21.827682", "item": "cstor-q5f4-679d74b956-dvrfp", "rc": 0, "start": "2020-03-18 04:39:20.966213", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if the storage class is created] ***********************************
2020-03-18T04:39:21.909280 (delta: 1.145378)         elapsed: 33.310039 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc", "delta": "0:00:00.892061", "end": "2020-03-18 04:39:23.000374", "failed_when_result": false, "rc": 0, "start": "2020-03-18 04:39:22.108313", "stderr": "", "stderr_lines": [], "stdout": "NAME                        PROVISIONER                                                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE\nopenebs-cstor-cspc          cstor.csi.openebs.io                                       Delete          Immediate              true                   36m\nopenebs-device              openebs.io/local                                           Delete          WaitForFirstConsumer   false                  8d\nopenebs-hostpath            openebs.io/local                                           Delete          WaitForFirstConsumer   false                  8d\nopenebs-jiva-default        openebs.io/provisioner-iscsi                               Delete          Immediate              false                  8d\nopenebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   Delete          Immediate              false                  8d\nstg                         cstor.csi.openebs.io                                       Delete          Immediate              true                   13s", "stdout_lines": ["NAME                        PROVISIONER                                                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE", "openebs-cstor-cspc          cstor.csi.openebs.io                                       Delete          Immediate              true                   36m", "openebs-device              openebs.io/local                                           Delete          WaitForFirstConsumer   false                  8d", "openebs-hostpath            openebs.io/local                                           Delete          WaitForFirstConsumer   false                  8d", "openebs-jiva-default        openebs.io/provisioner-iscsi                               Delete          Immediate              false                  8d", "openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   Delete          Immediate              false                  8d", "stg                         cstor.csi.openebs.io                                       Delete          Immediate              true                   13s"]}

TASK [Remove the CStor Pool Cluster] *******************************************
2020-03-18T04:39:23.068725 (delta: 1.159369)         elapsed: 34.469484 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CStor Pool Cluster is deleted] *****************************
2020-03-18T04:39:23.139197 (delta: 0.070398)         elapsed: 34.539956 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CSPI is getting removed] ***********************************
2020-03-18T04:39:23.206119 (delta: 0.066866)         elapsed: 34.606878 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor pool pods are deleted] *******************************
2020-03-18T04:39:23.275330 (delta: 0.06914)         elapsed: 34.676089 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-03-18T04:39:23.411886 (delta: 0.136493)         elapsed: 34.812645 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-03-18T04:39:23.493698 (delta: 0.081766)         elapsed: 34.894457 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-03-18T04:39:23.592109 (delta: 0.098343)         elapsed: 34.992868 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-03-18T04:39:23.649211 (delta: 0.057055)         elapsed: 35.04997 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-03-18T04:39:23.707367 (delta: 0.058108)         elapsed: 35.108126 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-03-18T04:39:23.766617 (delta: 0.059202)         elapsed: 35.167376 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "501786648ab66e7fc2a021e95e8fcc53f8ff4f77", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "23c79b43245ac077305a179ea8f3e971", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1584506363.82-232015083283902/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-03-18T04:39:25.582568 (delta: 1.815904)         elapsed: 36.983327 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.742879", "end": "2020-03-18 04:39:26.500041", "rc": 0, "start": "2020-03-18 04:39:25.757162", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-03-18T04:39:26.558896 (delta: 0.976279)         elapsed: 37.959655 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-03-18T04:03:09Z", "generation": 8, "name": "cstor-pool-provision", "resourceVersion": "2915515", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "155db1e2-28f7-47d1-a92b-515c5eee0f13"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=35   changed=26   unreachable=0    failed=0   

2020-03-18T04:39:27.410644 (delta: 0.851695)         elapsed: 38.811403 ******* 
===============================================================================
```
