### PR TITLE
refactor(scaledown): getting number of replicas from cvc poolinfo

### DIFF
--- a/experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml
@@ -76,7 +76,7 @@
         - name: Get the current replica count
           shell: >
             kubectl get cvc "{{ cvc_name }}" -n "{{ openebs_ns }}" --no-headers
-            -o custom-columns=:status.poolInfo | wc -l
+            -o custom-columns=:status.poolInfo | awk '{print NF}' 
           args:
             executable: /bin/bash
           register: current_replica
@@ -110,7 +110,7 @@
         - name: Check the replica count in cvc
           shell: >
             kubectl get cvc "{{ cvc_name }}" -n "{{ openebs_ns }}" --no-headers
-            -o custom-columns=:status.poolInfo | wc -l
+            -o custom-columns=:status.poolInfo | awk '{print NF}' 
           args:
             executable: /bin/bash
           register: updated_replica


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- All the elements in the pool info gets printed in single line.
- Using awk to get the number of elements.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2020-03-31T06:32:02.326240 (delta: 0.057964)         elapsed: 0.057964 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:1
2020-03-31T06:32:02.339001 (delta: 0.012727)         elapsed: 0.070725 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:13
2020-03-31T06:32:11.078933 (delta: 8.739903)         elapsed: 8.810657 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-03-31T06:32:11.166013 (delta: 0.087042)         elapsed: 8.897737 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-03-31T06:32:11.236371 (delta: 0.070292)         elapsed: 8.968095 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:16
2020-03-31T06:32:11.300211 (delta: 0.063798)         elapsed: 9.031935 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-03-31T06:32:11.399809 (delta: 0.099555)         elapsed: 9.131533 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "580e43b6f78c753c0000237dd6284990dcc75163", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "366829f396de1d70ecec0aee4bdad3b4", "mode": "0644", "owner": "root", "size": 428, "src": "/root/.ansible/tmp/ansible-tmp-1585636331.45-17611832651354/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-03-31T06:32:12.090657 (delta: 0.690803)         elapsed: 9.822381 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.725308", "end": "2020-03-31 06:32:13.130383", "rc": 0, "start": "2020-03-31 06:32:12.405075", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-replica-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-replica-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-03-31T06:32:13.184705 (delta: 1.094005)         elapsed: 10.916429 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-03-30T02:05:59Z", "generation": 11, "name": "cstor-csi-replica-scaledown", "resourceVersion": "2239381", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-replica-scaledown", "uid": "71f998d1-c272-44eb-b741-67c9618ba5b4"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-03-31T06:32:14.244922 (delta: 1.060161)         elapsed: 11.976646 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-03-31T06:32:14.304170 (delta: 0.059196)         elapsed: 12.035894 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-03-31T06:32:14.363653 (delta: 0.05943)         elapsed: 12.095377 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:20
2020-03-31T06:32:14.419027 (delta: 0.055321)         elapsed: 12.150751 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "68b329da9893e34099c7d8ad5cb9c940", "mode": "0644", "owner": "root", "size": 1, "src": "/root/.ansible/tmp/ansible-tmp-1585636334.47-69693602237625/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:25
2020-03-31T06:32:14.803970 (delta: 0.384852)         elapsed: 12.535694 ******* 
ok: [127.0.0.1] => {"ansible_facts": {}, "ansible_included_var_files": ["/experiments/functional/cStor/cstor-csi-volume-scaledown/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:28
2020-03-31T06:32:14.886969 (delta: 0.082933)         elapsed: 12.618693 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application pod name] ********************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:33
2020-03-31T06:32:14.970404 (delta: 0.083369)         elapsed: 12.702128 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n giri --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.173506", "end": "2020-03-31 06:32:16.348851", "rc": 0, "start": "2020-03-31 06:32:15.175345", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-twrzh", "stdout_lines": ["percona-8568b6cc96-twrzh"]}

