### PR TITLE
feat[rothreshold]: Included a test case to verify the cstor rothreshold limit

### DIFF
--- a/experiments/functional/rothreshold-limit/busybox_deployment.yml
+++ b/experiments/functional/rothreshold-limit/busybox_deployment.yml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    lkey: lvalue
+  name: busybox-rolimit
+spec:
+  clusterIP: None
+  selector:
+    lkey: lvalue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-busybox
+  labels:
+    lkey: lvalue
+    openebs.io/target-affinity: lvalue
+spec:
+  serviceName: busybox-limit
+  selector:
+    matchLabels:
+      lkey: lvalue
+      openebs.io/target-affinity: lvalue
+  template:
+    metadata:
+      labels:
+        lkey: lvalue
+        openebs.io/target-affinity: lvalue
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: testclaim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+  labels:
+    openebs.io/target-affinity: lvalue
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: teststorage

--- a/experiments/functional/rothreshold-limit/run_litmus_test.yml
+++ b/experiments/functional/rothreshold-limit/run_litmus_test.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-rothreshold-limit-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cstor-rothreshold-limit
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # Provide name POOL_NAME for the cstor-pool
+          - name: POOL_NAME
+            value: cstor-rothreshold-limit-pool
+
+           # Provide the value for POOL_TYPE 
+           # Supported values: striped, mirrored, raidz ,raidz2
+          - name: POOL_TYPE
+            value: striped
+            
+           # Provide the name of PROVIDER_STORAGE_CLASS
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-cstor-rothreshold-limit
+
+          - name: OPERATOR_NS
+            value: openebs
+
+          - name: ROTHRESHOLD_LIMIT
+            value: "20"
+
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+
+            # Application label
+          - name: APP_LABEL
+            value: 'app=busybox-limit'
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: rothreshold-limit
+
+            #Persistent Volume storage capacity
+          - name: PV_CAPACITY
+            value: 20Gi
+
+          - name: THICK_PROVISIONING
+            value: "false"
+        
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/rothreshold-limit/test.yml -i /etc/ansible/hosts -v; exit 0"]
+

--- a/experiments/functional/rothreshold-limit/spc.yml
+++ b/experiments/functional/rothreshold-limit/spc.yml
@@ -1,0 +1,27 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: pool-name
+spec:
+  name: pool-name
+  type: disk
+  poolSpec:
+    poolType: pool-type
+    thickProvisioning: true
+    roThresholdLimit: threshold-value
+  blockDevices:
+    blockDeviceList:
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: sc-name
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: pool-name
+      - name: ReplicaCount
+        value: "3"
+provisioner: openebs.io/provisioner-iscsi

--- a/experiments/functional/rothreshold-limit/test.yml
+++ b/experiments/functional/rothreshold-limit/test.yml
@@ -1,0 +1,422 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+      ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+        - name: Getting the compute node name
+          shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'}
+          register: nodes
+
+        - name: Replacing the pool type in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "pool-type"
+            replace: "{{ pool_type }}"
+
+        - name: Replacing the rothreshold limit value in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "threshold-value"
+            replace: "{{ rothreshold_limit }}"
+
+        - name: Replacing the over provisioning spec if it has to be disabled
+          replace:
+            path: ./spc.yml
+            regexp: "thickProvisioning: false"
+            replace: "thickProvisioning: true"
+          when: "{{ lookup('env', 'THICK_PROVISIONING') }} == true"
+        
+        - block:
+
+          - name: Getting the Unclaimed block-device from each node when pool type is STRIPE
+            shell: >
+              kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ item }} 
+              -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 1
+            register: blockDevice
+            with_items: "{{ nodes.stdout_lines }}"
+
+          - name: Initialize an empty list to store block device names
+            set_fact:
+              bd_names: []
+
+          - name: Store name of all block devices in the list 
+            set_fact:
+              bd_names: "{{ bd_names + item.stdout_lines }}"
+            with_items:
+              - "{{ blockDevice.results }}"
+              
+          - name: Adding discovered block device into SPC spec
+            lineinfile:
+              path: "./spc.yml"
+              insertafter: 'blockDeviceList:'
+              line: '    - {{ item }}'
+            with_items: "{{ bd_names }}"
+
+          when: pool_type == "striped" 
+
+        - block:
+
+          - name: Getting the Unclaimed block-devices from each node when pool type is MIRROR 
+            shell: >
+              kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} 
+              -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 2
+            register: blockDevice
+            with_items: "{{ nodes.stdout_lines }}" 
+          
+          - name: Initialize an empty list to store block device names
+            set_fact:
+              bd_names: []
+
+          - name: Store name of all block devices in the list 
+            set_fact:
+              bd_names: "{{ bd_names + item.stdout_lines }}"
+            with_items:
+              - "{{ blockDevice.results }}"
+          
+          - name: Adding discovered block devices into SPC spec
+            lineinfile:
+              path: "./spc.yml"
+              insertafter: 'blockDeviceList:'
+              line: '    - {{ item }}'
+            with_items: "{{ bd_names }}"
+
+          when: pool_type == "mirrored"
+
+        - block:
+
+          - name: Getting the Unclaimed block-devices from each node when pool type is RAIDZ1
+            shell: >
+              kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} 
+              -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 3
+            register: blockDevice
+            with_items: "{{ nodes.stdout_lines }}"
+
+          - name: Initialize an empty list to store block device names
+            set_fact:
+              bd_names: []
+
+          - name: Store name of all block devices in the list
+            set_fact:
+              bd_names: "{{ bd_names + item.stdout_lines }}"
+            with_items:
+              - "{{ blockDevice.results }}"
+
+          - name: Adding discovered block device into SPC spec
+            lineinfile:
+              path: "./spc.yml"
+              insertafter: 'blockDeviceList:'
+              line: '    - {{ item }}'
+            with_items: "{{ bd_names }}"
+
+          when: pool_type == "raidz"
+
+        - block:
+
+          - name: Getting the Unclaimed block-device from each node when pool type is RAIDZ2
+            shell: > 
+              kubectl get blockdevice -n openebs -l kubernetes.io/hostname={{ item }} 
+              -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n 6
+            register: blockDevice
+            with_items: "{{ nodes.stdout_lines }}"
+
+          - name: Initialize an empty list to store block device names
+            set_fact:
+              bd_names: []
+
+          - name: Store name of all block devices in the list
+            set_fact:
+              bd_names: "{{ bd_names + item.stdout_lines }}"
+            with_items:
+              - "{{ blockDevice.results }}"
+            
+          - name: Adding discovered block device into SPC spec
+            lineinfile:
+              path: "./spc.yml"
+              insertafter: 'blockDeviceList:'
+              line: '    - {{ item }}'
+            with_items: "{{ bd_names }}" 
+          
+          when: pool_type == "raidz2"  
+
+        - set_fact:
+            device_count: "{{ blockDevice|length}}"  
+
+        - name: Replacing the pool name in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "pool-name"
+            replace: "{{ pool_name }}"
+
+        - name: Replacing the storage class name in SPC spec
+          replace:
+            path: ./spc.yml
+            regexp: "sc-name"
+            replace: "{{ storage_class }}"
+
+        - name: Display spc.yml for verification 
+          debug: var=item
+          with_file:
+          - "spc.yml"
+
+        - name: Create cstor disk pool
+          shell: kubectl apply -f spc.yml
+          args:
+            executable: /bin/bash
+
+        - name: Verify if cStor Disk Pool are Running
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+            --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: pool_count
+          until: "((pool_count.stdout_lines|unique)|length) == 1 and 'Running' in pool_count.stdout"
+          retries: 30
+          delay: 10
+
+        - name: Get cStor Disk Pool names to verify the container statuses
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+            --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: cstor_pool_pod
+
+        - name: Get the runningStatus of pool pod
+          shell: >
+            kubectl get pod {{ item }} -n {{ operator_ns }}
+            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+            grep -w running | wc -l
+          args:
+            executable: /bin/bash
+          register: runningStatusCount
+          with_items: "{{ cstor_pool_pod.stdout_lines }}"
+          until: "runningStatusCount.stdout == device_count"
+          delay: 30
+          retries: 10
+
+        - name: Obtain the CSP name to verify the status
+          shell: >
+            kubectl get csp -l openebs.io/storage-pool-claim={{ pool_name }}
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: csp_name
+
+        - name: Verify the status of CSP
+          shell: >
+            kubectl get csp -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
+          args:
+            executable: /bin/bash
+          register: csp_status
+          with_items: "{{ csp_name.stdout_lines }}"
+          until: "'Healthy' in csp_status.stdout"
+          delay: 5
+          retries: 30
+
+        ## Creating namespaces and making the application for deployment
+        - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+
+        - name: Replace the volume capcity placeholder with provider
+          replace:
+            path: "{{ application_deployment }}"
+            regexp: "teststorage"
+            replace: "{{ lookup('env','PV_CAPACITY') }}"
+
+            ## Deploying the application
+        - include_tasks: /utils/k8s/deploy_single_app.yml
+          vars:
+            check_app_pod: 'yes'
+            delay: 10
+            retries: 20
+
+        - name: Obtain the PV name
+          shell: kubectl get pvc {{ app_pvc }} -n {{ app_ns }}  -o custom-columns=:.spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: pv_name
+
+        - name: Obtaining the pool deployments from cvr
+          shell: >
+            kubectl get cvr -n {{ operator_ns }}
+            -l openebs.io/persistent-volume={{ pv_name.stdout }} --no-headers
+            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+          args:
+            executable: /bin/bash
+          register: pool_deployment              
+
+        - name: Verify the readOnly status of CSP
+          shell: >
+            kubectl get csp -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.readOnly}'
+          args:
+            executable: /bin/bash
+          register: csp_status
+          with_items: "{{ pool_deployment.stdout_lines }}"
+          until: "'false' in csp_status.stdout"
+          delay: 5
+          retries: 30              
+
+        - name: Getting the pod name of Application
+          shell: kubectl get pod -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+          args:
+            executable: /bin/bash           
+          register: app_pod_name
+
+        - name: Getting the application mount point
+          shell: kubectl get pod {{ app_pod_name.stdout }} -n {{ app_ns }} -o jsonpath='{.spec.containers[0].volumeMounts[0].mountPath}'
+          args:
+            executable: /bin/bash               
+          register: app_mount_path
+
+        - name: Create some test data to verify the data persistence
+          include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ app_ns }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            blocksize: 4k
+            blockcount: 1024
+            testfile: rothreshold                
+              
+        - name: Writing data on application mount point
+          shell: >
+            kubectl exec -it {{ app_pod_name.stdout }} -n {{ app_ns }} 
+            -- sh -c "cd {{ app_mount_path.stdout }} && dd if=/dev/urandom of=test.txt bs=4k count=3932160"
+          args:
+            executable: /bin/bash
+
+        - name: Verify the readOnly status of CSP after reached the threshold limit
+          shell: >
+            kubectl get csp -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.readOnly}'
+          args:
+            executable: /bin/bash
+          register: aft_csp_status
+          with_items: "{{ pool_deployment.stdout_lines }}"
+          until: "'true' in aft_csp_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Patch the csp to change the threshold value
+          shell: >
+            kubectl patch csp {{ item }} --type='json' -p='[{"op":"replace", "path":"/spec/poolSpec/roThresholdLimit", "value":85}]'
+          args:
+            executable: /bin/bash
+          register: patch_csp_status
+          with_items: "{{ pool_deployment.stdout_lines }}"
+          failed_when: "'patched' not in patch_csp_status.stdout"
+
+        - name: Verify the readOnly status of CSP after changed it to default
+          shell: >
+            kubectl get csp -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.readOnly}'
+          args:
+            executable: /bin/bash
+          register: csp_status
+          with_items: "{{ pool_deployment.stdout_lines }}"
+          until: "'false' in csp_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Create some test data to verify the data persistence
+          include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ app_ns }}"
+            label: "{{ app_label }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            blocksize: 4k
+            blockcount: 1024
+            testfile: rothreshold              
+                                                    
+        - set_fact:
+            flag: "Pass"
+    
+      rescue:
+          - set_fact:
+              flag: "Fail"
+  
+      always:
+
+          - name: Deprovisioning the Application
+            include_tasks: "/utils/k8s/deprovision_deployment.yml"
+            vars:
+              app_deployer: "{{ application_deployment }}"
+              
+          - name: Obtain the claimed blockDevice list from bdc
+            shell: >
+              kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+              -o custom-columns=:.spec.blockDeviceName --no-headers
+            args:
+              executable: /bin/bash
+            register: blockdevice_name
+
+          - name: Remove the SPC
+            shell: kubectl delete spc {{ pool_name }}
+            args:
+              executable: /bin/bash
+            
+          - name: Verify if the SPC is deleted
+            shell: kubectl get spc
+            args:
+              executable: /bin/bash
+            register: spc_status
+            until: '"{{ pool_name }}" not in spc_status.stdout'
+            retries: 30
+            delay: 10
+
+          - name: Verify if the CSP is getting removed
+            shell: kubectl get csp -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            args:
+              executable: /bin/bash
+            register: csp_status
+            until: "'No resources found.' in csp_status.stderr"
+            retries: 30
+            delay: 10
+
+          - name: Verify if the cStor pool pods are deleted
+            shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+            args:
+              executable: /bin/bash
+            register: pool_status
+            until: "'No resources found.' in pool_status.stderr"
+            retries: 30
+            delay: 10
+
+          - name: Verify if the BDC are deleted
+            shell: kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ pool_name }}
+            args:
+              executable: /bin/bash
+            register: bdc_status
+            until: "'No resources found.' in bdc_status.stderr"
+            retries: 30
+            delay: 10
+
+          - name: Verify if the blockDevices are unclaimed
+            shell: >
+              kubectl get blockdevices -n {{ operator_ns }} 
+              -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.claimState}'
+            args:
+              executable: /bin/bash
+            register: bd_status
+            with_items: "{{ blockdevice_name.stdout_lines }}"
+            until: "'Unclaimed' in bd_status.stdout"
+            retries: 30
+            delay: 10 
+
+              ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'  
+        

