### PR TITLE
feat(Experiment): Added test for volume properties verify set via storage class

### DIFF
--- a/experiments/functional/zfs-LocalPV/zv-properties-verify/run_litmus_test.yml
+++ b/experiments/functional/zfs-LocalPV/zv-properties-verify/run_litmus_test.yml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: zv-properties-verify-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: zv-properties-verify
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays  #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE  ## Namespace in which application is deployed
+            value: ''
+
+          - name: OPERATOR_NAMESPACE ## Namespace in which all the resources created by zfs driver will be present
+            value: ''                ## for e.g. zfsvolume (zv) will be in this namespace         
+         
+          - name: APP_PVC            ## PersistentVolumeClaim Name for the application
+            value: ''
+          
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml
+++ b/experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml
@@ -1,0 +1,150 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+        - block:
+
+          - name: Get the zvolume name
+            shell: >
+              kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers
+              -o custom-columns=:.spec.volumeName
+            args: 
+              executable: /bin/bash
+            register: zvol_name
+
+          - name: Record the zvolume name
+            set_fact:
+              zv_name: "{{ zvol_name.stdout }}"
+
+          - name: Get the storage class name used to create volume
+            shell: >
+              kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers
+              -o custom-columns=:.spec.storageClassName
+            args: 
+              executable: /bin/bash
+            register: stg_class_name
+
+          - name: Record the storage class name
+            set_fact:
+              sc_name: "{{ stg_class_name.stdout }}"
+
+          - name: Get the value of compression parameter from the storage class
+            shell: >
+              kubectl get sc {{ sc_name }} --no-headers 
+              -o custom-columns=:.parameters.compression
+            args:
+              executable: /bin/bash
+            register: compression_parameter
+
+          - name: Compare this value with the compression field in zvolume
+            shell: > 
+              kubectl get zv {{ zv_name }} -n {{ operator_ns }} --no-headers
+              -o custom-columns=:.spec.compression
+            args: 
+              executable: /bin/bash
+            register: result
+            failed_when: compression_parameter.stdout != result.stdout
+            
+          - name: Get the value of dedup parameter from the storage class
+            shell: >
+              kubectl get sc {{ sc_name }} --no-headers
+              -o custom-columns=:.parameters.dedup
+            args:
+              executable: /bin/bash
+            register: dedup_parameter
+
+          - name: Compare this value with the dedup field in zvolume
+            shell: > 
+              kubectl get zv {{ zv_name }} -n {{ operator_ns }} --no-headers
+              -o custom-columns=:.spec.dedup
+            args: 
+              executable: /bin/bash
+            register: result
+            failed_when: dedup_parameter.stdout != result.stdout
+
+          - name: Get the file system type from the storage class on top of which application is deployed
+            shell: >
+              kubectl get sc {{ sc_name }} --no-headers
+              -o custom-columns=:.parameters.fstype
+            args:
+              executable: /bin/bash
+            register: fstype_parameter
+
+          - name: Compare this value with the fstype field in zvolume
+            shell: > 
+              kubectl get zv {{ zv_name }} -n {{ operator_ns }} --no-headers
+              -o custom-columns=:.spec.fsType
+            args: 
+              executable: /bin/bash
+            register: result  
+            failed_when: fstype_parameter.stdout != result.stdout          
+         
+          - block:
+
+            - name: Get the value of recordsize from the storage class when fstype is zfs
+              shell: >
+                kubectl get sc {{ sc_name }} --no-headers
+                -o custom-columns=:.parameters.recordsize
+              args:
+                executable: /bin/bash
+              register: recordsize_parameter
+
+            - name: Compare this value with the recordsize field in zvolume
+              shell: >
+                kubectl get zv {{ zv_name }} -n {{ operator_ns }} --no-headers
+                -o custom-columns=:.spec.recordsize
+              args: 
+                executable: /bin/bash
+              register: result
+              failed_when: recordsize_parameter.stdout != result.stdout
+
+            when: fstype_parameter.stdout == "zfs"
+
+          - block:
+
+            - name: Get the value of volblocksize from the storage class when fstype is xfs or ext
+              shell: >
+                kubectl get sc {{ sc_name }} --no-headers
+                -o custom-columns=:.parameters.volblocksize
+              args:
+                executable: /bin/bash
+              register: volblocksize_parameter
+
+            - name: Compare this value with the volblocksize field in the zvolume
+              shell: >
+                kubectl get zv {{ zv_name }} -n {{ operator_ns }} --no-headers
+                -o custom-columns=:.spec.volblocksize
+              args:
+                executable: /bin/bash
+              register: result
+              failed_when: volblocksize_parameter.stdout != result.stdout
+
+            when: 
+            - fstype_parameter.stdout == "xfs" or fstype_parameter.stdout == "ext4" or
+              fstype_parameter.stdout == "ext3" or fstype_parameter.stdout == "ext2"
+              
+          - set_fact:
+              flag: "Pass"
+        
+      rescue:
+        - set_fact:
+            flag: "Fail"
+        
+      always:
+      ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'            