TASK [Check if the application pod is in running state] ************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:40
2020-03-31T06:32:16.404851 (delta: 1.434382)         elapsed: 14.136575 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n giri --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.850870", "end": "2020-03-31 06:32:17.424244", "failed_when_result": false, "rc": 0, "start": "2020-03-31 06:32:16.573374", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:48
2020-03-31T06:32:17.491130 (delta: 1.086237)         elapsed: 15.222854 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC.] ************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:56
2020-03-31T06:32:17.566021 (delta: 0.07482)         elapsed: 15.297745 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc \"percona-mysql-claim\" -n \"giri\" --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.872223", "end": "2020-03-31 06:32:18.658530", "rc": 0, "start": "2020-03-31 06:32:17.786307", "stderr": "", "stderr_lines": [], "stdout": "pvc-c2af040a-7532-429b-8fa7-98ad13e25eab", "stdout_lines": ["pvc-c2af040a-7532-429b-8fa7-98ad13e25eab"]}

TASK [Get CVC name, note that CVC name is same as PV.] *************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:64
2020-03-31T06:32:18.711020 (delta: 1.144953)         elapsed: 16.442744 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"cvc_name": "pvc-c2af040a-7532-429b-8fa7-98ad13e25eab"}, "changed": false}

TASK [Obtain the CVC manifest into two files] **********************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:68
2020-03-31T06:32:18.790717 (delta: 0.079653)         elapsed: 16.522441 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvc \"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" -n \"openebs\" -o yaml | tee cvc1.yml cvc2.yml", "delta": "0:00:00.866575", "end": "2020-03-31 06:32:19.859754", "failed_when_result": false, "rc": 0, "start": "2020-03-31 06:32:18.993179", "stderr": "", "stderr_lines": [], "stdout": "apiVersion: openebs.io/v1alpha1\nkind: CStorVolumeClaim\nmetadata:\n  annotations:\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"openebs.io/v1alpha1\",\"kind\":\"CStorVolumeClaim\",\"metadata\":{\"annotations\":{\"openebs.io/volume-policy\":\"\",\"openebs.io/volumeID\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\"},\"creationTimestamp\":\"2020-03-31T05:57:19Z\",\"finalizers\":[\"cvc.openebs.io/finalizer\"],\"generation\":5,\"labels\":{\"openebs.io/cstor-pool-cluster\":\"cstor-cspc-disk-pool\"},\"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\",\"namespace\":\"openebs\",\"resourceVersion\":\"2230611\",\"selfLink\":\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\",\"uid\":\"985a952c-74bd-4f07-856c-d387c5922eb9\"},\"publish\":{\"nodeId\":\"giri-node2\"},\"spec\":{\"capacity\":{\"storage\":\"5Gi\"},\"cstorVolumeRef\":{\"apiVersion\":\"openebs.io/v1alpha1\",\"kind\":\"CStorVolume\",\"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\",\"namespace\":\"openebs\",\"resourceVersion\":\"2229980\",\"uid\":\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\"},\"policy\":{\"provision\":{\"replicaAffinity\":false},\"replica\":{\"affinity\":null,\"zvolWorkers\":\"\"},\"replicaPoolInfo\":[{\"poolName\":\"cstor-cspc-disk-pool-gzxl\"}],\"target\":{}},\"replicaCount\":1},\"status\":{\"capacity\":{\"storage\":\"5Gi\"},\"phase\":\"Bound\",\"poolInfo\":[\"cstor-cspc-disk-pool-jkf8\",\"cstor-cspc-disk-pool-gzxl\"]},\"versionDetails\":{\"autoUpgrade\":false,\"desired\":\"1.7.0\",\"status\":{\"current\":\"1.7.0\",\"dependentsUpgraded\":true,\"lastUpdateTime\":null,\"state\":\"\"}}}\n    openebs.io/volume-policy: \"\"\n    openebs.io/volumeID: pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\n  creationTimestamp: 2020-03-31T05:57:19Z\n  finalizers:\n  - cvc.openebs.io/finalizer\n  generation: 9\n  labels:\n    openebs.io/cstor-pool-cluster: cstor-cspc-disk-pool\n  name: pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\n  namespace: openebs\n  resourceVersion: \"2235040\"\n  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\n  uid: 985a952c-74bd-4f07-856c-d387c5922eb9\npublish:\n  nodeId: giri-node2\nspec:\n  capacity:\n    storage: 5Gi\n  cstorVolumeRef:\n    apiVersion: openebs.io/v1alpha1\n    kind: CStorVolume\n    name: pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\n    namespace: openebs\n    resourceVersion: \"2229980\"\n    uid: ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\n  policy:\n    provision:\n      replicaAffinity: false\n    replica:\n      affinity: null\n      zvolWorkers: \"\"\n    replicaPoolInfo:\n    - poolName: cstor-cspc-disk-pool-gzxl\n    - poolName: cstor-cspc-disk-pool-jkf8\n    target: {}\n  replicaCount: 1\nstatus:\n  capacity:\n    storage: 5Gi\n  phase: Bound\n  poolInfo:\n  - cstor-cspc-disk-pool-gzxl\n  - cstor-cspc-disk-pool-jkf8\nversionDetails:\n  autoUpgrade: false\n  desired: 1.7.0\n  status:\n    current: 1.7.0\n    dependentsUpgraded: true\n    lastUpdateTime: null\n    state: \"\"", "stdout_lines": ["apiVersion: openebs.io/v1alpha1", "kind: CStorVolumeClaim", "metadata:", "  annotations:", "    kubectl.kubernetes.io/last-applied-configuration: |", "      {\"apiVersion\":\"openebs.io/v1alpha1\",\"kind\":\"CStorVolumeClaim\",\"metadata\":{\"annotations\":{\"openebs.io/volume-policy\":\"\",\"openebs.io/volumeID\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\"},\"creationTimestamp\":\"2020-03-31T05:57:19Z\",\"finalizers\":[\"cvc.openebs.io/finalizer\"],\"generation\":5,\"labels\":{\"openebs.io/cstor-pool-cluster\":\"cstor-cspc-disk-pool\"},\"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\",\"namespace\":\"openebs\",\"resourceVersion\":\"2230611\",\"selfLink\":\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\",\"uid\":\"985a952c-74bd-4f07-856c-d387c5922eb9\"},\"publish\":{\"nodeId\":\"giri-node2\"},\"spec\":{\"capacity\":{\"storage\":\"5Gi\"},\"cstorVolumeRef\":{\"apiVersion\":\"openebs.io/v1alpha1\",\"kind\":\"CStorVolume\",\"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\",\"namespace\":\"openebs\",\"resourceVersion\":\"2229980\",\"uid\":\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\"},\"policy\":{\"provision\":{\"replicaAffinity\":false},\"replica\":{\"affinity\":null,\"zvolWorkers\":\"\"},\"replicaPoolInfo\":[{\"poolName\":\"cstor-cspc-disk-pool-gzxl\"}],\"target\":{}},\"replicaCount\":1},\"status\":{\"capacity\":{\"storage\":\"5Gi\"},\"phase\":\"Bound\",\"poolInfo\":[\"cstor-cspc-disk-pool-jkf8\",\"cstor-cspc-disk-pool-gzxl\"]},\"versionDetails\":{\"autoUpgrade\":false,\"desired\":\"1.7.0\",\"status\":{\"current\":\"1.7.0\",\"dependentsUpgraded\":true,\"lastUpdateTime\":null,\"state\":\"\"}}}", "    openebs.io/volume-policy: \"\"", "    openebs.io/volumeID: pvc-c2af040a-7532-429b-8fa7-98ad13e25eab", "  creationTimestamp: 2020-03-31T05:57:19Z", "  finalizers:", "  - cvc.openebs.io/finalizer", "  generation: 9", "  labels:", "    openebs.io/cstor-pool-cluster: cstor-cspc-disk-pool", "  name: pvc-c2af040a-7532-429b-8fa7-98ad13e25eab", "  namespace: openebs", "  resourceVersion: \"2235040\"", "  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab", "  uid: 985a952c-74bd-4f07-856c-d387c5922eb9", "publish:", "  nodeId: giri-node2", "spec:", "  capacity:", "    storage: 5Gi", "  cstorVolumeRef:", "    apiVersion: openebs.io/v1alpha1", "    kind: CStorVolume", "    name: pvc-c2af040a-7532-429b-8fa7-98ad13e25eab", "    namespace: openebs", "    resourceVersion: \"2229980\"", "    uid: ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a", "  policy:", "    provision:", "      replicaAffinity: false", "    replica:", "      affinity: null", "      zvolWorkers: \"\"", "    replicaPoolInfo:", "    - poolName: cstor-cspc-disk-pool-gzxl", "    - poolName: cstor-cspc-disk-pool-jkf8", "    target: {}", "  replicaCount: 1", "status:", "  capacity:", "    storage: 5Gi", "  phase: Bound", "  poolInfo:", "  - cstor-cspc-disk-pool-gzxl", "  - cstor-cspc-disk-pool-jkf8", "versionDetails:", "  autoUpgrade: false", "  desired: 1.7.0", "  status:", "    current: 1.7.0", "    dependentsUpgraded: true", "    lastUpdateTime: null", "    state: \"\""]}