--- a/experiments/functional/rothreshold-limit/test_vars.yml
+++ b/experiments/functional/rothreshold-limit/test_vars.yml
@@ -1,0 +1,11 @@
+# Test-specific parameters
+application_deployment: busybox_deployment.yml
+rothreshold_limit: "{{ lookup('env','ROTHRESHOLD_LIMIT') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+test_name: cstor-rothreshold-limit
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_type: "{{ lookup('env','POOL_TYPE') }}"
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+app_label: "{{ lookup('env','APP_LABEL') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- This PR is to verify the threshold limit of pools
- In this test case Pools will be created with the threshold limit and checks if the csp is went to readonly as true if the threshold limit exceeded.
- Again will increase the threshold limit and verifying the pools came back into readonly as false

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
d2iq@rack2:~$ kubectl logs -f cstor-rothreshold-limit-fhjs7-7g2ln -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-04-03T07:30:55.294865 (delta: 0.089055)         elapsed: 0.089055 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-03T07:30:55.310163 (delta: 0.015235)         elapsed: 0.104353 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-04-03T07:31:07.659711 (delta: 12.349528)         elapsed: 12.453901 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-04-03T07:31:07.883612 (delta: 0.223836)         elapsed: 12.677802 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-04-03T07:31:08.024671 (delta: 0.140923)         elapsed: 12.818861 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-03T07:31:08.172158 (delta: 0.147384)         elapsed: 12.966348 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-03T07:31:08.431590 (delta: 0.259312)         elapsed: 13.22578 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b3e433666764d0721de4a39c11fa33929b9a6682", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "dcb067bea82c60ae05f9ae9c6402726b", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1585899068.52-63194788334417/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T07:31:09.420262 (delta: 0.988594)         elapsed: 14.214452 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.157946", "end": "2020-04-03 07:31:11.141912", "rc": 0, "start": "2020-04-03 07:31:09.983966", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-rothreshold-limit \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-rothreshold-limit ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T07:31:11.241065 (delta: 1.820697)         elapsed: 16.035255 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T04:26:00Z", "generation": 10, "name": "cstor-rothreshold-limit", "resourceVersion": "363301", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-rothreshold-limit", "uid": "69bbb0ba-1243-486e-bb14-f8e4765c508e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-03T07:31:12.910384 (delta: 1.66925)         elapsed: 17.704574 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T07:31:13.038493 (delta: 0.128005)         elapsed: 17.832683 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T07:31:13.171005 (delta: 0.132414)         elapsed: 17.965195 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-04-03T07:31:13.297163 (delta: 0.126059)         elapsed: 18.091353 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'}", "delta": "0:00:01.477531", "end": "2020-04-03 07:31:15.150803", "rc": 0, "start": "2020-04-03 07:31:13.673272", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node1.mayalabs.io\nd2iq-node2.mayalabs.io\nd2iq-node3.mayalabs.io\nd2iq-node4.mayalabs.io\nd2iq-node5.mayalabs.io", "stdout_lines": ["d2iq-node1.mayalabs.io", "d2iq-node2.mayalabs.io", "d2iq-node3.mayalabs.io", "d2iq-node4.mayalabs.io", "d2iq-node5.mayalabs.io"]}

