### PR TITLE
Modified the disk replacement testcase to fetch the blockdevices based on the pool

### DIFF
--- a/experiments/functional/disk_replacement/test.yml
+++ b/experiments/functional/disk_replacement/test.yml
@@ -57,6 +57,14 @@
           retries: 30
           delay: 10
 
+        - name: Obtain the name of CStorPoolInstance
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: cspi_name
+
         - name: Get cStor Disk Pool names to verify the container statuses
           shell: >
             kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
@@ -127,23 +135,24 @@
           delay: 5
           retries: 60
 
-        - name: Obtain the node names where the CVR's are scheduled
+        - name: Select random cspi from the list of cspi as target cspi to perform disk replacement
+          set_fact:
+            target_cspi: "{{ item }}"
+          with_random_choice: "{{ cspi_name.stdout_lines }}"
+
+        - name: Obtain the node name of the targeted cspi
           shell: >
-             kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
-             -o=jsonpath='{range .items[*]}{.metadata.annotations.cstorpoolinstance\.openebs\.io\/hostname}{"\n"}'
+            kubectl get cspi -n {{ operator_ns }} {{ target_cspi }}
+            -o custom-columns=:.spec.hostName --no-headers
           args:
             executable: /bin/bash
-          register: node_name
-
-        - name: Select random cvr node from the list of nodes as target node to perform disk replacement
-          set_fact:
-            target_node: "{{ item }}"
-          with_random_choice: "{{ node_name.stdout_lines }}"
+          register: cspi_node_name
+          failed_when: 'cspi_node_name.stdout == ""'
 
         - name: Obtain the Claimed block device from the targeted node
           shell: >
-            kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ target_node }}
-            -o jsonpath='{.items[?(@.status.claimState=="Claimed")].metadata.name}' | tr " " "\n" | grep -v sparse
+            kubectl get cspi -n {{ operator_ns }} {{ target_cspi }}
+            -o custom-columns=:.spec.raidGroup[*].blockDevices[*].blockDeviceName --no-headers
           args:
             executable: /bin/bash
           register: claimed_bd
@@ -156,7 +165,7 @@
 
         - name: Obtain the Unclaimed block device from the targeted node to perform disk replacement
           shell: >
-            kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ target_node }}
+            kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ cspi_node_name.stdout }}
             -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse
           args:
             executable: /bin/bash


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified and updated the disk replacement test case to fetch the claimed blockdevice based on the pool name rather than getting all unclaimed blockdevices in node

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