--- a/experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml
+++ b/experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml
@@ -75,7 +75,7 @@
             register: result
             failed_when: dedup_parameter.stdout != result.stdout
 
-          - name: Get the file system type from the storage class on top of which application is deployed
+          - name: Get the file system type to be created on application mount from the storage class
             shell: >
               kubectl get sc {{ sc_name }} --no-headers
               -o custom-columns=:.parameters.fstype

--- a/experiments/functional/zfs-LocalPV/zv-properties-verify/test_vars.yml
+++ b/experiments/functional/zfs-LocalPV/zv-properties-verify/test_vars.yml
@@ -1,0 +1,7 @@
+test_name: zvol-properties-verify
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
+
+pvc_name: "{{ lookup('env','APP_PVC') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
 - Verify the properites set via storage class with the zvolume properties
- This PR verifies following properties by taking values from storage class and then compare with zvolume.
 1. compression
 2. dedup
 3. fsType
 4. recordsize in case of zfs file system
 5. volblocksize in case of xfs/ext4 file system

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #204

**Special notes for your reviewer**:
```PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml

PLAY [localhost] ***************************************************************
2020-03-23T17:46:32.706638 (delta: 0.067139)         elapsed: 0.067139 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:1
2020-03-23T17:46:32.726156 (delta: 0.019475)         elapsed: 0.086657 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:11
2020-03-23T17:46:43.505792 (delta: 10.779609)         elapsed: 10.866293 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-03-23T17:46:43.637248 (delta: 0.130695)         elapsed: 10.997749 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-03-23T17:46:43.736129 (delta: 0.098832)         elapsed: 11.09663 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:14
2020-03-23T17:46:43.892411 (delta: 0.156228)         elapsed: 11.252912 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-03-23T17:46:44.019894 (delta: 0.127414)         elapsed: 11.380395 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ffe0d9e7bbaae1d31355bf7c0084a577255f22df", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0ab4c7c84de5af7180dca896688f932e", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1584985604.11-271266207508844/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-03-23T17:46:45.140852 (delta: 1.120433)         elapsed: 12.501353 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.062101", "end": "2020-03-23 17:46:46.690534", "rc": 0, "start": "2020-03-23 17:46:45.628433", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: zvol-properties-verify \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: zvol-properties-verify ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-03-23T17:46:46.813403 (delta: 1.672486)         elapsed: 14.173904 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-03-23T17:25:11Z", "generation": 11, "name": "zvol-properties-verify", "resourceVersion": "947496", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/zvol-properties-verify", "uid": "a3be69ca-c815-40e2-bcb8-f87a71027d28"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-03-23T17:46:48.481298 (delta: 1.667814)         elapsed: 15.841799 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-03-23T17:46:48.548519 (delta: 0.067133)         elapsed: 15.90902 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-03-23T17:46:48.627046 (delta: 0.078122)         elapsed: 15.987547 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the zvolume name] ****************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:20
2020-03-23T17:46:48.760934 (delta: 0.133806)         elapsed: 16.121435 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n abc --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.350277", "end": "2020-03-23 17:46:50.375589", "rc": 0, "start": "2020-03-23 17:46:49.025312", "stderr": "", "stderr_lines": [], "stdout": "pvc-61e2151f-9685-4b0b-a211-9c8928f95af3", "stdout_lines": ["pvc-61e2151f-9685-4b0b-a211-9c8928f95af3"]}

TASK [Record the zvolume name] *************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:28
2020-03-23T17:46:50.480989 (delta: 1.719997)         elapsed: 17.84149 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"zv_name": "pvc-61e2151f-9685-4b0b-a211-9c8928f95af3"}, "changed": false}

TASK [Get the storage class name used to create volume] ************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:32
2020-03-23T17:46:50.747427 (delta: 0.264005)         elapsed: 18.107928 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n abc --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:00.926282", "end": "2020-03-23 17:46:51.954881", "rc": 0, "start": "2020-03-23 17:46:51.028599", "stderr": "", "stderr_lines": [], "stdout": "sc-xfs", "stdout_lines": ["sc-xfs"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:40
2020-03-23T17:46:52.031572 (delta: 1.283906)         elapsed: 19.392073 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc_name": "sc-xfs"}, "changed": false}

TASK [Get the value of compression parameter from the storage class] ***********
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:44
2020-03-23T17:46:52.135651 (delta: 0.104014)         elapsed: 19.496152 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc sc-xfs --no-headers -o custom-columns=:.parameters.compression", "delta": "0:00:00.853354", "end": "2020-03-23 17:46:53.207721", "rc": 0, "start": "2020-03-23 17:46:52.354367", "stderr": "", "stderr_lines": [], "stdout": "off", "stdout_lines": ["off"]}

TASK [Compare this value with the compression field in zvolume] ****************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:52
2020-03-23T17:46:53.284739 (delta: 1.149022)         elapsed: 20.64524 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get zv pvc-61e2151f-9685-4b0b-a211-9c8928f95af3 -n openebs --no-headers -o custom-columns=:.spec.compression", "delta": "0:00:01.254912", "end": "2020-03-23 17:46:54.880172", "failed_when_result": false, "rc": 0, "start": "2020-03-23 17:46:53.625260", "stderr": "", "stderr_lines": [], "stdout": "off", "stdout_lines": ["off"]}

TASK [Get the value of dedup parameter from the storage class] *****************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:61
2020-03-23T17:46:54.960756 (delta: 1.675915)         elapsed: 22.321257 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc sc-xfs --no-headers -o custom-columns=:.parameters.dedup", "delta": "0:00:01.011434", "end": "2020-03-23 17:46:56.187644", "rc": 0, "start": "2020-03-23 17:46:55.176210", "stderr": "", "stderr_lines": [], "stdout": "off", "stdout_lines": ["off"]}

TASK [Compare this value with the dedup field in zvolume] **********************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:69
2020-03-23T17:46:56.276046 (delta: 1.315239)         elapsed: 23.636547 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get zv pvc-61e2151f-9685-4b0b-a211-9c8928f95af3 -n openebs --no-headers -o custom-columns=:.spec.dedup", "delta": "0:00:01.013260", "end": "2020-03-23 17:46:57.598132", "failed_when_result": false, "rc": 0, "start": "2020-03-23 17:46:56.584872", "stderr": "", "stderr_lines": [], "stdout": "off", "stdout_lines": ["off"]}

TASK [Get the file system type from the storage class on top of which application is deployed] ***
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:78
2020-03-23T17:46:57.703247 (delta: 1.427124)         elapsed: 25.063748 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc sc-xfs --no-headers -o custom-columns=:.parameters.fstype", "delta": "0:00:00.976748", "end": "2020-03-23 17:46:58.930490", "rc": 0, "start": "2020-03-23 17:46:57.953742", "stderr": "", "stderr_lines": [], "stdout": "xfs", "stdout_lines": ["xfs"]}

TASK [Compare this value with the fstype field in zvolume] *********************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:86
2020-03-23T17:46:59.012039 (delta: 1.308737)         elapsed: 26.37254 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get zv pvc-61e2151f-9685-4b0b-a211-9c8928f95af3 -n openebs --no-headers -o custom-columns=:.spec.fsType", "delta": "0:00:01.138432", "end": "2020-03-23 17:47:00.422301", "failed_when_result": false, "rc": 0, "start": "2020-03-23 17:46:59.283869", "stderr": "", "stderr_lines": [], "stdout": "xfs", "stdout_lines": ["xfs"]}

TASK [Get the value of recordsize from the storage class when fstype is zfs] ***
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:97
2020-03-23T17:47:00.502859 (delta: 1.490728)         elapsed: 27.86336 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Compare this value with the recordsize field in zvolume] *****************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:105
2020-03-23T17:47:00.588617 (delta: 0.085666)         elapsed: 27.949118 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the value of volblocksize from the storage class when fstype is xfs or ext] ***
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:118
2020-03-23T17:47:00.765586 (delta: 0.176849)         elapsed: 28.126087 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc sc-xfs --no-headers -o custom-columns=:.parameters.volblocksize", "delta": "0:00:01.053329", "end": "2020-03-23 17:47:02.071047", "rc": 0, "start": "2020-03-23 17:47:01.017718", "stderr": "", "stderr_lines": [], "stdout": "4k", "stdout_lines": ["4k"]}

TASK [Compare this value with the volblocksize field in the zvolume] ***********
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:126
2020-03-23T17:47:02.139493 (delta: 1.373763)         elapsed: 29.499994 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get zv pvc-61e2151f-9685-4b0b-a211-9c8928f95af3 -n openebs --no-headers -o custom-columns=:.spec.volblocksize", "delta": "0:00:01.266215", "end": "2020-03-23 17:47:03.702134", "failed_when_result": false, "rc": 0, "start": "2020-03-23 17:47:02.435919", "stderr": "", "stderr_lines": [], "stdout": "4k", "stdout_lines": ["4k"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:139
2020-03-23T17:47:03.830289 (delta: 1.690742)         elapsed: 31.19079 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/zfs-LocalPV/zv-properties-verify/test.yml:148
2020-03-23T17:47:03.941308 (delta: 0.110908)         elapsed: 31.301809 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-03-23T17:47:04.069050 (delta: 0.12769)         elapsed: 31.429551 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-03-23T17:47:04.138247 (delta: 0.069138)         elapsed: 31.498748 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-03-23T17:47:04.216309 (delta: 0.077981)         elapsed: 31.57681 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-03-23T17:47:04.297002 (delta: 0.080611)         elapsed: 31.657503 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "6c79f4a5978b7dee457419e40a6c0c6fa4b35e31", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "cbaec8eb9eb74f23eea061f2d032cfb2", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1584985624.38-239481166410171/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-03-23T17:47:06.942967 (delta: 2.645896)         elapsed: 34.303468 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.899839", "end": "2020-03-23 17:47:08.113938", "rc": 0, "start": "2020-03-23 17:47:07.214099", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: zvol-properties-verify \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: zvol-properties-verify ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-03-23T17:47:08.236772 (delta: 1.293714)         elapsed: 35.597273 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-03-23T17:25:11Z", "generation": 12, "name": "zvol-properties-verify", "resourceVersion": "947574", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/zvol-properties-verify", "uid": "a3be69ca-c815-40e2-bcb8-f87a71027d28"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=23   changed=16   unreachable=0    failed=0   

2020-03-23T17:47:09.467810 (delta: 1.229773)         elapsed: 36.828311 ******* 
=============================================================================== ```