TASK [Replacing the pool type in SPC spec] *************************************
2020-04-03T07:31:15.289370 (delta: 1.992109)         elapsed: 20.08356 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the rothreshold limit value in SPC spec] ***********************
2020-04-03T07:31:16.005743 (delta: 0.716272)         elapsed: 20.799933 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the over provisioning spec if it has to be disabled] ***********
2020-04-03T07:31:16.514998 (delta: 0.509134)         elapsed: 21.309188 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ lookup('env', 'THICK_PROVISIONING') }} ==
true
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is STRIPE] ***
2020-04-03T07:31:16.608592 (delta: 0.093524)         elapsed: 21.402782 ******* 
changed: [127.0.0.1] => (item=d2iq-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.391542", "end": "2020-04-03 07:31:18.303273", "item": "d2iq-node1.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:16.911731", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0d523d92406ce19801b840738bf83497", "stdout_lines": ["blockdevice-0d523d92406ce19801b840738bf83497"]}
changed: [127.0.0.1] => (item=d2iq-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.471486", "end": "2020-04-03 07:31:20.143972", "item": "d2iq-node2.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:18.672486", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "stdout_lines": ["blockdevice-0980f7d094a8b4feb069c7745b9b891f"]}
changed: [127.0.0.1] => (item=d2iq-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.473259", "end": "2020-04-03 07:31:21.981481", "item": "d2iq-node3.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:20.508222", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0deb852da7a97b23017975b37d133cc7", "stdout_lines": ["blockdevice-0deb852da7a97b23017975b37d133cc7"]}
changed: [127.0.0.1] => (item=d2iq-node4.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.321511", "end": "2020-04-03 07:31:23.640493", "item": "d2iq-node4.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:22.318982", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "stdout_lines": ["blockdevice-06e7e15fd8721f276f87859b3d64e889"]}
changed: [127.0.0.1] => (item=d2iq-node5.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.419072", "end": "2020-04-03 07:31:25.435907", "item": "d2iq-node5.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:24.016835", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "stdout_lines": ["blockdevice-07d7245a501cf554818a4c75cbe985aa"]}

TASK [Initialize an empty list to store block device names] ********************
2020-04-03T07:31:25.571887 (delta: 8.963193)         elapsed: 30.366077 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"bd_names": []}, "changed": false}

TASK [Store name of all block devices in the list] *****************************
2020-04-03T07:31:25.790227 (delta: 0.218241)         elapsed: 30.584417 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-0d523d92406ce19801b840738bf83497', '_ansible_item_result': True, u'delta': u'0:00:01.391542', 'stdout_lines': [u'blockdevice-0d523d92406ce19801b840738bf83497'], '_ansible_item_label': u'd2iq-node1.mayalabs.io', u'end': u'2020-04-03 07:31:18.303273', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'd2iq-node1.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-04-03 07:31:16.911731', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0d523d92406ce19801b840738bf83497"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.391542", "end": "2020-04-03 07:31:18.303273", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "d2iq-node1.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:16.911731", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0d523d92406ce19801b840738bf83497", "stdout_lines": ["blockdevice-0d523d92406ce19801b840738bf83497"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-0980f7d094a8b4feb069c7745b9b891f', '_ansible_item_result': True, u'delta': u'0:00:01.471486', 'stdout_lines': [u'blockdevice-0980f7d094a8b4feb069c7745b9b891f'], '_ansible_item_label': u'd2iq-node2.mayalabs.io', u'end': u'2020-04-03 07:31:20.143972', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'd2iq-node2.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-04-03 07:31:18.672486', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0d523d92406ce19801b840738bf83497", "blockdevice-0980f7d094a8b4feb069c7745b9b891f"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.471486", "end": "2020-04-03 07:31:20.143972", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "d2iq-node2.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:18.672486", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "stdout_lines": ["blockdevice-0980f7d094a8b4feb069c7745b9b891f"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-0deb852da7a97b23017975b37d133cc7', '_ansible_item_result': True, u'delta': u'0:00:01.473259', 'stdout_lines': [u'blockdevice-0deb852da7a97b23017975b37d133cc7'], '_ansible_item_label': u'd2iq-node3.mayalabs.io', u'end': u'2020-04-03 07:31:21.981481', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'd2iq-node3.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-04-03 07:31:20.508222', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0d523d92406ce19801b840738bf83497", "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "blockdevice-0deb852da7a97b23017975b37d133cc7"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.473259", "end": "2020-04-03 07:31:21.981481", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "d2iq-node3.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:20.508222", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0deb852da7a97b23017975b37d133cc7", "stdout_lines": ["blockdevice-0deb852da7a97b23017975b37d133cc7"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-06e7e15fd8721f276f87859b3d64e889', '_ansible_item_result': True, u'delta': u'0:00:01.321511', 'stdout_lines': [u'blockdevice-06e7e15fd8721f276f87859b3d64e889'], '_ansible_item_label': u'd2iq-node4.mayalabs.io', u'end': u'2020-04-03 07:31:23.640493', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'd2iq-node4.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node4.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-04-03 07:31:22.318982', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0d523d92406ce19801b840738bf83497", "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "blockdevice-0deb852da7a97b23017975b37d133cc7", "blockdevice-06e7e15fd8721f276f87859b3d64e889"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.321511", "end": "2020-04-03 07:31:23.640493", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node4.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "d2iq-node4.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:22.318982", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "stdout_lines": ["blockdevice-06e7e15fd8721f276f87859b3d64e889"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-07d7245a501cf554818a4c75cbe985aa', '_ansible_item_result': True, u'delta': u'0:00:01.419072', 'stdout_lines': [u'blockdevice-07d7245a501cf554818a4c75cbe985aa'], '_ansible_item_label': u'd2iq-node5.mayalabs.io', u'end': u'2020-04-03 07:31:25.435907', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', 'item': u'd2iq-node5.mayalabs.io', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node5.mayalabs.io -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | grep -v sparse | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-04-03 07:31:24.016835', '_ansible_ignore_errors': None}) => {"ansible_facts": {"bd_names": ["blockdevice-0d523d92406ce19801b840738bf83497", "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "blockdevice-0deb852da7a97b23017975b37d133cc7", "blockdevice-06e7e15fd8721f276f87859b3d64e889", "blockdevice-07d7245a501cf554818a4c75cbe985aa"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "delta": "0:00:01.419072", "end": "2020-04-03 07:31:25.435907", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node5.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n 1", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "d2iq-node5.mayalabs.io", "rc": 0, "start": "2020-04-03 07:31:24.016835", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "stdout_lines": ["blockdevice-07d7245a501cf554818a4c75cbe985aa"]}}

TASK [Adding discovered block device into SPC spec] ****************************
2020-04-03T07:31:26.047145 (delta: 0.256814)         elapsed: 30.841335 ******* 
changed: [127.0.0.1] => (item=blockdevice-0d523d92406ce19801b840738bf83497) => {"backup": "", "changed": true, "item": "blockdevice-0d523d92406ce19801b840738bf83497", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-0980f7d094a8b4feb069c7745b9b891f) => {"backup": "", "changed": true, "item": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-0deb852da7a97b23017975b37d133cc7) => {"backup": "", "changed": true, "item": "blockdevice-0deb852da7a97b23017975b37d133cc7", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-06e7e15fd8721f276f87859b3d64e889) => {"backup": "", "changed": true, "item": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "msg": "line added"}
changed: [127.0.0.1] => (item=blockdevice-07d7245a501cf554818a4c75cbe985aa) => {"backup": "", "changed": true, "item": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "msg": "line added"}

TASK [Getting the Unclaimed block-devices from each node when pool type is MIRROR] ***
2020-04-03T07:31:27.645313 (delta: 1.598097)         elapsed: 32.439503 ******* 
skipping: [127.0.0.1] => (item=d2iq-node1.mayalabs.io)  => {"changed": false, "item": "d2iq-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node2.mayalabs.io)  => {"changed": false, "item": "d2iq-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node3.mayalabs.io)  => {"changed": false, "item": "d2iq-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node4.mayalabs.io)  => {"changed": false, "item": "d2iq-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node5.mayalabs.io)  => {"changed": false, "item": "d2iq-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2020-04-03T07:31:27.854000 (delta: 0.208627)         elapsed: 32.64819 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2020-04-03T07:31:27.948172 (delta: 0.094113)         elapsed: 32.742362 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block devices into SPC spec] ***************************
2020-04-03T07:31:28.197568 (delta: 0.249309)         elapsed: 32.991758 ******* 
skipping: [127.0.0.1] => (item=blockdevice-0d523d92406ce19801b840738bf83497)  => {"changed": false, "item": "blockdevice-0d523d92406ce19801b840738bf83497", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0980f7d094a8b4feb069c7745b9b891f)  => {"changed": false, "item": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0deb852da7a97b23017975b37d133cc7)  => {"changed": false, "item": "blockdevice-0deb852da7a97b23017975b37d133cc7", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-06e7e15fd8721f276f87859b3d64e889)  => {"changed": false, "item": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-07d7245a501cf554818a4c75cbe985aa)  => {"changed": false, "item": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-devices from each node when pool type is RAIDZ1] ***
2020-04-03T07:31:28.447762 (delta: 0.250052)         elapsed: 33.241952 ******* 
skipping: [127.0.0.1] => (item=d2iq-node1.mayalabs.io)  => {"changed": false, "item": "d2iq-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node2.mayalabs.io)  => {"changed": false, "item": "d2iq-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node3.mayalabs.io)  => {"changed": false, "item": "d2iq-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node4.mayalabs.io)  => {"changed": false, "item": "d2iq-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node5.mayalabs.io)  => {"changed": false, "item": "d2iq-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2020-04-03T07:31:28.694980 (delta: 0.247066)         elapsed: 33.48917 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2020-04-03T07:31:28.852365 (delta: 0.157283)         elapsed: 33.646555 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2020-04-03T07:31:29.147127 (delta: 0.294645)         elapsed: 33.941317 ******* 
skipping: [127.0.0.1] => (item=blockdevice-0d523d92406ce19801b840738bf83497)  => {"changed": false, "item": "blockdevice-0d523d92406ce19801b840738bf83497", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0980f7d094a8b4feb069c7745b9b891f)  => {"changed": false, "item": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0deb852da7a97b23017975b37d133cc7)  => {"changed": false, "item": "blockdevice-0deb852da7a97b23017975b37d133cc7", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-06e7e15fd8721f276f87859b3d64e889)  => {"changed": false, "item": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-07d7245a501cf554818a4c75cbe985aa)  => {"changed": false, "item": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device from each node when pool type is RAIDZ2] ***
2020-04-03T07:31:29.371141 (delta: 0.223861)         elapsed: 34.165331 ******* 
skipping: [127.0.0.1] => (item=d2iq-node1.mayalabs.io)  => {"changed": false, "item": "d2iq-node1.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node2.mayalabs.io)  => {"changed": false, "item": "d2iq-node2.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node3.mayalabs.io)  => {"changed": false, "item": "d2iq-node3.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node4.mayalabs.io)  => {"changed": false, "item": "d2iq-node4.mayalabs.io", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=d2iq-node5.mayalabs.io)  => {"changed": false, "item": "d2iq-node5.mayalabs.io", "skip_reason": "Conditional result was False"}

TASK [Initialize an empty list to store block device names] ********************
2020-04-03T07:31:29.512356 (delta: 0.141127)         elapsed: 34.306546 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Store name of all block devices in the list] *****************************
2020-04-03T07:31:29.625363 (delta: 0.112939)         elapsed: 34.419553 ******* 
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node1.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node1.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node1.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node2.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node2.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node2.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node3.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node3.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node3.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node4.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node4.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node4.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'skipped': True, '_ansible_no_log': False, 'skip_reason': u'Conditional result was False', '_ansible_item_result': True, 'item': u'd2iq-node5.mayalabs.io', 'changed': False, '_ansible_ignore_errors': None, '_ansible_item_label': u'd2iq-node5.mayalabs.io'})  => {"changed": false, "item": {"changed": false, "item": "d2iq-node5.mayalabs.io", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}

TASK [Adding discovered block device into SPC spec] ****************************
2020-04-03T07:31:29.860197 (delta: 0.234739)         elapsed: 34.654387 ******* 
skipping: [127.0.0.1] => (item=blockdevice-0d523d92406ce19801b840738bf83497)  => {"changed": false, "item": "blockdevice-0d523d92406ce19801b840738bf83497", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0980f7d094a8b4feb069c7745b9b891f)  => {"changed": false, "item": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-0deb852da7a97b23017975b37d133cc7)  => {"changed": false, "item": "blockdevice-0deb852da7a97b23017975b37d133cc7", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-06e7e15fd8721f276f87859b3d64e889)  => {"changed": false, "item": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=blockdevice-07d7245a501cf554818a4c75cbe985aa)  => {"changed": false, "item": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-04-03T07:31:30.105535 (delta: 0.245244)         elapsed: 34.899725 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Replacing the pool name in SPC spec] *************************************
2020-04-03T07:31:30.305575 (delta: 0.199904)         elapsed: 35.099765 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Replacing the storage class name in SPC spec] ****************************
2020-04-03T07:31:30.760007 (delta: 0.454303)         elapsed: 35.554197 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Display spc.yml for verification] ****************************************
2020-04-03T07:31:31.228106 (delta: 0.468037)         elapsed: 36.022296 ******* 
ok: [127.0.0.1] => (item=apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-rothreshold-limit-pool
spec:
  name: cstor-rothreshold-limit-pool
  type: disk
  poolSpec:
    poolType: striped
    thickProvisioning: true
    roThresholdLimit: 20
  blockDevices:
    blockDeviceList:
    - blockdevice-07d7245a501cf554818a4c75cbe985aa
    - blockdevice-06e7e15fd8721f276f87859b3d64e889
    - blockdevice-0deb852da7a97b23017975b37d133cc7
    - blockdevice-0980f7d094a8b4feb069c7745b9b891f
    - blockdevice-0d523d92406ce19801b840738bf83497

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-cstor-rothreshold-limit
  annotations:
    openebs.io/cas-type: cstor
    cas.openebs.io/config: |
      - name: StoragePoolClaim
        value: cstor-rothreshold-limit-pool
      - name: ReplicaCount
        value: "3"
provisioner: openebs.io/provisioner-iscsi) => {
    "item": "apiVersion: openebs.io/v1alpha1\nkind: StoragePoolClaim\nmetadata:\n  name: cstor-rothreshold-limit-pool\nspec:\n  name: cstor-rothreshold-limit-pool\n  type: disk\n  poolSpec:\n    poolType: striped\n    thickProvisioning: true\n    roThresholdLimit: 20\n  blockDevices:\n    blockDeviceList:\n    - blockdevice-07d7245a501cf554818a4c75cbe985aa\n    - blockdevice-06e7e15fd8721f276f87859b3d64e889\n    - blockdevice-0deb852da7a97b23017975b37d133cc7\n    - blockdevice-0980f7d094a8b4feb069c7745b9b891f\n    - blockdevice-0d523d92406ce19801b840738bf83497\n\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n  name: openebs-cstor-rothreshold-limit\n  annotations:\n    openebs.io/cas-type: cstor\n    cas.openebs.io/config: |\n      - name: StoragePoolClaim\n        value: cstor-rothreshold-limit-pool\n      - name: ReplicaCount\n        value: \"3\"\nprovisioner: openebs.io/provisioner-iscsi"
}

TASK [Create cstor disk pool] **************************************************
2020-04-03T07:31:31.376733 (delta: 0.148576)         elapsed: 36.170923 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f spc.yml", "delta": "0:00:01.754817", "end": "2020-04-03 07:31:33.464330", "rc": 0, "start": "2020-04-03 07:31:31.709513", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io/cstor-rothreshold-limit-pool created\nstorageclass.storage.k8s.io/openebs-cstor-rothreshold-limit unchanged", "stdout_lines": ["storagepoolclaim.openebs.io/cstor-rothreshold-limit-pool created", "storageclass.storage.k8s.io/openebs-cstor-rothreshold-limit unchanged"]}