TASK [Get the current replica count] *******************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:76
2020-03-31T06:32:19.928784 (delta: 1.138005)         elapsed: 17.660508 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvc \"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" -n \"openebs\" --no-headers -o custom-columns=:status.poolInfo | awk '{print NF}'", "delta": "0:00:00.859532", "end": "2020-03-31 06:32:20.983843", "rc": 0, "start": "2020-03-31 06:32:20.124311", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Remove couple of pool instances from cvc manifest] ***********************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:84
2020-03-31T06:32:21.042501 (delta: 1.113639)         elapsed: 18.774225 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sed -i '/replicaPoolInfo\\:/{n;N;N;d}' cvc2.yml", "delta": "0:00:00.747508", "end": "2020-03-31 06:32:21.963100", "rc": 0, "start": "2020-03-31 06:32:21.215592", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
 [WARNING]: Consider using the replace, lineinfile or template module rather
than running sed.  If you need to use command because replace, lineinfile or
template is insufficient you can add warn=False to this command task or set
command_warnings=False in ansible.cfg to get rid of this message.

TASK [Try to scale down couple of replicas by applying above manifest] *********
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:91
2020-03-31T06:32:22.037987 (delta: 0.995442)         elapsed: 19.769711 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cvc2.yml", "delta": "0:00:01.126241", "end": "2020-03-31 06:32:23.334416", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2020-03-31 06:32:22.208175", "stderr": "Error from server (BadRequest): error when applying patch:\n{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolumeClaim\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"openebs.io/volume-policy\\\":\\\"\\\",\\\"openebs.io/volumeID\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\"},\\\"creationTimestamp\\\":\\\"2020-03-31T05:57:19Z\\\",\\\"finalizers\\\":[\\\"cvc.openebs.io/finalizer\\\"],\\\"generation\\\":9,\\\"labels\\\":{\\\"openebs.io/cstor-pool-cluster\\\":\\\"cstor-cspc-disk-pool\\\"},\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2235040\\\",\\\"selfLink\\\":\\\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"uid\\\":\\\"985a952c-74bd-4f07-856c-d387c5922eb9\\\"},\\\"publish\\\":{\\\"nodeId\\\":\\\"giri-node2\\\"},\\\"spec\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"cstorVolumeRef\\\":{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolume\\\",\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2229980\\\",\\\"uid\\\":\\\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\\\"},\\\"policy\\\":{\\\"provision\\\":{\\\"replicaAffinity\\\":false},\\\"replica\\\":{\\\"affinity\\\":null,\\\"zvolWorkers\\\":\\\"\\\"},\\\"replicaPoolInfo\\\":null},\\\"replicaCount\\\":1},\\\"status\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"phase\\\":\\\"Bound\\\",\\\"poolInfo\\\":[\\\"cstor-cspc-disk-pool-gzxl\\\",\\\"cstor-cspc-disk-pool-jkf8\\\"]},\\\"versionDetails\\\":{\\\"autoUpgrade\\\":false,\\\"desired\\\":\\\"1.7.0\\\",\\\"status\\\":{\\\"current\\\":\\\"1.7.0\\\",\\\"dependentsUpgraded\\\":true,\\\"lastUpdateTime\\\":null,\\\"state\\\":\\\"\\\"}}}\\n\"}},\"spec\":{\"policy\":{\"replicaPoolInfo\":null,\"target\":null}}}\nto:\nResource: \"openebs.io/v1alpha1, Resource=cstorvolumeclaims\", GroupVersionKind: \"openebs.io/v1alpha1, Kind=CStorVolumeClaim\"\nName: \"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\", Namespace: \"openebs\"\nObject: &{map[\"versionDetails\":map[\"desired\":\"1.7.0\" \"status\":map[\"current\":\"1.7.0\" \"dependentsUpgraded\":%!q(bool=true) \"lastUpdateTime\":<nil> \"state\":\"\"] \"autoUpgrade\":%!q(bool=false)] \"apiVersion\":\"openebs.io/v1alpha1\" \"kind\":\"CStorVolumeClaim\" \"metadata\":map[\"annotations\":map[\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolumeClaim\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"openebs.io/volume-policy\\\":\\\"\\\",\\\"openebs.io/volumeID\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\"},\\\"creationTimestamp\\\":\\\"2020-03-31T05:57:19Z\\\",\\\"finalizers\\\":[\\\"cvc.openebs.io/finalizer\\\"],\\\"generation\\\":5,\\\"labels\\\":{\\\"openebs.io/cstor-pool-cluster\\\":\\\"cstor-cspc-disk-pool\\\"},\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2230611\\\",\\\"selfLink\\\":\\\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"uid\\\":\\\"985a952c-74bd-4f07-856c-d387c5922eb9\\\"},\\\"publish\\\":{\\\"nodeId\\\":\\\"giri-node2\\\"},\\\"spec\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"cstorVolumeRef\\\":{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolume\\\",\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2229980\\\",\\\"uid\\\":\\\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\\\"},\\\"policy\\\":{\\\"provision\\\":{\\\"replicaAffinity\\\":false},\\\"replica\\\":{\\\"affinity\\\":null,\\\"zvolWorkers\\\":\\\"\\\"},\\\"replicaPoolInfo\\\":[{\\\"poolName\\\":\\\"cstor-cspc-disk-pool-gzxl\\\"}],\\\"target\\\":{}},\\\"replicaCount\\\":1},\\\"status\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"phase\\\":\\\"Bound\\\",\\\"poolInfo\\\":[\\\"cstor-cspc-disk-pool-jkf8\\\",\\\"cstor-cspc-disk-pool-gzxl\\\"]},\\\"versionDetails\\\":{\\\"autoUpgrade\\\":false,\\\"desired\\\":\\\"1.7.0\\\",\\\"status\\\":{\\\"current\\\":\\\"1.7.0\\\",\\\"dependentsUpgraded\\\":true,\\\"lastUpdateTime\\\":null,\\\"state\\\":\\\"\\\"}}}\\n\" \"openebs.io/volume-policy\":\"\" \"openebs.io/volumeID\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\"] \"generation\":'\\t' \"labels\":map[\"openebs.io/cstor-pool-cluster\":\"cstor-cspc-disk-pool\"] \"uid\":\"985a952c-74bd-4f07-856c-d387c5922eb9\" \"resourceVersion\":\"2235040\" \"selfLink\":\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" \"creationTimestamp\":\"2020-03-31T05:57:19Z\" \"finalizers\":[\"cvc.openebs.io/finalizer\"] \"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" \"namespace\":\"openebs\"] \"publish\":map[\"nodeId\":\"giri-node2\"] \"spec\":map[\"policy\":map[\"provision\":map[\"replicaAffinity\":%!q(bool=false)] \"replica\":map[\"affinity\":<nil> \"zvolWorkers\":\"\"] \"replicaPoolInfo\":[map[\"poolName\":\"cstor-cspc-disk-pool-gzxl\"] map[\"poolName\":\"cstor-cspc-disk-pool-jkf8\"]] \"target\":map[]] \"replicaCount\":'\\x01' \"capacity\":map[\"storage\":\"5Gi\"] \"cstorVolumeRef\":map[\"apiVersion\":\"openebs.io/v1alpha1\" \"kind\":\"CStorVolume\" \"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" \"namespace\":\"openebs\" \"resourceVersion\":\"2229980\" \"uid\":\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\"]] \"status\":map[\"capacity\":map[\"storage\":\"5Gi\"] \"phase\":\"Bound\" \"poolInfo\":[\"cstor-cspc-disk-pool-gzxl\" \"cstor-cspc-disk-pool-jkf8\"]]]}\nfor: \"cvc2.yml\": admission webhook \"admission-webhook.openebs.io\" denied the request: Can't perform more than one replica scale down requested scale down count 2", "stderr_lines": ["Error from server (BadRequest): error when applying patch:", "{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolumeClaim\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"openebs.io/volume-policy\\\":\\\"\\\",\\\"openebs.io/volumeID\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\"},\\\"creationTimestamp\\\":\\\"2020-03-31T05:57:19Z\\\",\\\"finalizers\\\":[\\\"cvc.openebs.io/finalizer\\\"],\\\"generation\\\":9,\\\"labels\\\":{\\\"openebs.io/cstor-pool-cluster\\\":\\\"cstor-cspc-disk-pool\\\"},\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2235040\\\",\\\"selfLink\\\":\\\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"uid\\\":\\\"985a952c-74bd-4f07-856c-d387c5922eb9\\\"},\\\"publish\\\":{\\\"nodeId\\\":\\\"giri-node2\\\"},\\\"spec\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"cstorVolumeRef\\\":{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolume\\\",\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2229980\\\",\\\"uid\\\":\\\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\\\"},\\\"policy\\\":{\\\"provision\\\":{\\\"replicaAffinity\\\":false},\\\"replica\\\":{\\\"affinity\\\":null,\\\"zvolWorkers\\\":\\\"\\\"},\\\"replicaPoolInfo\\\":null},\\\"replicaCount\\\":1},\\\"status\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"phase\\\":\\\"Bound\\\",\\\"poolInfo\\\":[\\\"cstor-cspc-disk-pool-gzxl\\\",\\\"cstor-cspc-disk-pool-jkf8\\\"]},\\\"versionDetails\\\":{\\\"autoUpgrade\\\":false,\\\"desired\\\":\\\"1.7.0\\\",\\\"status\\\":{\\\"current\\\":\\\"1.7.0\\\",\\\"dependentsUpgraded\\\":true,\\\"lastUpdateTime\\\":null,\\\"state\\\":\\\"\\\"}}}\\n\"}},\"spec\":{\"policy\":{\"replicaPoolInfo\":null,\"target\":null}}}", "to:", "Resource: \"openebs.io/v1alpha1, Resource=cstorvolumeclaims\", GroupVersionKind: \"openebs.io/v1alpha1, Kind=CStorVolumeClaim\"", "Name: \"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\", Namespace: \"openebs\"", "Object: &{map[\"versionDetails\":map[\"desired\":\"1.7.0\" \"status\":map[\"current\":\"1.7.0\" \"dependentsUpgraded\":%!q(bool=true) \"lastUpdateTime\":<nil> \"state\":\"\"] \"autoUpgrade\":%!q(bool=false)] \"apiVersion\":\"openebs.io/v1alpha1\" \"kind\":\"CStorVolumeClaim\" \"metadata\":map[\"annotations\":map[\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolumeClaim\\\",\\\"metadata\\\":{\\\"annotations\\\":{\\\"openebs.io/volume-policy\\\":\\\"\\\",\\\"openebs.io/volumeID\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\"},\\\"creationTimestamp\\\":\\\"2020-03-31T05:57:19Z\\\",\\\"finalizers\\\":[\\\"cvc.openebs.io/finalizer\\\"],\\\"generation\\\":5,\\\"labels\\\":{\\\"openebs.io/cstor-pool-cluster\\\":\\\"cstor-cspc-disk-pool\\\"},\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2230611\\\",\\\"selfLink\\\":\\\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"uid\\\":\\\"985a952c-74bd-4f07-856c-d387c5922eb9\\\"},\\\"publish\\\":{\\\"nodeId\\\":\\\"giri-node2\\\"},\\\"spec\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"cstorVolumeRef\\\":{\\\"apiVersion\\\":\\\"openebs.io/v1alpha1\\\",\\\"kind\\\":\\\"CStorVolume\\\",\\\"name\\\":\\\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\\\",\\\"namespace\\\":\\\"openebs\\\",\\\"resourceVersion\\\":\\\"2229980\\\",\\\"uid\\\":\\\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\\\"},\\\"policy\\\":{\\\"provision\\\":{\\\"replicaAffinity\\\":false},\\\"replica\\\":{\\\"affinity\\\":null,\\\"zvolWorkers\\\":\\\"\\\"},\\\"replicaPoolInfo\\\":[{\\\"poolName\\\":\\\"cstor-cspc-disk-pool-gzxl\\\"}],\\\"target\\\":{}},\\\"replicaCount\\\":1},\\\"status\\\":{\\\"capacity\\\":{\\\"storage\\\":\\\"5Gi\\\"},\\\"phase\\\":\\\"Bound\\\",\\\"poolInfo\\\":[\\\"cstor-cspc-disk-pool-jkf8\\\",\\\"cstor-cspc-disk-pool-gzxl\\\"]},\\\"versionDetails\\\":{\\\"autoUpgrade\\\":false,\\\"desired\\\":\\\"1.7.0\\\",\\\"status\\\":{\\\"current\\\":\\\"1.7.0\\\",\\\"dependentsUpgraded\\\":true,\\\"lastUpdateTime\\\":null,\\\"state\\\":\\\"\\\"}}}\\n\" \"openebs.io/volume-policy\":\"\" \"openebs.io/volumeID\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\"] \"generation\":'\\t' \"labels\":map[\"openebs.io/cstor-pool-cluster\":\"cstor-cspc-disk-pool\"] \"uid\":\"985a952c-74bd-4f07-856c-d387c5922eb9\" \"resourceVersion\":\"2235040\" \"selfLink\":\"/apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" \"creationTimestamp\":\"2020-03-31T05:57:19Z\" \"finalizers\":[\"cvc.openebs.io/finalizer\"] \"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" \"namespace\":\"openebs\"] \"publish\":map[\"nodeId\":\"giri-node2\"] \"spec\":map[\"policy\":map[\"provision\":map[\"replicaAffinity\":%!q(bool=false)] \"replica\":map[\"affinity\":<nil> \"zvolWorkers\":\"\"] \"replicaPoolInfo\":[map[\"poolName\":\"cstor-cspc-disk-pool-gzxl\"] map[\"poolName\":\"cstor-cspc-disk-pool-jkf8\"]] \"target\":map[]] \"replicaCount\":'\\x01' \"capacity\":map[\"storage\":\"5Gi\"] \"cstorVolumeRef\":map[\"apiVersion\":\"openebs.io/v1alpha1\" \"kind\":\"CStorVolume\" \"name\":\"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" \"namespace\":\"openebs\" \"resourceVersion\":\"2229980\" \"uid\":\"ecc054e1-ab4a-4b8a-b9ae-56a1f6c6353a\"]] \"status\":map[\"capacity\":map[\"storage\":\"5Gi\"] \"phase\":\"Bound\" \"poolInfo\":[\"cstor-cspc-disk-pool-gzxl\" \"cstor-cspc-disk-pool-jkf8\"]]]}", "for: \"cvc2.yml\": admission webhook \"admission-webhook.openebs.io\" denied the request: Can't perform more than one replica scale down requested scale down count 2"], "stdout": "", "stdout_lines": []}

