### PR TITLE
Modified zfspv provisioner to take custom-images for zfs-driver

### DIFF
--- a/providers/zfs-localpv-provisioner/run_litmus_test.yml
+++ b/providers/zfs-localpv-provisioner/run_litmus_test.yml
@@ -22,7 +22,8 @@ spec:
             #value: log_plays
             value: default
 
-            ## Provide openebs ZFS_DRIVER version tag. To use ci images leave this env blank. 
+            ## Provide openebs ZFS_DRIVER image. To use ci images use ci tag.
+            ## Give full image name (for e.g. quay.io/openebs/zfs-driver:<tag>)
           - name: ZFS_DRIVER_TAG
             value:
 

--- a/providers/zfs-localpv-provisioner/test.yml
+++ b/providers/zfs-localpv-provisioner/test.yml
@@ -34,7 +34,7 @@
             replace:
               path: ./zfs_operator.yml
               regexp: quay.io/openebs/zfs-driver:ci
-              replace: quay.io/openebs/zfs-driver:{{ lookup('env','ZFS_DRIVER_TAG') }}
+              replace: "{{ lookup('env','ZFS_DRIVER_TAG') }}"
             when: lookup('env','ZFS_DRIVER_TAG') | length > 0
 
           - name: Apply the zfs_operator file to deploy zfs-driver components


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR modifies zfspv provisioner to take zfs-driver images as custom-images.
- now not only tag is a env variable but the whole custom-images is the env variable