TASK [Verify if cStor Disk Pool are Running] ***********************************
2020-04-03T07:31:33.528625 (delta: 2.151801)         elapsed: 38.322815 ******* 
FAILED - RETRYING: Verify if cStor Disk Pool are Running (30 retries left).
FAILED - RETRYING: Verify if cStor Disk Pool are Running (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-rothreshold-limit-pool --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.120984", "end": "2020-04-03 07:31:59.450245", "rc": 0, "start": "2020-04-03 07:31:58.329261", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running", "Running", "Running"]}

TASK [Get cStor Disk Pool names to verify the container statuses] **************
2020-04-03T07:31:59.610503 (delta: 26.081796)         elapsed: 64.404693 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-rothreshold-limit-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.444545", "end": "2020-04-03 07:32:01.439755", "rc": 0, "start": "2020-04-03 07:31:59.995210", "stderr": "", "stderr_lines": [], "stdout": "cstor-rothreshold-limit-pool-g9hy-579c85d6b8-c2rrq\ncstor-rothreshold-limit-pool-k5fe-6cf6d8b6bb-5fhwf\ncstor-rothreshold-limit-pool-lsn0-5b767bccbf-mtdpc\ncstor-rothreshold-limit-pool-pz7t-6b64f765dd-7btsx\ncstor-rothreshold-limit-pool-xv3r-7f99fb6577-fcbff", "stdout_lines": ["cstor-rothreshold-limit-pool-g9hy-579c85d6b8-c2rrq", "cstor-rothreshold-limit-pool-k5fe-6cf6d8b6bb-5fhwf", "cstor-rothreshold-limit-pool-lsn0-5b767bccbf-mtdpc", "cstor-rothreshold-limit-pool-pz7t-6b64f765dd-7btsx", "cstor-rothreshold-limit-pool-xv3r-7f99fb6577-fcbff"]}

TASK [Get the runningStatus of pool pod] ***************************************
2020-04-03T07:32:01.545202 (delta: 1.934606)         elapsed: 66.339392 ******* 
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-g9hy-579c85d6b8-c2rrq) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-rothreshold-limit-pool-g9hy-579c85d6b8-c2rrq -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.319328", "end": "2020-04-03 07:32:03.251406", "item": "cstor-rothreshold-limit-pool-g9hy-579c85d6b8-c2rrq", "rc": 0, "start": "2020-04-03 07:32:01.932078", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-k5fe-6cf6d8b6bb-5fhwf) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-rothreshold-limit-pool-k5fe-6cf6d8b6bb-5fhwf -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.262946", "end": "2020-04-03 07:32:04.834307", "item": "cstor-rothreshold-limit-pool-k5fe-6cf6d8b6bb-5fhwf", "rc": 0, "start": "2020-04-03 07:32:03.571361", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-lsn0-5b767bccbf-mtdpc) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-rothreshold-limit-pool-lsn0-5b767bccbf-mtdpc -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.236833", "end": "2020-04-03 07:32:06.410193", "item": "cstor-rothreshold-limit-pool-lsn0-5b767bccbf-mtdpc", "rc": 0, "start": "2020-04-03 07:32:05.173360", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-pz7t-6b64f765dd-7btsx) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-rothreshold-limit-pool-pz7t-6b64f765dd-7btsx -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.361177", "end": "2020-04-03 07:32:08.050047", "item": "cstor-rothreshold-limit-pool-pz7t-6b64f765dd-7btsx", "rc": 0, "start": "2020-04-03 07:32:06.688870", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-xv3r-7f99fb6577-fcbff) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-rothreshold-limit-pool-xv3r-7f99fb6577-fcbff -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.379666", "end": "2020-04-03 07:32:09.775506", "item": "cstor-rothreshold-limit-pool-xv3r-7f99fb6577-fcbff", "rc": 0, "start": "2020-04-03 07:32:08.395840", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Obtain the CSP name to verify the status] ********************************
2020-04-03T07:32:09.914842 (delta: 8.369552)         elapsed: 74.709032 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get csp -l openebs.io/storage-pool-claim=cstor-rothreshold-limit-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.222437", "end": "2020-04-03 07:32:11.406344", "rc": 0, "start": "2020-04-03 07:32:10.183907", "stderr": "", "stderr_lines": [], "stdout": "cstor-rothreshold-limit-pool-g9hy\ncstor-rothreshold-limit-pool-k5fe\ncstor-rothreshold-limit-pool-lsn0\ncstor-rothreshold-limit-pool-pz7t\ncstor-rothreshold-limit-pool-xv3r", "stdout_lines": ["cstor-rothreshold-limit-pool-g9hy", "cstor-rothreshold-limit-pool-k5fe", "cstor-rothreshold-limit-pool-lsn0", "cstor-rothreshold-limit-pool-pz7t", "cstor-rothreshold-limit-pool-xv3r"]}

TASK [Verify the status of CSP] ************************************************
2020-04-03T07:32:11.548151 (delta: 1.633207)         elapsed: 76.342341 ******* 
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-g9hy) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-g9hy\")].status.phase}'", "delta": "0:00:01.447631", "end": "2020-04-03 07:32:13.344308", "item": "cstor-rothreshold-limit-pool-g9hy", "rc": 0, "start": "2020-04-03 07:32:11.896677", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-k5fe) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-k5fe\")].status.phase}'", "delta": "0:00:01.184535", "end": "2020-04-03 07:32:14.872543", "item": "cstor-rothreshold-limit-pool-k5fe", "rc": 0, "start": "2020-04-03 07:32:13.688008", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-lsn0) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-lsn0\")].status.phase}'", "delta": "0:00:01.294319", "end": "2020-04-03 07:32:16.494669", "item": "cstor-rothreshold-limit-pool-lsn0", "rc": 0, "start": "2020-04-03 07:32:15.200350", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-pz7t) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-pz7t\")].status.phase}'", "delta": "0:00:01.273767", "end": "2020-04-03 07:32:18.055311", "item": "cstor-rothreshold-limit-pool-pz7t", "rc": 0, "start": "2020-04-03 07:32:16.781544", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-xv3r) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-xv3r\")].status.phase}'", "delta": "0:00:02.363992", "end": "2020-04-03 07:32:20.748587", "item": "cstor-rothreshold-limit-pool-xv3r", "rc": 0, "start": "2020-04-03 07:32:18.384595", "stderr": "", "stderr_lines": [], "stdout": "Healthy", "stdout_lines": ["Healthy"]}

