### PR TITLE
refactor(pool-scaledown): Modified and updated the pool scaledown to check when the pool has volumes

### DIFF
--- a/experiments/functional/day2_ops/cspc_pool/pool_scaledown/pool_scaledown.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaledown/pool_scaledown.yml
@@ -7,6 +7,14 @@
         executable: /bin/bash
       register: node_name
 
+    - name: Check if the pool that are going to scaledown is contains volume 
+      shell: >
+        kubectl get cvr -n {{ operator_ns }} -l cstorpoolinstance.openebs.io/name={{ targeted_cspi }}
+        -o custom-columns=:.metadata.name --no-headers
+      args:
+        executable: /bin/bash
+      register: volume
+       
     - name: Getting the used block-device by CSPI
       shell: >
         kubectl get cspi -n {{ operator_ns }} {{ targeted_cspi }} 
@@ -31,15 +39,37 @@
       register: patch_cspc
       failed_when: "'patched' not in patch_cspc.stdout"
 
-    - name: Check if the Blockdevice is in UnClaimed state
-      shell: >
-        kubectl get blockdevice -n {{ operator_ns }} {{ item }}
-        --no-headers -o custom-columns=:.status.claimState
-      args:
-        executable: /bin/bash
-      register: bd_state
-      with_items:
-        - "{{ blockDevice.stdout_lines }}"
-      until: "'Unclaimed' in bd_state.stdout"
-      delay: 5
-      retries: 60
+    - block:
+
+        - name: Check if the Blockdevice is in UnClaimed state
+          shell: >
+            kubectl get blockdevice -n {{ operator_ns }} {{ item }}
+            --no-headers -o custom-columns=:.status.claimState
+          args:
+            executable: /bin/bash
+          register: bd_state
+          with_items:
+            - "{{ blockDevice.stdout_lines }}"
+          until: "'Unclaimed' in bd_state.stdout"
+          delay: 5
+          retries: 60
+      when: volume.stdout == ''
+
+    - block:
+        
+        # wait 5 minutes
+        - name: Wait for the blockdevices going to unclaimed state
+          wait_for:
+            timeout: 300
+
+        - name: Check if the Blockdevice is in UnClaimed state
+          shell: >
+            kubectl get blockdevice -n {{ operator_ns }} {{ item }}
+            --no-headers -o custom-columns=:.status.claimState
+          args:
+            executable: /bin/bash
+          register: bd_state
+          with_items:
+            - "{{ blockDevice.stdout_lines }}"
+          failed_when: "'Unclaimed' in bd_state.stdout"
+      when: volume.stdout != ''


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a condition to check the pool scaledown is failing when the pool has the volumes

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