TASK [Remove one pool instance info from cvc manifest] *************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:98
2020-03-31T06:32:23.409589 (delta: 1.371535)         elapsed: 21.141313 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sed -i '/replicaPoolInfo:/{N;s/\\n.*//;}' cvc1.yml", "delta": "0:00:00.801019", "end": "2020-03-31 06:32:24.389599", "rc": 0, "start": "2020-03-31 06:32:23.588580", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Scale down the replicas by configuring cvc] ******************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:103
2020-03-31T06:32:24.465301 (delta: 1.055637)         elapsed: 22.197025 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cvc1.yml", "delta": "0:00:01.026925", "end": "2020-03-31 06:32:25.658755", "failed_when_result": false, "rc": 0, "start": "2020-03-31 06:32:24.631830", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumeclaim.openebs.io/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab configured", "stdout_lines": ["cstorvolumeclaim.openebs.io/pvc-c2af040a-7532-429b-8fa7-98ad13e25eab configured"]}

TASK [Check the replica count in cvc] ******************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:110
2020-03-31T06:32:25.729647 (delta: 1.264275)         elapsed: 23.461371 ******* 
FAILED - RETRYING: Check the replica count in cvc (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get cvc \"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" -n \"openebs\" --no-headers -o custom-columns=:status.poolInfo | awk '{print NF}'", "delta": "0:00:00.893382", "end": "2020-03-31 06:32:37.843429", "rc": 0, "start": "2020-03-31 06:32:36.950047", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [check the replica count in cStorvolume] **********************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:121
2020-03-31T06:32:37.909792 (delta: 12.180005)         elapsed: 35.641516 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume \"pvc-c2af040a-7532-429b-8fa7-98ad13e25eab\" -n \"openebs\" --no-headers -o custom-columns=:spec.replicationFactor", "delta": "0:00:00.927814", "end": "2020-03-31 06:32:39.035405", "rc": 0, "start": "2020-03-31 06:32:38.107591", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Delete the application pod] **********************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:132
2020-03-31T06:32:39.099536 (delta: 1.189675)         elapsed: 36.83126 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"percona-8568b6cc96-twrzh\" -n \"giri\"", "delta": "0:00:04.877942", "end": "2020-03-31 06:32:44.192089", "failed_when_result": false, "rc": 0, "start": "2020-03-31 06:32:39.314147", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-8568b6cc96-twrzh\" deleted", "stdout_lines": ["pod \"percona-8568b6cc96-twrzh\" deleted"]}