TASK [include_tasks] ***********************************************************
2020-04-03T07:32:20.907517 (delta: 9.359262)         elapsed: 85.701707 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2020-04-03T07:32:21.188438 (delta: 0.28082)         elapsed: 85.982628 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc \"openebs-cstor-rothreshold-limit\"", "delta": "0:00:01.332513", "end": "2020-04-03 07:32:22.765851", "failed_when_result": false, "rc": 0, "start": "2020-04-03 07:32:21.433338", "stderr": "", "stderr_lines": [], "stdout": "NAME                              PROVISIONER                    AGE\nopenebs-cstor-rothreshold-limit   openebs.io/provisioner-iscsi   26m", "stdout_lines": ["NAME                              PROVISIONER                    AGE", "openebs-cstor-rothreshold-limit   openebs.io/provisioner-iscsi   26m"]}

TASK [Replace the pvc placeholder with provider] *******************************
2020-04-03T07:32:22.909245 (delta: 1.720749)         elapsed: 87.703435 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2020-04-03T07:32:23.251380 (delta: 0.342028)         elapsed: 88.04557 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2020-04-03T07:32:23.641321 (delta: 0.389861)         elapsed: 88.435511 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2020-04-03T07:32:23.732926 (delta: 0.09155)         elapsed: 88.527116 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-limit"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2020-04-03T07:32:23.932453 (delta: 0.199455)         elapsed: 88.726643 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2020-04-03T07:32:24.391494 (delta: 0.458938)         elapsed: 89.185684 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-03T07:32:24.506281 (delta: 0.114722)         elapsed: 89.300471 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2020-04-03T07:32:24.691002 (delta: 0.18457)         elapsed: 89.485192 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:02.390382", "end": "2020-04-03 07:32:27.315270", "rc": 0, "start": "2020-04-03 07:32:24.924888", "stderr": "", "stderr_lines": [], "stdout": "cert-manager\ndefault\nkommander\nkube-node-lease\nkube-public\nkube-system\nkubeaddons\nlitmus\nopenebs", "stdout_lines": ["cert-manager", "default", "kommander", "kube-node-lease", "kube-public", "kube-system", "kubeaddons", "litmus", "openebs"]}

TASK [Create test specific namespace.] *****************************************
2020-04-03T07:32:27.455607 (delta: 2.764538)         elapsed: 92.249797 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns rothreshold-limit", "delta": "0:00:01.288184", "end": "2020-04-03 07:32:29.132901", "rc": 0, "start": "2020-04-03 07:32:27.844717", "stderr": "", "stderr_lines": [], "stdout": "namespace/rothreshold-limit created", "stdout_lines": ["namespace/rothreshold-limit created"]}

TASK [include_tasks] ***********************************************************
2020-04-03T07:32:29.242658 (delta: 1.786915)         elapsed: 94.036848 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2020-04-03T07:32:29.433521 (delta: 0.190751)         elapsed: 94.227711 ******* 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2020-04-03T07:32:29Z", "name": "rothreshold-limit", "resourceVersion": "363906", "selfLink": "/api/v1/namespaces/rothreshold-limit", "uid": "c52ad14b-41d9-4587-934e-09880bb3fee2"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [Replace the volume capcity placeholder with provider] ********************
2020-04-03T07:32:30.856784 (delta: 1.423199)         elapsed: 95.650974 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2020-04-03T07:32:31.264274 (delta: 0.407426)         elapsed: 96.058464 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying {{ application_name }}] ****************************************
2020-04-03T07:32:31.449290 (delta: 0.184911)         elapsed: 96.24348 ******** 
changed: [127.0.0.1] => {"changed": true, "result": {"results": [{"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "Service", "metadata": {"creationTimestamp": "2020-04-03T07:32:32Z", "labels": {"app": "busybox-limit"}, "name": "busybox-rolimit", "namespace": "rothreshold-limit", "resourceVersion": "363924", "selfLink": "/api/v1/namespaces/rothreshold-limit/services/busybox-rolimit", "uid": "bada94aa-c092-4e66-a9dd-f98a82164abd"}, "spec": {"clusterIP": "None", "selector": {"app": "busybox-limit"}, "sessionAffinity": "None", "type": "ClusterIP"}, "status": {"loadBalancer": {}}}}, {"changed": true, "method": "create", "result": {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"creationTimestamp": "2020-04-03T07:32:32Z", "generation": 1, "labels": {"app": "busybox-limit", "openebs.io/target-affinity": "lvalue"}, "name": "app-busybox", "namespace": "rothreshold-limit", "resourceVersion": "363926", "selfLink": "/apis/apps/v1/namespaces/rothreshold-limit/deployments/app-busybox", "uid": "72743840-e144-4fd1-acbc-818500384774"}, "spec": {"progressDeadlineSeconds": 600, "replicas": 1, "revisionHistoryLimit": 10, "selector": {"matchLabels": {"app": "busybox-limit", "openebs.io/target-affinity": "lvalue"}}, "strategy": {"rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"}, "type": "RollingUpdate"}, "template": {"metadata": {"creationTimestamp": null, "labels": {"app": "busybox-limit", "openebs.io/target-affinity": "lvalue"}}, "spec": {"containers": [{"args": ["-c", "while true; do sleep 10;done"], "command": ["/bin/sh"], "image": "busybox", "imagePullPolicy": "IfNotPresent", "name": "app-busybox", "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/busybox", "name": "data-vol"}]}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "terminationGracePeriodSeconds": 30, "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "openebs-busybox"}}]}}}, "status": {}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"creationTimestamp": "2020-04-03T07:32:32Z", "finalizers": ["kubernetes.io/pvc-protection"], "labels": {"openebs.io/target-affinity": "lvalue"}, "name": "openebs-busybox", "namespace": "rothreshold-limit", "resourceVersion": "363931", "selfLink": "/api/v1/namespaces/rothreshold-limit/persistentvolumeclaims/openebs-busybox", "uid": "3ccc17bd-ab24-4a6f-9029-af7e75bb220c"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "20Gi"}}, "storageClassName": "openebs-cstor-rothreshold-limit", "volumeMode": "Filesystem"}, "status": {"phase": "Pending"}}}]}}

TASK [include_tasks] ***********************************************************
2020-04-03T07:32:32.822304 (delta: 1.372952)         elapsed: 97.616494 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2020-04-03T07:32:33.085659 (delta: 0.263253)         elapsed: 97.879849 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get pod -n rothreshold-limit -l app=\"busybox-limit\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.285987", "end": "2020-04-03 07:33:03.877820", "rc": 0, "start": "2020-04-03 07:33:02.591833", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-04-03T07:33:02Z]]", "stdout_lines": ["map[running:map[startedAt:2020-04-03T07:33:02Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
2020-04-03T07:33:03.947234 (delta: 30.861477)         elapsed: 128.741424 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n rothreshold-limit -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-limit\")].status.phase}'", "delta": "0:00:01.306178", "end": "2020-04-03 07:33:05.453836", "rc": 0, "start": "2020-04-03 07:33:04.147658", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
2020-04-03T07:33:05.555892 (delta: 1.608608)         elapsed: 130.350082 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the PV name] ******************************************************
2020-04-03T07:33:05.651759 (delta: 0.095789)         elapsed: 130.445949 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n rothreshold-limit -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.420363", "end": "2020-04-03 07:33:07.333673", "rc": 0, "start": "2020-04-03 07:33:05.913310", "stderr": "", "stderr_lines": [], "stdout": "pvc-3ccc17bd-ab24-4a6f-9029-af7e75bb220c", "stdout_lines": ["pvc-3ccc17bd-ab24-4a6f-9029-af7e75bb220c"]}

TASK [Obtaining the pool deployments from cvr] *********************************
2020-04-03T07:33:07.404961 (delta: 1.753123)         elapsed: 132.199151 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-3ccc17bd-ab24-4a6f-9029-af7e75bb220c --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.365656", "end": "2020-04-03 07:33:09.027141", "rc": 0, "start": "2020-04-03 07:33:07.661485", "stderr": "", "stderr_lines": [], "stdout": "cstor-rothreshold-limit-pool-g9hy\ncstor-rothreshold-limit-pool-pz7t\ncstor-rothreshold-limit-pool-xv3r", "stdout_lines": ["cstor-rothreshold-limit-pool-g9hy", "cstor-rothreshold-limit-pool-pz7t", "cstor-rothreshold-limit-pool-xv3r"]}

TASK [Verify the readOnly status of CSP] ***************************************
2020-04-03T07:33:09.100365 (delta: 1.695336)         elapsed: 133.894555 ****** 
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-g9hy) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-g9hy\")].status.readOnly}'", "delta": "0:00:01.326246", "end": "2020-04-03 07:33:10.635222", "item": "cstor-rothreshold-limit-pool-g9hy", "rc": 0, "start": "2020-04-03 07:33:09.308976", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-pz7t) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-pz7t\")].status.readOnly}'", "delta": "0:00:01.321373", "end": "2020-04-03 07:33:12.338071", "item": "cstor-rothreshold-limit-pool-pz7t", "rc": 0, "start": "2020-04-03 07:33:11.016698", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-xv3r) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-xv3r\")].status.readOnly}'", "delta": "0:00:01.302844", "end": "2020-04-03 07:33:13.998395", "item": "cstor-rothreshold-limit-pool-xv3r", "rc": 0, "start": "2020-04-03 07:33:12.695551", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}

TASK [Getting the pod name of Application] *************************************
2020-04-03T07:33:14.072481 (delta: 4.97203)         elapsed: 138.866671 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n rothreshold-limit -l app=busybox-limit -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:02.380279", "end": "2020-04-03 07:33:16.661836", "rc": 0, "start": "2020-04-03 07:33:14.281557", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-696959c8d-tdqgn", "stdout_lines": ["app-busybox-696959c8d-tdqgn"]}

TASK [Getting the application mount point] *************************************
2020-04-03T07:33:16.748233 (delta: 2.675694)         elapsed: 141.542423 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod app-busybox-696959c8d-tdqgn -n rothreshold-limit -o jsonpath='{.spec.containers[0].volumeMounts[0].mountPath}'", "delta": "0:00:01.300006", "end": "2020-04-03 07:33:18.279560", "rc": 0, "start": "2020-04-03 07:33:16.979554", "stderr": "", "stderr_lines": [], "stdout": "/busybox", "stdout_lines": ["/busybox"]}

TASK [Create some test data to verify the data persistence] ********************
2020-04-03T07:33:18.347520 (delta: 1.599189)         elapsed: 143.14171 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
2020-04-03T07:33:18.516950 (delta: 0.169361)         elapsed: 143.31114 ******* 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/rothreshold bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-696959c8d-tdqgn -n rothreshold-limit -- sh -c \"dd if=/dev/urandom of=/busybox/rothreshold bs=4k count=1024\"", "delta": "0:00:01.669984", "end": "2020-04-03 07:33:20.428965", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/rothreshold bs=4k count=1024", "rc": 0, "start": "2020-04-03 07:33:18.758981", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.040643 seconds, 98.4MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.040643 seconds, 98.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/rothreshold > /busybox/rothreshold-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-696959c8d-tdqgn -n rothreshold-limit -- sh -c \"md5sum /busybox/rothreshold > /busybox/rothreshold-pre-chaos-md5\"", "delta": "0:00:01.855417", "end": "2020-04-03 07:33:22.474810", "failed_when_result": false, "item": "md5sum /busybox/rothreshold > /busybox/rothreshold-pre-chaos-md5", "rc": 0, "start": "2020-04-03 07:33:20.619393", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=sync;sync;sync) => {"changed": true, "cmd": "kubectl exec app-busybox-696959c8d-tdqgn -n rothreshold-limit -- sh -c \"sync;sync;sync\"", "delta": "0:00:02.178582", "end": "2020-04-03 07:33:25.005411", "failed_when_result": false, "item": "sync;sync;sync", "rc": 0, "start": "2020-04-03 07:33:22.826829", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
2020-04-03T07:33:25.077624 (delta: 6.560611)         elapsed: 149.871814 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
2020-04-03T07:33:25.140237 (delta: 0.062538)         elapsed: 149.934427 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
2020-04-03T07:33:25.201925 (delta: 0.061634)         elapsed: 149.996115 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
2020-04-03T07:33:25.262877 (delta: 0.060897)         elapsed: 150.057067 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
2020-04-03T07:33:25.328065 (delta: 0.065135)         elapsed: 150.122255 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
2020-04-03T07:33:25.388205 (delta: 0.060054)         elapsed: 150.182395 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
2020-04-03T07:33:25.449519 (delta: 0.061236)         elapsed: 150.243709 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for application] *****************************
2020-04-03T07:33:25.512869 (delta: 0.063296)         elapsed: 150.307059 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
2020-04-03T07:33:25.589435 (delta: 0.0765)         elapsed: 150.383625 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
2020-04-03T07:33:25.664985 (delta: 0.075476)         elapsed: 150.459175 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Writing data on application mount point] *********************************
2020-04-03T07:33:25.743809 (delta: 0.078755)         elapsed: 150.537999 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it app-busybox-696959c8d-tdqgn -n rothreshold-limit -- sh -c \"cd /busybox && dd if=/dev/urandom of=test.txt bs=4k count=3932160\"", "delta": "0:03:59.316935", "end": "2020-04-03 07:37:25.274526", "rc": 0, "start": "2020-04-03 07:33:25.957591", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n3932160+0 records in\n3932160+0 records out\n16106127360 bytes (15.0GB) copied, 237.508113 seconds, 64.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "3932160+0 records in", "3932160+0 records out", "16106127360 bytes (15.0GB) copied, 237.508113 seconds, 64.7MB/s"], "stdout": "", "stdout_lines": []}