TASK [Get the application pod name] ********************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:139
2020-03-31T06:32:44.266040 (delta: 5.166463)         elapsed: 41.997764 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n giri --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.875683", "end": "2020-03-31 06:32:45.323276", "rc": 0, "start": "2020-03-31 06:32:44.447593", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-znwh6", "stdout_lines": ["percona-8568b6cc96-znwh6"]}

TASK [Check if the application pod is in running state] ************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:146
2020-03-31T06:32:45.382534 (delta: 1.116418)         elapsed: 43.114258 ******* 
FAILED - RETRYING: Check if the application pod is in running state (30 retries left).
FAILED - RETRYING: Check if the application pod is in running state (29 retries left).
FAILED - RETRYING: Check if the application pod is in running state (28 retries left).
FAILED - RETRYING: Check if the application pod is in running state (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods \"percona-8568b6cc96-znwh6\" -n \"giri\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.844121", "end": "2020-03-31 06:33:30.685263", "rc": 0, "start": "2020-03-31 06:33:29.841142", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:157
2020-03-31T06:33:30.753687 (delta: 45.371019)         elapsed: 88.485411 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:165
2020-03-31T06:33:30.823734 (delta: 0.070004)         elapsed: 88.555458 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:174
2020-03-31T06:33:30.903226 (delta: 0.079445)         elapsed: 88.63495 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-03-31T06:33:30.996918 (delta: 0.093644)         elapsed: 88.728642 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-03-31T06:33:31.059732 (delta: 0.062742)         elapsed: 88.791456 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-03-31T06:33:31.112894 (delta: 0.053083)         elapsed: 88.844618 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-03-31T06:33:31.170913 (delta: 0.057954)         elapsed: 88.902637 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "edef4929c2aeb0b4080b53449e71fdd2989816ca", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b21152f8341923b57281ccf4a5984def", "mode": "0644", "owner": "root", "size": 426, "src": "/root/.ansible/tmp/ansible-tmp-1585636411.27-274093139376818/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-03-31T06:33:33.048523 (delta: 1.877544)         elapsed: 90.780247 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.735436", "end": "2020-03-31 06:33:33.967925", "rc": 0, "start": "2020-03-31 06:33:33.232489", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-replica-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-replica-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-03-31T06:33:34.040336 (delta: 0.991765)         elapsed: 91.77206 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-03-30T02:05:59Z", "generation": 12, "name": "cstor-csi-replica-scaledown", "resourceVersion": "2239801", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-replica-scaledown", "uid": "71f998d1-c272-44eb-b741-67c9618ba5b4"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=28   changed=21   unreachable=0    failed=0   

2020-03-31T06:33:34.875070 (delta: 0.834667)         elapsed: 92.606794 ******* 
=============================================================================== 
```