TASK [Verify the readOnly status of CSP after reached the threshold limit] *****
2020-04-03T07:37:25.366252 (delta: 239.62235)         elapsed: 390.160442 ***** 
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (30 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (29 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (28 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (27 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (26 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (25 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (24 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (23 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (22 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (21 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (20 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after reached the threshold limit (19 retries left).
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-g9hy) => {"attempts": 13, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-g9hy\")].status.readOnly}'", "delta": "0:00:02.371530", "end": "2020-04-03 07:38:51.076787", "item": "cstor-rothreshold-limit-pool-g9hy", "rc": 0, "start": "2020-04-03 07:38:48.705257", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-pz7t) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-pz7t\")].status.readOnly}'", "delta": "0:00:01.369539", "end": "2020-04-03 07:38:52.817951", "item": "cstor-rothreshold-limit-pool-pz7t", "rc": 0, "start": "2020-04-03 07:38:51.448412", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-xv3r) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-xv3r\")].status.readOnly}'", "delta": "0:00:01.295492", "end": "2020-04-03 07:38:54.486740", "item": "cstor-rothreshold-limit-pool-xv3r", "rc": 0, "start": "2020-04-03 07:38:53.191248", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Patch the csp to change the threshold value] *****************************
2020-04-03T07:38:54.594041 (delta: 89.22771)         elapsed: 479.388231 ****** 
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-g9hy) => {"changed": true, "cmd": "kubectl patch csp cstor-rothreshold-limit-pool-g9hy --type='json' -p='[{\"op\":\"replace\", \"path\":\"/spec/poolSpec/roThresholdLimit\", \"value\":85}]'", "delta": "0:00:01.366149", "end": "2020-04-03 07:38:56.219563", "failed_when_result": false, "item": "cstor-rothreshold-limit-pool-g9hy", "rc": 0, "start": "2020-04-03 07:38:54.853414", "stderr": "", "stderr_lines": [], "stdout": "cstorpool.openebs.io/cstor-rothreshold-limit-pool-g9hy patched", "stdout_lines": ["cstorpool.openebs.io/cstor-rothreshold-limit-pool-g9hy patched"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-pz7t) => {"changed": true, "cmd": "kubectl patch csp cstor-rothreshold-limit-pool-pz7t --type='json' -p='[{\"op\":\"replace\", \"path\":\"/spec/poolSpec/roThresholdLimit\", \"value\":85}]'", "delta": "0:00:01.415296", "end": "2020-04-03 07:38:57.994977", "failed_when_result": false, "item": "cstor-rothreshold-limit-pool-pz7t", "rc": 0, "start": "2020-04-03 07:38:56.579681", "stderr": "", "stderr_lines": [], "stdout": "cstorpool.openebs.io/cstor-rothreshold-limit-pool-pz7t patched", "stdout_lines": ["cstorpool.openebs.io/cstor-rothreshold-limit-pool-pz7t patched"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-xv3r) => {"changed": true, "cmd": "kubectl patch csp cstor-rothreshold-limit-pool-xv3r --type='json' -p='[{\"op\":\"replace\", \"path\":\"/spec/poolSpec/roThresholdLimit\", \"value\":85}]'", "delta": "0:00:01.358291", "end": "2020-04-03 07:38:59.684663", "failed_when_result": false, "item": "cstor-rothreshold-limit-pool-xv3r", "rc": 0, "start": "2020-04-03 07:38:58.326372", "stderr": "", "stderr_lines": [], "stdout": "cstorpool.openebs.io/cstor-rothreshold-limit-pool-xv3r patched", "stdout_lines": ["cstorpool.openebs.io/cstor-rothreshold-limit-pool-xv3r patched"]}

TASK [Verify the readOnly status of CSP after changed it to default] ***********
2020-04-03T07:38:59.818234 (delta: 5.224105)         elapsed: 484.612424 ****** 
FAILED - RETRYING: Verify the readOnly status of CSP after changed it to default (30 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after changed it to default (29 retries left).
FAILED - RETRYING: Verify the readOnly status of CSP after changed it to default (28 retries left).
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-g9hy) => {"attempts": 4, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-g9hy\")].status.readOnly}'", "delta": "0:00:01.620523", "end": "2020-04-03 07:39:22.086403", "item": "cstor-rothreshold-limit-pool-g9hy", "rc": 0, "start": "2020-04-03 07:39:20.465880", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-pz7t) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-pz7t\")].status.readOnly}'", "delta": "0:00:01.542350", "end": "2020-04-03 07:39:23.940506", "item": "cstor-rothreshold-limit-pool-pz7t", "rc": 0, "start": "2020-04-03 07:39:22.398156", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}
changed: [127.0.0.1] => (item=cstor-rothreshold-limit-pool-xv3r) => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -o jsonpath='{.items[?(@.metadata.name==\"cstor-rothreshold-limit-pool-xv3r\")].status.readOnly}'", "delta": "0:00:01.523693", "end": "2020-04-03 07:39:25.827489", "item": "cstor-rothreshold-limit-pool-xv3r", "rc": 0, "start": "2020-04-03 07:39:24.303796", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}

TASK [Create some test data to verify the data persistence] ********************
2020-04-03T07:39:26.058371 (delta: 26.240043)         elapsed: 510.852561 ***** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
2020-04-03T07:39:26.407263 (delta: 0.348783)         elapsed: 511.201453 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/rothreshold bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/rothreshold bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/rothreshold > /busybox/rothreshold-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/rothreshold > /busybox/rothreshold-pre-chaos-md5", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=sync;sync;sync)  => {"changed": false, "item": "sync;sync;sync", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
2020-04-03T07:39:26.540378 (delta: 0.133031)         elapsed: 511.334568 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-696959c8d-tdqgn -n rothreshold-limit", "delta": "0:00:37.793045", "end": "2020-04-03 07:40:04.653400", "rc": 0, "start": "2020-04-03 07:39:26.860355", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-696959c8d-tdqgn\" deleted", "stdout_lines": ["pod \"app-busybox-696959c8d-tdqgn\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
2020-04-03T07:40:04.774805 (delta: 38.234348)         elapsed: 549.568995 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n rothreshold-limit", "delta": "0:00:01.527103", "end": "2020-04-03 07:40:06.598112", "rc": 0, "start": "2020-04-03 07:40:05.071009", "stderr": "", "stderr_lines": [], "stdout": "NAME                          READY   STATUS    RESTARTS   AGE\napp-busybox-696959c8d-zg76n   1/1     Running   0          38s", "stdout_lines": ["NAME                          READY   STATUS    RESTARTS   AGE", "app-busybox-696959c8d-zg76n   1/1     Running   0          38s"]}

TASK [Obtain the newly created pod name for application] ***********************
2020-04-03T07:40:06.724847 (delta: 1.949946)         elapsed: 551.519037 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n rothreshold-limit -l app=busybox-limit -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.472848", "end": "2020-04-03 07:40:08.530991", "rc": 0, "start": "2020-04-03 07:40:07.058143", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-696959c8d-zg76n", "stdout_lines": ["app-busybox-696959c8d-zg76n"]}

TASK [Checking application pod is in running state] ****************************
2020-04-03T07:40:08.635381 (delta: 1.910449)         elapsed: 553.429571 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n rothreshold-limit -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-696959c8d-zg76n\")].status.phase}'", "delta": "0:00:01.613952", "end": "2020-04-03 07:40:10.676878", "rc": 0, "start": "2020-04-03 07:40:09.062926", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
2020-04-03T07:40:10.787392 (delta: 2.15191)         elapsed: 555.581582 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n rothreshold-limit -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-696959c8d-zg76n\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.513398", "end": "2020-04-03 07:40:12.625327", "rc": 0, "start": "2020-04-03 07:40:11.111929", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-04-03T07:39:34Z]]", "stdout_lines": ["map[running:map[startedAt:2020-04-03T07:39:34Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
2020-04-03T07:40:12.725781 (delta: 1.938252)         elapsed: 557.519971 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-696959c8d-zg76n -n rothreshold-limit -- sh -c \"md5sum /busybox/rothreshold > /busybox/rothreshold-post-chaos-md5\"", "delta": "0:00:01.957884", "end": "2020-04-03 07:40:15.023741", "failed_when_result": false, "rc": 0, "start": "2020-04-03 07:40:13.065857", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
2020-04-03T07:40:15.154291 (delta: 2.428425)         elapsed: 559.948481 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-696959c8d-zg76n -n rothreshold-limit -- sh -c \"diff /busybox/rothreshold-pre-chaos-md5 /busybox/rothreshold-post-chaos-md5\"", "delta": "0:00:02.154316", "end": "2020-04-03 07:40:17.643913", "failed_when_result": false, "rc": 0, "start": "2020-04-03 07:40:15.489597", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for application] *****************************
2020-04-03T07:40:17.809537 (delta: 2.65514)         elapsed: 562.603727 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
2020-04-03T07:40:17.957197 (delta: 0.147519)         elapsed: 562.751387 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
2020-04-03T07:40:18.105172 (delta: 0.147866)         elapsed: 562.899362 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-04-03T07:40:18.237602 (delta: 0.132318)         elapsed: 563.031792 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning the Application] ******************************************
2020-04-03T07:40:18.361956 (delta: 0.124218)         elapsed: 563.156146 ****** 
included: /utils/k8s/deprovision_deployment.yml for 127.0.0.1

TASK [Check if the application to be deleted is available.] ********************
2020-04-03T07:40:18.596526 (delta: 0.23442)         elapsed: 563.390716 ******* 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Pod", "metadata": {"annotations": {"cni.projectcalico.org/podIP": "172.168.26.92/32"}, "creationTimestamp": "2020-04-03T07:39:28Z", "generateName": "app-busybox-696959c8d-", "labels": {"app": "busybox-limit", "openebs.io/target-affinity": "lvalue", "pod-template-hash": "696959c8d"}, "name": "app-busybox-696959c8d-zg76n", "namespace": "rothreshold-limit", "ownerReferences": [{"apiVersion": "apps/v1", "blockOwnerDeletion": true, "controller": true, "kind": "ReplicaSet", "name": "app-busybox-696959c8d", "uid": "0fde04f6-0ee8-45b3-8886-259c5d80170d"}], "resourceVersion": "366292", "selfLink": "/api/v1/namespaces/rothreshold-limit/pods/app-busybox-696959c8d-zg76n", "uid": "494128f4-7102-43f8-9e63-0261ce6d1195"}, "spec": {"containers": [{"args": ["-c", "while true; do sleep 10;done"], "command": ["/bin/sh"], "image": "busybox", "imagePullPolicy": "Always", "name": "app-busybox", "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/busybox", "name": "data-vol"}, {"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount", "name": "default-token-c4dsl", "readOnly": true}]}], "dnsPolicy": "ClusterFirst", "enableServiceLinks": true, "nodeName": "d2iq-node2.mayalabs.io", "priority": 0, "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "serviceAccount": "default", "serviceAccountName": "default", "terminationGracePeriodSeconds": 30, "tolerations": [{"effect": "NoExecute", "key": "node.kubernetes.io/not-ready", "operator": "Exists", "tolerationSeconds": 300}, {"effect": "NoExecute", "key": "node.kubernetes.io/unreachable", "operator": "Exists", "tolerationSeconds": 300}], "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "openebs-busybox"}}, {"name": "default-token-c4dsl", "secret": {"defaultMode": 420, "secretName": "default-token-c4dsl"}}]}, "status": {"conditions": [{"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:39:28Z", "status": "True", "type": "Initialized"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:39:34Z", "status": "True", "type": "Ready"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:39:34Z", "status": "True", "type": "ContainersReady"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:39:28Z", "status": "True", "type": "PodScheduled"}], "containerStatuses": [{"containerID": "containerd://7013531761cecfaa1491dc2aa4aed597acad7ea7aaf652f740e1a932c1f24794", "image": "docker.io/library/busybox:latest", "imageID": "docker.io/library/busybox@sha256:b26cd013274a657b86e706210ddd5cc1f82f50155791199d29b9e86e935ce135", "lastState": {}, "name": "app-busybox", "ready": true, "restartCount": 0, "state": {"running": {"startedAt": "2020-04-03T07:39:34Z"}}}], "hostIP": "10.34.1.164", "phase": "Running", "podIP": "172.168.26.92", "qosClass": "BestEffort", "startTime": "2020-04-03T07:39:28Z"}}]}

TASK [Obtaining the PVC name using application label.] *************************
2020-04-03T07:40:19.991419 (delta: 1.394815)         elapsed: 564.785609 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "app-busybox-696959c8d-zg76n", "pvc_name": "openebs-busybox"}, "changed": false}

TASK [Obtaining the PV name from PVC name.] ************************************
2020-04-03T07:40:20.126698 (delta: 0.135188)         elapsed: 564.920888 ****** 
ok: [127.0.0.1] => {"changed": false, "resources": [{"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"annotations": {"pv.kubernetes.io/bind-completed": "yes", "pv.kubernetes.io/bound-by-controller": "yes", "volume.beta.kubernetes.io/storage-provisioner": "openebs.io/provisioner-iscsi"}, "creationTimestamp": "2020-04-03T07:32:32Z", "finalizers": ["kubernetes.io/pvc-protection"], "labels": {"openebs.io/target-affinity": "lvalue"}, "name": "openebs-busybox", "namespace": "rothreshold-limit", "resourceVersion": "363988", "selfLink": "/api/v1/namespaces/rothreshold-limit/persistentvolumeclaims/openebs-busybox", "uid": "3ccc17bd-ab24-4a6f-9029-af7e75bb220c"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "20Gi"}}, "storageClassName": "openebs-cstor-rothreshold-limit", "volumeMode": "Filesystem", "volumeName": "pvc-3ccc17bd-ab24-4a6f-9029-af7e75bb220c"}, "status": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "20Gi"}, "phase": "Bound"}}]}

TASK [set_fact] ****************************************************************
2020-04-03T07:40:21.319743 (delta: 1.192962)         elapsed: 566.113933 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"pvname": "pvc-3ccc17bd-ab24-4a6f-9029-af7e75bb220c"}, "changed": false}

TASK [Check for presence & value of cas type annotation] ***********************
2020-04-03T07:40:21.492598 (delta: 0.172737)         elapsed: 566.286788 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-3ccc17bd-ab24-4a6f-9029-af7e75bb220c --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.501433", "end": "2020-04-03 07:40:23.251849", "rc": 0, "start": "2020-04-03 07:40:21.750416", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
2020-04-03T07:40:23.343493 (delta: 1.850744)         elapsed: 568.137683 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Replace the PVC name in application deployer spec.] **********************
2020-04-03T07:40:23.515383 (delta: 0.17181)         elapsed: 568.309573 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Replace the storageclass placeholder with provider] **********************
2020-04-03T07:40:23.956363 (delta: 0.440881)         elapsed: 568.750553 ****** 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Get the application label values from env] *******************************
2020-04-03T07:40:24.312472 (delta: 0.35603)         elapsed: 569.106662 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-limit"}, "changed": false}

TASK [Replace the application label placeholder] *******************************
2020-04-03T07:40:24.448437 (delta: 0.13589)         elapsed: 569.242627 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Delete the application deployment.] **************************************
2020-04-03T07:40:24.799736 (delta: 0.351219)         elapsed: 569.593926 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f busybox_deployment.yml -n rothreshold-limit", "delta": "0:00:39.527871", "end": "2020-04-03 07:41:04.675699", "rc": 0, "start": "2020-04-03 07:40:25.147828", "stderr": "", "stderr_lines": [], "stdout": "service \"busybox-rolimit\" deleted\ndeployment.apps \"app-busybox\" deleted\npersistentvolumeclaim \"openebs-busybox\" deleted", "stdout_lines": ["service \"busybox-rolimit\" deleted", "deployment.apps \"app-busybox\" deleted", "persistentvolumeclaim \"openebs-busybox\" deleted"]}

TASK [Check if the PVC is deleted.] ********************************************
2020-04-03T07:41:04.759819 (delta: 39.960012)         elapsed: 609.554009 ***** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": []}

TASK [Check if the ctrl-pod is deleted.] ***************************************
2020-04-03T07:41:06.157462 (delta: 1.397564)         elapsed: 610.951652 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the  replica-pod is deleted.] ***********************************
2020-04-03T07:41:06.273809 (delta: 0.116277)         elapsed: 611.067999 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the target pod is deleted.] *************************************
2020-04-03T07:41:06.376228 (delta: 0.102336)         elapsed: 611.170418 ****** 
FAILED - RETRYING: Check if the target pod is deleted. (20 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (19 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (18 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (17 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (16 retries left).
FAILED - RETRYING: Check if the target pod is deleted. (15 retries left).
ok: [127.0.0.1] => {"attempts": 7, "changed": false, "resources": []}

TASK [Check status of the pool deployments from cvr] ***************************
2020-04-03T07:41:44.278478 (delta: 37.902167)         elapsed: 649.072668 ***** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": []}

TASK [Check if the pods are deleted in the namespaces] *************************
2020-04-03T07:41:46.114197 (delta: 1.835635)         elapsed: 650.908387 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n rothreshold-limit", "delta": "0:00:01.359695", "end": "2020-04-03 07:41:47.922619", "rc": 0, "start": "2020-04-03 07:41:46.562924", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete the namespace.] ***************************************************
2020-04-03T07:41:47.996680 (delta: 1.882373)         elapsed: 652.79087 ******* 
changed: [127.0.0.1] => {"changed": true, "method": "delete", "result": {"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2020-04-03T07:32:29Z", "deletionTimestamp": "2020-04-03T07:41:48Z", "name": "rothreshold-limit", "resourceVersion": "367131", "selfLink": "/api/v1/namespaces/rothreshold-limit", "uid": "c52ad14b-41d9-4587-934e-09880bb3fee2"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Terminating"}}}

TASK [Check if the PV is deleted.] *********************************************
2020-04-03T07:41:48.998828 (delta: 1.002087)         elapsed: 653.793018 ****** 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "resources": []}

TASK [Obtain the claimed blockDevice list from bdc] ****************************
2020-04-03T07:41:49.986194 (delta: 0.987287)         elapsed: 654.780384 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get bdc -n openebs -l openebs.io/storage-pool-claim=cstor-rothreshold-limit-pool -o custom-columns=:.spec.blockDeviceName --no-headers", "delta": "0:00:01.209488", "end": "2020-04-03 07:41:51.404513", "rc": 0, "start": "2020-04-03 07:41:50.195025", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-07d7245a501cf554818a4c75cbe985aa\nblockdevice-0deb852da7a97b23017975b37d133cc7\nblockdevice-0980f7d094a8b4feb069c7745b9b891f\nblockdevice-0d523d92406ce19801b840738bf83497\nblockdevice-06e7e15fd8721f276f87859b3d64e889", "stdout_lines": ["blockdevice-07d7245a501cf554818a4c75cbe985aa", "blockdevice-0deb852da7a97b23017975b37d133cc7", "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "blockdevice-0d523d92406ce19801b840738bf83497", "blockdevice-06e7e15fd8721f276f87859b3d64e889"]}

TASK [Remove the SPC] **********************************************************
2020-04-03T07:41:51.478384 (delta: 1.492126)         elapsed: 656.272574 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete spc cstor-rothreshold-limit-pool", "delta": "0:05:04.618712", "end": "2020-04-03 07:46:56.312153", "rc": 0, "start": "2020-04-03 07:41:51.693441", "stderr": "", "stderr_lines": [], "stdout": "storagepoolclaim.openebs.io \"cstor-rothreshold-limit-pool\" deleted", "stdout_lines": ["storagepoolclaim.openebs.io \"cstor-rothreshold-limit-pool\" deleted"]}

TASK [Verify if the SPC is deleted] ********************************************
2020-04-03T07:46:56.463003 (delta: 304.984559)         elapsed: 961.257193 **** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pool_name }}" not in spc_status.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get spc", "delta": "0:00:01.414498", "end": "2020-04-03 07:46:58.301721", "rc": 0, "start": "2020-04-03 07:46:56.887223", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the CSP is getting removed] ************************************
2020-04-03T07:46:58.440797 (delta: 1.977585)         elapsed: 963.234987 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get csp -n openebs -l openebs.io/cstor-pool-cluster=cstor-rothreshold-limit-pool", "delta": "0:00:01.361420", "end": "2020-04-03 07:47:00.203237", "rc": 0, "start": "2020-04-03 07:46:58.841817", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the cStor pool pods are deleted] *******************************
2020-04-03T07:47:00.322053 (delta: 1.881097)         elapsed: 965.116243 ****** 
FAILED - RETRYING: Verify if the cStor pool pods are deleted (30 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (29 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (28 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/storage-pool-claim=cstor-rothreshold-limit-pool", "delta": "0:00:01.353174", "end": "2020-04-03 07:47:49.051328", "rc": 0, "start": "2020-04-03 07:47:47.698154", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the BDC are deleted] *******************************************
2020-04-03T07:47:49.133552 (delta: 48.811396)         elapsed: 1013.927742 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get bdc -n openebs -l openebs.io/storage-pool-claim=cstor-rothreshold-limit-pool", "delta": "0:00:01.376360", "end": "2020-04-03 07:47:50.916076", "rc": 0, "start": "2020-04-03 07:47:49.539716", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the blockDevices are unclaimed] ********************************
2020-04-03T07:47:51.075491 (delta: 1.941876)         elapsed: 1015.869681 ***** 
changed: [127.0.0.1] => (item=blockdevice-07d7245a501cf554818a4c75cbe985aa) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevices -n openebs -o jsonpath='{.items[?(@.metadata.name==\"blockdevice-07d7245a501cf554818a4c75cbe985aa\")].status.claimState}'", "delta": "0:00:01.527543", "end": "2020-04-03 07:47:52.994273", "item": "blockdevice-07d7245a501cf554818a4c75cbe985aa", "rc": 0, "start": "2020-04-03 07:47:51.466730", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}
changed: [127.0.0.1] => (item=blockdevice-0deb852da7a97b23017975b37d133cc7) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevices -n openebs -o jsonpath='{.items[?(@.metadata.name==\"blockdevice-0deb852da7a97b23017975b37d133cc7\")].status.claimState}'", "delta": "0:00:02.484769", "end": "2020-04-03 07:47:55.816212", "item": "blockdevice-0deb852da7a97b23017975b37d133cc7", "rc": 0, "start": "2020-04-03 07:47:53.331443", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}
changed: [127.0.0.1] => (item=blockdevice-0980f7d094a8b4feb069c7745b9b891f) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevices -n openebs -o jsonpath='{.items[?(@.metadata.name==\"blockdevice-0980f7d094a8b4feb069c7745b9b891f\")].status.claimState}'", "delta": "0:00:01.468328", "end": "2020-04-03 07:47:57.650842", "item": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "rc": 0, "start": "2020-04-03 07:47:56.182514", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}
changed: [127.0.0.1] => (item=blockdevice-0d523d92406ce19801b840738bf83497) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevices -n openebs -o jsonpath='{.items[?(@.metadata.name==\"blockdevice-0d523d92406ce19801b840738bf83497\")].status.claimState}'", "delta": "0:00:01.549635", "end": "2020-04-03 07:47:59.591782", "item": "blockdevice-0d523d92406ce19801b840738bf83497", "rc": 0, "start": "2020-04-03 07:47:58.042147", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}
changed: [127.0.0.1] => (item=blockdevice-06e7e15fd8721f276f87859b3d64e889) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevices -n openebs -o jsonpath='{.items[?(@.metadata.name==\"blockdevice-06e7e15fd8721f276f87859b3d64e889\")].status.claimState}'", "delta": "0:00:01.536351", "end": "2020-04-03 07:48:01.381425", "item": "blockdevice-06e7e15fd8721f276f87859b3d64e889", "rc": 0, "start": "2020-04-03 07:47:59.845074", "stderr": "", "stderr_lines": [], "stdout": "Unclaimed", "stdout_lines": ["Unclaimed"]}

TASK [include_tasks] ***********************************************************
2020-04-03T07:48:01.541279 (delta: 10.465678)         elapsed: 1026.335469 **** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-03T07:48:01.924235 (delta: 0.382847)         elapsed: 1026.718425 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T07:48:01.994618 (delta: 0.070308)         elapsed: 1026.788808 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T07:48:02.064185 (delta: 0.069488)         elapsed: 1026.858375 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-03T07:48:02.157034 (delta: 0.092773)         elapsed: 1026.951224 ***** 
changed: [127.0.0.1] => {"changed": true, "checksum": "0b007462871317202bce59e66ddde5a895cd59c1", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5a7ba5ccbeddc76188e47ea43058c3c6", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1585900082.26-255417270276014/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T07:48:05.039685 (delta: 2.882575)         elapsed: 1029.833875 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.304342", "end": "2020-04-03 07:48:06.617587", "rc": 0, "start": "2020-04-03 07:48:05.313245", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-rothreshold-limit \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-rothreshold-limit ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T07:48:06.685541 (delta: 1.645787)         elapsed: 1031.479731 ***** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T04:26:00Z", "generation": 11, "name": "cstor-rothreshold-limit", "resourceVersion": "369293", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-rothreshold-limit", "uid": "69bbb0ba-1243-486e-bb14-f8e4765c508e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=89   changed=57   unreachable=0    failed=0   

2020-04-03T07:48:07.755938 (delta: 1.070333)         elapsed: 1032.550128 ***** 
=============================================================================== 
```
