### PR TITLE
refactor[yaml]: Modified functional test cases for jiva

### DIFF
--- a/experiments/functional/custom/tests/memcheck/test-mem.py
+++ b/experiments/functional/custom/tests/memcheck/test-mem.py
@@ -9,7 +9,8 @@ import time, os, sys
 list = []
 namespace = sys.argv[1]
 benchmark = sys.argv[2]
-cmd_cntrl_name = "kubectl get pod -n %s -l openebs.io/controller=jiva-controller --no-headers | awk '{print $1}'" %(namespace)
+pvname = sys.argv[3]
+cmd_cntrl_name = "kubectl get pod -n %s -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=%s --no-headers | awk '{print $1}'" %(namespace,pvname)
 print cmd_cntrl_name
 out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE,shell=True)
 cntrl_name = out.communicate()

--- a/experiments/functional/custom/tests/memcheck/test.yml
+++ b/experiments/functional/custom/tests/memcheck/test.yml
@@ -60,8 +60,15 @@
          delay: 30
          retries: 10
 
+       - name: Obtain the volume name
+         shell: >
+           kubectl get pvc -n {{ app_ns }} --no-headers -o custom-columns=:.spec.volumeName
+         args:
+           executable: /bin/bash
+         register: pv_name
+
        - name: Run python script for memory usage validation it takes couple of minutes
-         shell: python test-mem.py {{ app_ns }} {{ memory_bm }}
+         shell: python test-mem.py {{ operator_ns }} {{ memory_bm }} {{ pv_name.stdout }}
          args:
            executable: /bin/bash
          register: result

--- a/experiments/functional/custom/tests/memcheck/test_vars.yml
+++ b/experiments/functional/custom/tests/memcheck/test_vars.yml
@@ -5,3 +5,4 @@ test_name: memleak-test
 memleak_yml: memleak.yml
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 memory_bm: "{{ lookup('env','MEMORY_BM') }}"
+operator_ns: 'openebs'

--- a/experiments/functional/scale_jiva_replica/test.yml
+++ b/experiments/functional/scale_jiva_replica/test.yml
@@ -48,20 +48,29 @@
          set_fact:
             node_count: "{{node_out.stdout}}"
         
+       - name: Get the volume name
+         shell: >
+           kubectl get pvc -n {{ namespace }} --no-headers -o custom-columns=:.spec.volumeName
+         args:
+           executable: /bin/bash
+         register: pv_name
+
        - name: Get the replica deployment name
-         shell: kubectl get deployments -n {{ namespace }} -l openebs.io/replica=jiva-replica -o jsonpath='{.items[0].metadata.name}'
+         shell: >
+           kubectl get deployments -n {{ operator_namespace }} -l openebs.io/persistent-volume="{{ pv_name.stdout }}",openebs.io/replica=jiva-replica 
+           --no-headers -o jsonpath='{.items[0].metadata.name}'
          args:
            executable: /bin/bash
          register: rep_deployment_name
         
        - name: Get the controller deployment name 
-         shell: kubectl get deployment -n {{ namespace }} -l openebs.io/controller=jiva-controller -o jsonpath='{.items[0].metadata.name}'
+         shell: kubectl get deployment -n {{ operator_namespace }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
          args:
            executable: /bin/bash
          register: ctrl_deploy
 
        - name: Getting the node name on which replica is scheduled
-         shell: kubectl get deploy {{ rep_deployment_name.stdout }} -n {{ namespace }} -o jsonpath='{.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]}' 
+         shell: kubectl get deploy {{ rep_deployment_name.stdout }} -n {{ operator_namespace }} -o jsonpath='{.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]}' 
          register: replica_node_name
 
        - name: Getting the node name where replica is not scheduled
@@ -82,16 +91,16 @@
          with_items: "{{ node_name.stdout_lines }}"
 
        - name: Patching replica deployment
-         shell: kubectl patch deployment {{ rep_deployment_name.stdout }} -n {{ namespace }} --patch "$(cat rep_patch.yml)"
+         shell: kubectl patch deployment {{ rep_deployment_name.stdout }} -n {{ operator_namespace }} --patch "$(cat rep_patch.yml)"
          register: status
          failed_when: "'patched' not in status.stdout"
 
        - name: Obtaining the current replication factor
-         shell: kubectl get deployments {{ ctrl_deploy.stdout }} -n {{ namespace }} -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'    
+         shell: kubectl get deployments {{ ctrl_deploy.stdout }} -n {{ operator_namespace }} -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'    
          register: replication_factor
 
        - name: Update Controller deployment
-         shell: kubectl set env deployment/{{ ctrl_deploy.stdout }} -n {{ namespace }}  REPLICATION_FACTOR="{{ node_count }}" 
+         shell: kubectl set env deployment/{{ ctrl_deploy.stdout }} -n {{ operator_namespace }}  REPLICATION_FACTOR="{{ node_count }}" 
          register: update_ctrl 
          until: "'env updated' in update_ctrl.stdout"
          retries: 5
@@ -106,7 +115,7 @@
              app_ns: "{{ namespace }}"
              deploy_type: "deployment"
              app_name: "{{ rep_deployment_name.stdout }}"   
-             app_label: "openebs.io/replica=jiva-replica"  
+             app_label: "openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name.stdout }}" 
              app_replica_count: "{{ node_count }}"
 
 
@@ -132,23 +141,23 @@
        - block:
            
            - name: Getting the Controller pod name
-             shell: kubectl get pod -n {{ namespace }} -l openebs.io/controller=jiva-controller -o jsonpath='{.items[0].metadata.name}'
+             shell: kubectl get pod -n {{ operator_namespace }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
              register: ctrl_pod_name
              
            - name: Restarting controller
-             shell: kubectl delete pod {{ ctrl_pod_name.stdout }} -n {{ namespace }}
+             shell: kubectl delete pod {{ ctrl_pod_name.stdout }} -n {{ operator_namespace }}
              register: ctrl_delete
              failed_when: "'deleted' not in ctrl_delete.stdout"
 
            - name: Verifying successful deletion of controller
-             shell: kubectl get pod -n {{ namespace }} -l openebs.io/controller=jiva-controller -o jsonpath='{.items[0].metadata.name}'
+             shell: kubectl get pod -n {{ operator_namespace }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
              register: ctrl_del_status
              until: "'{{ ctrl_pod_name.stdout }}' not in ctrl_del_status.stdout"
              delay: 10
              retries: 100
 
            - name: Waiting for new controller to be in running state
-             shell: kubectl get pod -n {{ namespace }} -l openebs.io/controller=jiva-controller -o jsonpath='{.items[0].status.phase}'
+             shell: kubectl get pod -n {{ operator_namespace }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].status.phase}'
              register: new_ctrl_state
              until: "'Running' in new_ctrl_state.stdout"
              delay: 10
@@ -159,23 +168,23 @@
        - block:
           
            - name: Getting the replica pod name
-             shell: kubectl get pod -n {{ namespace }} -l openebs.io/replica=jiva-replica -o jsonpath='{.items[0].metadata.name}'
+             shell: kubectl get pod -n {{ operator_namespace }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
              register: rep_pod_name
 
            - name: Restarting replica
-             shell: kubectl delete pod {{ rep_pod_name.stdout }} -n {{ namespace }}
+             shell: kubectl delete pod {{ rep_pod_name.stdout }} -n {{ operator_namespace }}
              register: replica_delete
              failed_when: "'deleted' not in replica_delete.stdout"
 
            - name: Verifying successful deletion of replica
-             shell: kubectl get pod -n {{ namespace }} -l openebs.io/replica=jiva-replica -o jsonpath='{.items[0].metadata.name}'
+             shell: kubectl get pod -n {{ operator_namespace }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
              register: replica_del_status
              until: "'{{ rep_pod_name.stdout }}' not in replica_del_status.stdout"
              delay: 10
              retries: 100
 
            - name: Checking for all replicas to be in Running state
-             shell: kubectl get pod -n {{ namespace }} -l openebs.io/replica=jiva-replica --no-headers -o custom-columns=:status.phase
+             shell: kubectl get pod -n {{ operator_namespace }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv_name.stdout }}" --no-headers -o custom-columns=:status.phase
              register: running_rep_status
              until: "((running_rep_status|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
              delay: 10

--- a/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
+++ b/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
@@ -1,7 +1,7 @@
 - name: Get controller svc
   shell: >
-    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
-    -n {{ app_ns }} --no-headers -o custom-columns=:spec.clusterIP
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume={{ pv_name }} 
+    -n {{ operator_ns }} --no-headers -o custom-columns=:spec.clusterIP
   args:
     executable: /bin/bash
   register: controller_svc

--- a/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
@@ -1,13 +1,13 @@
 - name: Get the name of controller pod
   shell: >
-    kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pv_name }} -n {{ app_ns }} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+    kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
   args:
     executable: /bin/bash
   register: controller_pod
 
 - name: Getting number of snapshots
   shell: >
-    kubectl exec -it {{ controller_pod.stdout }} -n {{ app_ns }} -- jivactl snapshot ls | grep -v ID | wc -l
+    kubectl exec -it {{ controller_pod.stdout }} -n {{ operator_ns }} -- jivactl snapshot ls | grep -v ID | wc -l
   args:
     executable: /bin/bash
   register: snapshot_number

--- a/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
@@ -1,6 +1,6 @@
 - name: Get the name of replica pods
   shell: >
-    kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ app_ns }} --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}'
+    kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}'
   args:
     executable: /bin/bash
   register: replica_pod
@@ -11,7 +11,7 @@
 
 - name: Delete replica with latest creation timestamp
   shell: >
-    kubectl delete pod {{ replica_name }} -n {{ app_ns }}
+    kubectl delete pod {{ replica_name }} -n {{ operator_ns }}
   args:
     executable: /bin/bash
 

--- a/experiments/functional/snapshot_deletion/jiva/test_vars.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_vars.yml
@@ -10,3 +10,4 @@ app_ns: "{{ lookup('env','FIO_NAMESPACE') }}"
 data_check: "{{ lookup('env','DATA_CHECK') }}"
 pvc_yml: pvc.yml
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+operator_ns: 'openebs'

--- a/funclib/kubectl/scale_replicas.yml
+++ b/funclib/kubectl/scale_replicas.yml
@@ -8,7 +8,7 @@
 # The above parameters should be obtained as environmental variables from the litmus-book.
 
 - name: Obtaining the application pod name.
-  shell: kubectl get {{ deploy_type }} -n {{ app_ns }} --no-headers -l {{ app_label }} -o custom-columns=:metadata.name
+  shell: kubectl get {{ deploy_type }} -n {{ operator_namespace }} --no-headers -l {{ app_label }} -o custom-columns=:metadata.name
   args:
     executable: /bin/bash
   register: result
@@ -18,14 +18,14 @@
     app_name: "{{ result.stdout }}"
 
 - name: scaling up the replicas.
-  shell: kubectl scale {{ deploy_type}} {{ app_name }} --replicas={{ app_replica_count }} -n {{ app_ns }}
+  shell: kubectl scale {{ deploy_type}} {{ app_name }} --replicas={{ app_replica_count }} -n {{ operator_namespace }}
   args:
     executable: /bin/bash
   register: result
   failed_when: "'scaled' not in result.stdout"
 
 - name: Check if all the application replicas are running.
-  shell: kubectl get {{ deploy_type }} -n {{ app_ns }} --no-headers -l {{ app_label }} -o custom-columns=:..readyReplicas
+  shell: kubectl get {{ deploy_type }} -n {{ operator_namespace }} --no-headers -l {{ app_label }} -o custom-columns=:..readyReplicas
   args:
     executable: /bin/bash
   register: running_replicas

--- a/utils/scm/openebs/target_affinity_check.yml
+++ b/utils/scm/openebs/target_affinity_check.yml
@@ -33,7 +33,7 @@
   with_items: "{{ stg_engine.resources }}"
   
 - set_fact: 
-    target_ns: "{{ app_ns }}"
+    target_ns: "{{ operator_ns }}"
     target_label: "openebs.io/controller=jiva-controller"
   when: stg_engine.resources.0.metadata.annotations['openebs.io/cas-type'] == 'jiva'
 


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified functional test cases for jiva to incorporate the following change.
1.  All the jiva replica pod and controller pod will be in openebs namespace.
2.  Earlier jiva replica pods were controlled by single deployment now each jiva replica pod is controlled by separate deployment.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #237 
**Special notes for reviewer**
-Logs for app target affinity
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/app-target-affinity/test.yml

PLAY [localhost] ***************************************************************
2020-04-03T09:05:53.216128 (delta: 0.077179)         elapsed: 0.077179 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:11
2020-04-03T09:05:53.231650 (delta: 0.015472)         elapsed: 0.092701 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:21
2020-04-03T09:06:01.573392 (delta: 8.341707)         elapsed: 8.434443 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-04-03T09:06:01.854101 (delta: 0.280646)         elapsed: 8.715152 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-04-03T09:06:01.959870 (delta: 0.105689)         elapsed: 8.820921 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:24
2020-04-03T09:06:02.051078 (delta: 0.091141)         elapsed: 8.912129 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-03T09:06:02.174255 (delta: 0.123018)         elapsed: 9.035306 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "70ecada792ff7601e79af6b588f7ab2a08600218", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "14bf30aa512da3c90c5db005b94cded3", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1585904762.25-2396916709020/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-03T09:06:03.219641 (delta: 1.0453)         elapsed: 10.080692 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.790978", "end": "2020-04-03 09:06:04.498314", "rc": 0, "start": "2020-04-03 09:06:03.707336", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: app-target-affinity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: app-target-affinity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-03T09:06:04.562458 (delta: 1.342744)         elapsed: 11.423509 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T09:06:05Z", "generation": 1, "name": "app-target-affinity", "resourceVersion": "56686", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/app-target-affinity", "uid": "a5b9fadb-afda-4da7-89fe-56bb1593e9bf"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-03T09:06:05.886504 (delta: 1.323981)         elapsed: 12.747555 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-03T09:06:05.966412 (delta: 0.079845)         elapsed: 12.827463 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-03T09:06:06.041804 (delta: 0.075333)         elapsed: 12.902855 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the functional util to be invoked] ******************************
task path: /experiments/functional/app-target-affinity/test.yml:28
2020-04-03T09:06:06.109462 (delta: 0.0676)         elapsed: 12.970513 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7d4d3d0cc777a7ac0509fcef7d7324fe78ebed75", "dest": "./functional_util.yml", "gid": 0, "group": "root", "md5sum": "ae43a116e1bd64faac3f8c479386556f", "mode": "0644", "owner": "root", "size": 57, "src": "/root/.ansible/tmp/ansible-tmp-1585904766.16-147355537105433/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/functional/app-target-affinity/test.yml:33
2020-04-03T09:06:06.637693 (delta: 0.528166)         elapsed: 13.498744 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"functional_util": "scm/openebs/target_affinity_check.yml"}, "ansible_included_var_files": ["/experiments/functional/app-target-affinity/functional_util.yml"], "changed": false}

TASK [Record the functional util path] *****************************************
task path: /experiments/functional/app-target-affinity/test.yml:36
2020-04-03T09:06:06.761750 (delta: 0.123982)         elapsed: 13.622801 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"functional_util_path": "/utils/scm/openebs/target_affinity_check.yml"}, "changed": false}

TASK [Obtain the pvc name of the application.] *********************************
task path: /experiments/functional/app-target-affinity/test.yml:40
2020-04-03T09:06:06.891207 (delta: 0.129366)         elapsed: 13.752258 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n sam -l app=busybox-sts -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.026807", "end": "2020-04-03 09:06:08.136982", "rc": 0, "start": "2020-04-03 09:06:07.110175", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [include] *****************************************************************
task path: /experiments/functional/app-target-affinity/test.yml:49
2020-04-03T09:06:08.218202 (delta: 1.326923)         elapsed: 15.079253 ******* 
included: /utils/scm/openebs/target_affinity_check.yml for 127.0.0.1

TASK [Obtain node where app pod resides] ***************************************
task path: /utils/scm/openebs/target_affinity_check.yml:1
2020-04-03T09:06:08.393465 (delta: 0.175172)         elapsed: 15.254516 ******* 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "resources": [{"apiVersion": "v1", "kind": "Pod", "metadata": {"annotations": {"cni.projectcalico.org/podIP": "192.168.173.78/32"}, "creationTimestamp": "2020-04-03T07:15:38Z", "generateName": "app-busybox-85d45b855f-", "labels": {"app": "busybox-sts", "openebs.io/target-affinity": "lvalue", "pod-template-hash": "85d45b855f"}, "name": "app-busybox-85d45b855f-rxw6h", "namespace": "sam", "ownerReferences": [{"apiVersion": "apps/v1", "blockOwnerDeletion": true, "controller": true, "kind": "ReplicaSet", "name": "app-busybox-85d45b855f", "uid": "d64650e0-3773-48bd-b310-0a6a09d924ba"}], "resourceVersion": "28359", "selfLink": "/api/v1/namespaces/sam/pods/app-busybox-85d45b855f-rxw6h", "uid": "a29661fd-d302-4ed2-8158-3321999b11d7"}, "spec": {"containers": [{"args": ["-c", "while true; do sleep 10;done"], "command": ["/bin/sh"], "image": "busybox", "imagePullPolicy": "IfNotPresent", "name": "app-busybox", "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/busybox", "name": "data-vol"}, {"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount", "name": "default-token-tjqfq", "readOnly": true}]}], "dnsPolicy": "ClusterFirst", "enableServiceLinks": true, "nodeName": "e2e1-node3", "priority": 0, "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "serviceAccount": "default", "serviceAccountName": "default", "terminationGracePeriodSeconds": 30, "tolerations": [{"effect": "NoExecute", "key": "node.kubernetes.io/not-ready", "operator": "Exists", "tolerationSeconds": 300}, {"effect": "NoExecute", "key": "node.kubernetes.io/unreachable", "operator": "Exists", "tolerationSeconds": 300}], "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "openebs-busybox"}}, {"name": "default-token-tjqfq", "secret": {"defaultMode": 420, "secretName": "default-token-tjqfq"}}]}, "status": {"conditions": [{"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:15:43Z", "status": "True", "type": "Initialized"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:16:13Z", "status": "True", "type": "Ready"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:16:13Z", "status": "True", "type": "ContainersReady"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:15:43Z", "status": "True", "type": "PodScheduled"}], "containerStatuses": [{"containerID": "docker://fef7d44ef8bc719766a884667fd295b380d4dbeaa9531a4ac3a7091105ddff8e", "image": "busybox:latest", "imageID": "docker-pullable://busybox@sha256:b26cd013274a657b86e706210ddd5cc1f82f50155791199d29b9e86e935ce135", "lastState": {}, "name": "app-busybox", "ready": true, "restartCount": 0, "started": true, "state": {"running": {"startedAt": "2020-04-03T07:16:11Z"}}}], "hostIP": "10.34.1.233", "phase": "Running", "podIP": "192.168.173.78", "podIPs": [{"ip": "192.168.173.78"}], "qosClass": "BestEffort", "startTime": "2020-04-03T07:15:43Z"}}]}

TASK [debug] *******************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:10
2020-04-03T09:06:09.881551 (delta: 1.487983)         elapsed: 16.742602 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "e2e1-node3"
    ]
}

TASK [Derive PV from application PVC] ******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:14
2020-04-03T09:06:10.002627 (delta: 0.120977)         elapsed: 16.863678 ******* 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "resources": [{"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"annotations": {"pv.kubernetes.io/bind-completed": "yes", "pv.kubernetes.io/bound-by-controller": "yes", "volume.beta.kubernetes.io/storage-provisioner": "openebs.io/provisioner-iscsi"}, "creationTimestamp": "2020-04-03T07:15:38Z", "finalizers": ["kubernetes.io/pvc-protection"], "labels": {"openebs.io/target-affinity": "lvalue"}, "name": "openebs-busybox", "namespace": "sam", "resourceVersion": "28103", "selfLink": "/api/v1/namespaces/sam/persistentvolumeclaims/openebs-busybox", "uid": "c62a9af2-a53f-4806-9403-5b196b3bafea"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "5Gi"}}, "storageClassName": "openebs-jiva-default", "volumeMode": "Filesystem", "volumeName": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea"}, "status": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "5Gi"}, "phase": "Bound"}}]}

TASK [debug] *******************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:22
2020-04-03T09:06:11.302931 (delta: 1.300237)         elapsed: 18.163982 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea"
    ]
}

TASK [Derive storage engine from PV] *******************************************
task path: /utils/scm/openebs/target_affinity_check.yml:25
2020-04-03T09:06:11.409477 (delta: 0.106482)         elapsed: 18.270528 ******* 
ok: [127.0.0.1] => {"changed": false, "resources": [{"apiVersion": "v1", "kind": "PersistentVolume", "metadata": {"annotations": {"openEBSProvisionerIdentity": "e2e1-node1", "openebs.io/cas-type": "jiva", "pv.kubernetes.io/provisioned-by": "openebs.io/provisioner-iscsi"}, "creationTimestamp": "2020-04-03T07:15:41Z", "finalizers": ["kubernetes.io/pv-protection"], "labels": {"openebs.io/cas-type": "jiva", "openebs.io/storageclass": "openebs-jiva-default"}, "name": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea", "resourceVersion": "28098", "selfLink": "/api/v1/persistentvolumes/pvc-c62a9af2-a53f-4806-9403-5b196b3bafea", "uid": "7bd5e2a3-ce1d-4031-ad1a-1debe77d717d"}, "spec": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "5Gi"}, "claimRef": {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "name": "openebs-busybox", "namespace": "sam", "resourceVersion": "28001", "uid": "c62a9af2-a53f-4806-9403-5b196b3bafea"}, "iscsi": {"fsType": "ext4", "iqn": "iqn.2016-09.com.openebs.jiva:pvc-c62a9af2-a53f-4806-9403-5b196b3bafea", "iscsiInterface": "default", "lun": 0, "targetPortal": "10.107.146.39:3260"}, "persistentVolumeReclaimPolicy": "Delete", "storageClassName": "openebs-jiva-default", "volumeMode": "Filesystem"}, "status": {"phase": "Bound"}}]}

TASK [debug] *******************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:31
2020-04-03T09:06:12.651675 (delta: 1.242131)         elapsed: 19.512726 ******* 
ok: [127.0.0.1] => (item={u'status': {u'phase': u'Bound'}, u'kind': u'PersistentVolume', u'spec': {u'storageClassName': u'openebs-jiva-default', u'accessModes': [u'ReadWriteOnce'], u'claimRef': {u'kind': u'PersistentVolumeClaim', u'uid': u'c62a9af2-a53f-4806-9403-5b196b3bafea', u'resourceVersion': u'28001', u'namespace': u'sam', u'apiVersion': u'v1', u'name': u'openebs-busybox'}, u'capacity': {u'storage': u'5Gi'}, u'volumeMode': u'Filesystem', u'persistentVolumeReclaimPolicy': u'Delete', u'iscsi': {u'targetPortal': u'10.107.146.39:3260', u'iqn': u'iqn.2016-09.com.openebs.jiva:pvc-c62a9af2-a53f-4806-9403-5b196b3bafea', u'lun': 0, u'iscsiInterface': u'default', u'fsType': u'ext4'}}, u'apiVersion': u'v1', u'metadata': {u'name': u'pvc-c62a9af2-a53f-4806-9403-5b196b3bafea', u'labels': {u'openebs.io/cas-type': u'jiva', u'openebs.io/storageclass': u'openebs-jiva-default'}, u'finalizers': [u'kubernetes.io/pv-protection'], u'resourceVersion': u'28098', u'creationTimestamp': u'2020-04-03T07:15:41Z', u'annotations': {u'pv.kubernetes.io/provisioned-by': u'openebs.io/provisioner-iscsi', u'openEBSProvisionerIdentity': u'e2e1-node1', u'openebs.io/cas-type': u'jiva'}, u'selfLink': u'/api/v1/persistentvolumes/pvc-c62a9af2-a53f-4806-9403-5b196b3bafea', u'uid': u'7bd5e2a3-ce1d-4031-ad1a-1debe77d717d'}}) => {
    "msg": "jiva"
}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:35
2020-04-03T09:06:12.806279 (delta: 0.154541)         elapsed: 19.66733 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"target_label": "openebs.io/controller=jiva-controller", "target_ns": "openebs"}, "changed": false}

TASK [set_fact] ****************************************************************
task path: /utils/scm/openebs/target_affinity_check.yml:44
2020-04-03T09:06:12.920201 (delta: 0.113842)         elapsed: 19.781252 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the node where PV target pod resides] *****************************
task path: /utils/scm/openebs/target_affinity_check.yml:49
2020-04-03T09:06:12.993392 (delta: 0.073123)         elapsed: 19.854443 ******* 
ok: [127.0.0.1] => {"changed": false, "resources": [{"apiVersion": "v1", "kind": "Pod", "metadata": {"annotations": {"cni.projectcalico.org/podIP": "192.168.173.76/32", "openebs.io/fs-type": "ext4", "openebs.io/lun": "0", "openebs.io/storage-class-ref": "name: openebs-jiva-default\nresourceVersion: 16793\n", "prometheus.io/path": "/metrics", "prometheus.io/port": "9500", "prometheus.io/scrape": "true"}, "creationTimestamp": "2020-04-03T07:15:39Z", "generateName": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea-ctrl-7c489dc849-", "labels": {"monitoring": "volume_exporter_prometheus", "openebs.io/controller": "jiva-controller", "openebs.io/persistent-volume": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea", "openebs.io/persistent-volume-claim": "openebs-busybox", "openebs.io/version": "1.9.0", "pod-template-hash": "7c489dc849"}, "name": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea-ctrl-7c489dc849-q2dm8", "namespace": "openebs", "ownerReferences": [{"apiVersion": "apps/v1", "blockOwnerDeletion": true, "controller": true, "kind": "ReplicaSet", "name": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea-ctrl-7c489dc849", "uid": "72f41592-1bad-43e3-891a-27da20e3b10a"}], "resourceVersion": "28266", "selfLink": "/api/v1/namespaces/openebs/pods/pvc-c62a9af2-a53f-4806-9403-5b196b3bafea-ctrl-7c489dc849-q2dm8", "uid": "ab2dcdb1-3576-4b7c-8112-82cebc2a56d4"}, "spec": {"affinity": {"podAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": [{"labelSelector": {"matchExpressions": [{"key": "openebs.io/target-affinity", "operator": "In", "values": ["lvalue"]}]}, "namespaces": ["sam"], "topologyKey": "kubernetes.io/hostname"}]}}, "containers": [{"args": ["controller", "--frontend", "gotgt", "--clusterIP", "10.107.146.39", "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea"], "command": ["launch"], "env": [{"name": "REPLICATION_FACTOR", "value": "3"}], "image": "quay.io/openebs/jiva:ci", "imagePullPolicy": "IfNotPresent", "name": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea-ctrl-con", "ports": [{"containerPort": 3260, "protocol": "TCP"}, {"containerPort": 9501, "protocol": "TCP"}], "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount", "name": "default-token-nk7dk", "readOnly": true}]}, {"args": ["-c=http://127.0.0.1:9501"], "command": ["maya-exporter"], "image": "quay.io/openebs/m-exporter:ci", "imagePullPolicy": "IfNotPresent", "name": "maya-volume-exporter", "ports": [{"containerPort": 9500, "protocol": "TCP"}], "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount", "name": "default-token-nk7dk", "readOnly": true}]}], "dnsPolicy": "ClusterFirst", "enableServiceLinks": true, "nodeName": "e2e1-node3", "priority": 0, "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "serviceAccount": "default", "serviceAccountName": "default", "terminationGracePeriodSeconds": 30, "tolerations": [{"effect": "NoExecute", "key": "node.alpha.kubernetes.io/notReady", "operator": "Exists", "tolerationSeconds": 0}, {"effect": "NoExecute", "key": "node.alpha.kubernetes.io/unreachable", "operator": "Exists", "tolerationSeconds": 0}, {"effect": "NoExecute", "key": "node.kubernetes.io/not-ready", "operator": "Exists", "tolerationSeconds": 0}, {"effect": "NoExecute", "key": "node.kubernetes.io/unreachable", "operator": "Exists", "tolerationSeconds": 0}], "volumes": [{"name": "default-token-nk7dk", "secret": {"defaultMode": 420, "secretName": "default-token-nk7dk"}}]}, "status": {"conditions": [{"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:15:44Z", "status": "True", "type": "Initialized"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:15:56Z", "status": "True", "type": "Ready"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:15:56Z", "status": "True", "type": "ContainersReady"}, {"lastProbeTime": null, "lastTransitionTime": "2020-04-03T07:15:44Z", "status": "True", "type": "PodScheduled"}], "containerStatuses": [{"containerID": "docker://a0486b3409057a61891055f370732c710b4d98466d3682346958827eeba90557", "image": "quay.io/openebs/m-exporter:ci", "imageID": "docker-pullable://quay.io/openebs/m-exporter@sha256:2dcf1133747eb583fb96ba0d6530e06fb15438c51cafcf62d8b7a6fac689b6de", "lastState": {}, "name": "maya-volume-exporter", "ready": true, "restartCount": 0, "started": true, "state": {"running": {"startedAt": "2020-04-03T07:15:55Z"}}}, {"containerID": "docker://3fedc5f0c032628d600fe43a57e7228280f44f2ba28fa5d0aeb9653cf374b37d", "image": "quay.io/openebs/jiva:ci", "imageID": "docker-pullable://quay.io/openebs/jiva@sha256:9033cd3eb74f50c59a4079100f27cc4d29adb719a0654d22c053c2be9b08dccb", "lastState": {}, "name": "pvc-c62a9af2-a53f-4806-9403-5b196b3bafea-ctrl-con", "ready": true, "restartCount": 0, "started": true, "state": {"running": {"startedAt": "2020-04-03T07:15:54Z"}}}], "hostIP": "10.34.1.233", "phase": "Running", "podIP": "192.168.173.76", "podIPs": [{"ip": "192.168.173.76"}], "qosClass": "BestEffort", "startTime": "2020-04-03T07:15:44Z"}}]}

TASK [Verify whether the app & target pod co-exist on same node] ***************
task path: /utils/scm/openebs/target_affinity_check.yml:58
2020-04-03T09:06:14.116923 (delta: 1.123465)         elapsed: 20.977974 ******* 
ok: [127.0.0.1] => {
    "msg": "App and Target affinity is maintained"
}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/app-target-affinity/test.yml:55
2020-04-03T09:06:14.239247 (delta: 0.12226)         elapsed: 21.100298 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/app-target-affinity/test.yml:64
2020-04-03T09:06:14.362588 (delta: 0.123273)         elapsed: 21.223639 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-03T09:06:14.497172 (delta: 0.134502)         elapsed: 21.358223 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-03T09:06:14.565283 (delta: 0.068051)         elapsed: 21.426334 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-03T09:06:14.631977 (delta: 0.066632)         elapsed: 21.493028 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-03T09:06:14.700160 (delta: 0.068121)         elapsed: 21.561211 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "0699a5e03a635b74e1f34e3333959b014cfc5a44", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "70712221afc41193cb8805683862b90e", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1585904774.78-73898316935740/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-03T09:06:16.893112 (delta: 2.19289)         elapsed: 23.754163 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.903294", "end": "2020-04-03 09:06:18.083523", "rc": 0, "start": "2020-04-03 09:06:17.180229", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: app-target-affinity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: app-target-affinity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-03T09:06:18.148833 (delta: 1.255629)         elapsed: 25.009884 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T09:06:05Z", "generation": 2, "name": "app-target-affinity", "resourceVersion": "56739", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/app-target-affinity", "uid": "a5b9fadb-afda-4da7-89fe-56bb1593e9bf"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=25   changed=8    unreachable=0    failed=0   

2020-04-03T09:06:19.267686 (delta: 1.118787)         elapsed: 26.128737 ******* 
=============================================================================== 
```

- Logs for memleak test
```
PLAY [localhost] ***************************************************************
2020-04-03T08:45:57.464553 (delta: 0.067558)         elapsed: 0.067558 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-03T08:45:57.482044 (delta: 0.017444)         elapsed: 0.085049 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-04-03T08:46:06.252995 (delta: 8.770911)         elapsed: 8.856 *********** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-04-03T08:46:06.352058 (delta: 0.099004)         elapsed: 8.955063 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-04-03T08:46:06.455256 (delta: 0.103136)         elapsed: 9.058261 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-03T08:46:06.553960 (delta: 0.098623)         elapsed: 9.156965 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-03T08:46:06.732773 (delta: 0.178736)         elapsed: 9.335778 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "ed7acbdcb5026a3a2af463df18806c1ea6747633", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "fc9a99a2f3314a5a56f4a6e7bbb16bea", "mode": "0644", "owner": "root", "size": 413, "src": "/root/.ansible/tmp/ansible-tmp-1585903566.84-232445419527939/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T08:46:07.695785 (delta: 0.962932)         elapsed: 10.29879 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.934195", "end": "2020-04-03 08:46:09.059593", "rc": 0, "start": "2020-04-03 08:46:08.125398", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: memleak-test \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: memleak-test ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T08:46:09.133335 (delta: 1.437487)         elapsed: 11.73634 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T08:37:08Z", "generation": 2, "name": "memleak-test", "resourceVersion": "51405", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/memleak-test", "uid": "003240e4-6f1c-40db-80b2-664c781f8fca"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-03T08:46:10.584476 (delta: 1.450962)         elapsed: 13.187481 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T08:46:10.652837 (delta: 0.068298)         elapsed: 13.255842 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T08:46:10.723664 (delta: 0.070763)         elapsed: 13.326669 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2020-04-03T08:46:10.841641 (delta: 0.117909)         elapsed: 13.444646 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-standard", "delta": "0:00:01.090644", "end": "2020-04-03 08:46:12.191681", "rc": 0, "start": "2020-04-03 08:46:11.101037", "stderr": "", "stderr_lines": [], "stdout": "NAME               PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE\nopenebs-standard   openebs.io/provisioner-iscsi   Delete          Immediate           false                  115s", "stdout_lines": ["NAME               PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE", "openebs-standard   openebs.io/provisioner-iscsi   Delete          Immediate           false                  115s"]}

TASK [Replace the storageclass placeholder with provider] **********************
2020-04-03T08:46:12.264019 (delta: 1.422283)         elapsed: 14.867024 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create test specific namespace.] *****************************************
2020-04-03T08:46:12.770119 (delta: 0.506033)         elapsed: 15.373124 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns memleak", "delta": "0:00:00.953760", "end": "2020-04-03 08:46:13.964965", "rc": 0, "start": "2020-04-03 08:46:13.011205", "stderr": "", "stderr_lines": [], "stdout": "namespace/memleak created", "stdout_lines": ["namespace/memleak created"]}

TASK [Checking the status  of test specific namespace.] ************************
2020-04-03T08:46:14.055599 (delta: 1.285415)         elapsed: 16.658604 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns memleak -o jsonpath='{.status.phase}'", "delta": "0:00:01.036497", "end": "2020-04-03 08:46:15.402726", "rc": 0, "start": "2020-04-03 08:46:14.366229", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deploy OpenEBS volume and run dd Load] ***********************************
2020-04-03T08:46:15.494310 (delta: 1.4386)         elapsed: 18.097315 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f memleak.yml -n memleak", "delta": "0:00:01.305801", "end": "2020-04-03 08:46:17.102827", "rc": 0, "start": "2020-04-03 08:46:15.797026", "stderr": "", "stderr_lines": [], "stdout": "pod/memleak-test created\npersistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["pod/memleak-test created", "persistentvolumeclaim/demo-vol1-claim created"]}

TASK [Confirm volume status is running] ****************************************
2020-04-03T08:46:17.207702 (delta: 1.713327)         elapsed: 19.810707 ******* 
FAILED - RETRYING: Confirm volume status is running (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n memleak -o jsonpath='{.items[?(@.metadata.labels.name==\"memleak\")].status.phase}'", "delta": "0:00:01.113779", "end": "2020-04-03 08:46:50.732779", "rc": 0, "start": "2020-04-03 08:46:49.619000", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the volume name] **************************************************
2020-04-03T08:46:50.839240 (delta: 33.631439)         elapsed: 53.442245 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n memleak --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.176511", "end": "2020-04-03 08:46:52.439553", "rc": 0, "start": "2020-04-03 08:46:51.263042", "stderr": "", "stderr_lines": [], "stdout": "pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591", "stdout_lines": ["pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591"]}

TASK [Run python script for memory usage validation it takes couple of minutes] ***
2020-04-03T08:46:52.516628 (delta: 1.677307)         elapsed: 55.119633 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "python test-mem.py openebs 800 pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591", "delta": "0:03:26.921202", "end": "2020-04-03 08:50:19.675602", "failed_when_result": false, "rc": 0, "start": "2020-04-03 08:46:52.754400", "stderr": "", "stderr_lines": [], "stdout": "kubectl get pod -n openebs -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591 --no-headers | awk '{print $1}'\npvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591-ctrl-con\nkubectl exec pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591-ctrl-5997448bfb-zr99k -c pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591-ctrl-con -n openebs -- pmap -x 1 | awk ''/total'/ {print $3}'\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n385.0390625 MB\n[385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625]\nPass", "stdout_lines": ["kubectl get pod -n openebs -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591 --no-headers | awk '{print $1}'", "pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591-ctrl-con", "kubectl exec pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591-ctrl-5997448bfb-zr99k -c pvc-cb8d4566-6d31-4c72-beac-7aea2e7c5591-ctrl-con -n openebs -- pmap -x 1 | awk ''/total'/ {print $3}'", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "385.0390625 MB", "[385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625, 385.0390625]", "Pass"]}

TASK [set_fact] ****************************************************************
2020-04-03T08:50:19.817843 (delta: 207.301064)         elapsed: 262.420848 **** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning test related resources] ***********************************
2020-04-03T08:50:19.990574 (delta: 0.171844)         elapsed: 262.593579 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f memleak.yml -n memleak", "delta": "0:00:42.909507", "end": "2020-04-03 08:51:03.311607", "rc": 0, "start": "2020-04-03 08:50:20.402100", "stderr": "", "stderr_lines": [], "stdout": "pod \"memleak-test\" deleted\npersistentvolumeclaim \"demo-vol1-claim\" deleted", "stdout_lines": ["pod \"memleak-test\" deleted", "persistentvolumeclaim \"demo-vol1-claim\" deleted"]}

TASK [Checking whether the application pod is removed] *************************
2020-04-03T08:51:03.442754 (delta: 43.452108)         elapsed: 306.045759 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n memleak -l name=memleak | wc -l", "delta": "0:00:01.409907", "end": "2020-04-03 08:51:05.203421", "rc": 0, "start": "2020-04-03 08:51:03.793514", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "0", "stdout_lines": ["0"]}

TASK [include_tasks] ***********************************************************
2020-04-03T08:51:05.278733 (delta: 1.834593)         elapsed: 307.881738 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-03T08:51:05.431294 (delta: 0.152488)         elapsed: 308.034299 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T08:51:05.585146 (delta: 0.15378)         elapsed: 308.188151 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T08:51:05.686661 (delta: 0.101443)         elapsed: 308.289666 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-03T08:51:05.804655 (delta: 0.117913)         elapsed: 308.40766 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "4895c4d619d6c95588107fcd6486ddd7c776648b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "6580cd853fcf54b161be7f7d32f18140", "mode": "0644", "owner": "root", "size": 411, "src": "/root/.ansible/tmp/ansible-tmp-1585903865.88-180474587710455/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T08:51:07.980009 (delta: 2.175282)         elapsed: 310.583014 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.004163", "end": "2020-04-03 08:51:09.243682", "rc": 0, "start": "2020-04-03 08:51:08.239519", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: memleak-test \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: memleak-test ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T08:51:09.324218 (delta: 1.344149)         elapsed: 311.927223 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T08:37:08Z", "generation": 3, "name": "memleak-test", "resourceVersion": "52996", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/memleak-test", "uid": "003240e4-6f1c-40db-80b2-664c781f8fca"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=16   unreachable=0    failed=0   

2020-04-03T08:51:10.967397 (delta: 1.643117)         elapsed: 313.570402 ****** 
=============================================================================== 
```


- Logs for jiva replica scaleup
```
PLAY [localhost] ***************************************************************
2020-04-03T09:46:25.315980 (delta: 0.06686)         elapsed: 0.06686 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-03T09:46:25.331281 (delta: 0.015206)         elapsed: 0.082161 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-04-03T09:46:33.971013 (delta: 8.639657)         elapsed: 8.721893 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-04-03T09:46:34.121936 (delta: 0.150852)         elapsed: 8.872816 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-04-03T09:46:34.217566 (delta: 0.095456)         elapsed: 8.968446 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-03T09:46:34.307884 (delta: 0.090203)         elapsed: 9.058764 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-03T09:46:34.467262 (delta: 0.159291)         elapsed: 9.218142 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "1df2d431d14527432a66738db78b77fd3695e86b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "64d3375040c2b0cfa197b3dd9adf5745", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1585907194.53-194340575083524/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T09:46:35.308273 (delta: 0.840946)         elapsed: 10.059153 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.778055", "end": "2020-04-03 09:46:36.452074", "rc": 0, "start": "2020-04-03 09:46:35.674019", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: scaleup-jiva-replica \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: scaleup-jiva-replica ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T09:46:36.526909 (delta: 1.218566)         elapsed: 11.277789 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T09:46:37Z", "generation": 1, "name": "scaleup-jiva-replica", "resourceVersion": "67668", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/scaleup-jiva-replica", "uid": "f9f74875-1116-4112-ae08-af8b4db30867"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-03T09:46:37.950725 (delta: 1.42373)         elapsed: 12.701605 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T09:46:38.025760 (delta: 0.074969)         elapsed: 12.77664 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T09:46:38.102712 (delta: 0.076881)         elapsed: 12.853592 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application pod name] ****************************************
2020-04-03T09:46:38.182802 (delta: 0.080019)         elapsed: 12.933682 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting maya-api server pod name] ****************************************
2020-04-03T09:46:38.350606 (delta: 0.167723)         elapsed: 13.101486 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application mount point] *************************************
2020-04-03T09:46:38.436236 (delta: 0.085537)         elapsed: 13.187116 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Writing data on application mount point] *********************************
2020-04-03T09:46:38.524528 (delta: 0.087932)         elapsed: 13.275408 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the number of nodes in the cluster] **********************************
2020-04-03T09:46:38.614547 (delta: 0.089761)         elapsed: 13.365427 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | wc -l", "delta": "0:00:01.054632", "end": "2020-04-03 09:46:39.892262", "rc": 0, "start": "2020-04-03 09:46:38.837630", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Fetch the node count from stdout] ****************************************
2020-04-03T09:46:39.976400 (delta: 1.361783)         elapsed: 14.72728 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"node_count": "3"}, "changed": false}

TASK [Get the volume name] *****************************************************
2020-04-03T09:46:40.213921 (delta: 0.237437)         elapsed: 14.964801 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n scale --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.972613", "end": "2020-04-03 09:46:41.410994", "rc": 0, "start": "2020-04-03 09:46:40.438381", "stderr": "", "stderr_lines": [], "stdout": "pvc-b234e711-079d-4621-b40c-ab7fec881543", "stdout_lines": ["pvc-b234e711-079d-4621-b40c-ab7fec881543"]}

TASK [Get the replica deployment name] *****************************************
2020-04-03T09:46:41.480164 (delta: 1.26616)         elapsed: 16.231044 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployments -n openebs -l openebs.io/persistent-volume=\"pvc-b234e711-079d-4621-b40c-ab7fec881543\",openebs.io/replica=jiva-replica --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.960773", "end": "2020-04-03 09:46:42.692210", "rc": 0, "start": "2020-04-03 09:46:41.731437", "stderr": "", "stderr_lines": [], "stdout": "pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1", "stdout_lines": ["pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1"]}

TASK [Get the controller deployment name] **************************************
2020-04-03T09:46:42.763238 (delta: 1.282825)         elapsed: 17.514118 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n openebs -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=\"pvc-b234e711-079d-4621-b40c-ab7fec881543\" -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.998960", "end": "2020-04-03 09:46:43.989554", "rc": 0, "start": "2020-04-03 09:46:42.990594", "stderr": "", "stderr_lines": [], "stdout": "pvc-b234e711-079d-4621-b40c-ab7fec881543-ctrl", "stdout_lines": ["pvc-b234e711-079d-4621-b40c-ab7fec881543-ctrl"]}

TASK [Getting the node name on which replica is scheduled] *********************
2020-04-03T09:46:44.065301 (delta: 1.301997)         elapsed: 18.816181 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 -n openebs -o jsonpath='{.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]}'", "delta": "0:00:01.036427", "end": "2020-04-03 09:46:45.382117", "rc": 0, "start": "2020-04-03 09:46:44.345690", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node2", "stdout_lines": ["e2e1-node2"]}

TASK [Getting the node name where replica is not scheduled] ********************
2020-04-03T09:46:45.455477 (delta: 1.390087)         elapsed: 20.206357 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | grep -v e2e1-node2 | awk {'print $1'}", "delta": "0:00:00.992792", "end": "2020-04-03 09:46:46.647465", "rc": 0, "start": "2020-04-03 09:46:45.654673", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1\ne2e1-node3", "stdout_lines": ["e2e1-node1", "e2e1-node3"]}

TASK [Adding the replica node-name in patch file] ******************************
2020-04-03T09:46:46.726748 (delta: 1.27121)         elapsed: 21.477628 ******** 
changed: [127.0.0.1] => {"backup": "", "changed": true, "msg": "line added"}

TASK [Adding node-name where replica is not scheduled in patch file] ***********
2020-04-03T09:46:47.289845 (delta: 0.563029)         elapsed: 22.040725 ******* 
changed: [127.0.0.1] => (item=e2e1-node1) => {"backup": "", "changed": true, "item": "e2e1-node1", "msg": "line added"}
changed: [127.0.0.1] => (item=e2e1-node3) => {"backup": "", "changed": true, "item": "e2e1-node3", "msg": "line added"}

TASK [Patching replica deployment] *********************************************
2020-04-03T09:46:47.780829 (delta: 0.490917)         elapsed: 22.531709 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch deployment pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 -n openebs --patch \"$(cat rep_patch.yml)\"", "delta": "0:00:01.153804", "end": "2020-04-03 09:46:49.152154", "failed_when_result": false, "rc": 0, "start": "2020-04-03 09:46:47.998350", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 patched", "stdout_lines": ["deployment.apps/pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 patched"]}

TASK [Obtaining the current replication factor] ********************************
2020-04-03T09:46:49.231364 (delta: 1.450414)         elapsed: 23.982244 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployments pvc-b234e711-079d-4621-b40c-ab7fec881543-ctrl -n openebs -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'", "delta": "0:00:00.897270", "end": "2020-04-03 09:46:50.454997", "rc": 0, "start": "2020-04-03 09:46:49.557727", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Update Controller deployment] ********************************************
2020-04-03T09:46:50.538595 (delta: 1.307125)         elapsed: 25.289475 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl set env deployment/pvc-b234e711-079d-4621-b40c-ab7fec881543-ctrl -n openebs REPLICATION_FACTOR=\"3\"", "delta": "0:00:00.969726", "end": "2020-04-03 09:46:51.772994", "rc": 0, "start": "2020-04-03 09:46:50.803268", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/pvc-b234e711-079d-4621-b40c-ab7fec881543-ctrl env updated", "stdout_lines": ["deployment.apps/pvc-b234e711-079d-4621-b40c-ab7fec881543-ctrl env updated"]}

TASK [Scaling-up Jiva replica] *************************************************
2020-04-03T09:46:51.862290 (delta: 1.323549)         elapsed: 26.61317 ******** 
included: /funclib/kubectl/scale_replicas.yml for 127.0.0.1

TASK [Obtaining the application pod name.] *************************************
2020-04-03T09:46:51.994688 (delta: 0.132234)         elapsed: 26.745568 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n openebs --no-headers -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-b234e711-079d-4621-b40c-ab7fec881543 -o custom-columns=:metadata.name", "delta": "0:00:01.135112", "end": "2020-04-03 09:46:53.354882", "rc": 0, "start": "2020-04-03 09:46:52.219770", "stderr": "", "stderr_lines": [], "stdout": "pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1", "stdout_lines": ["pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1"]}

TASK [Recording the application pod name.] *************************************
2020-04-03T09:46:53.433381 (delta: 1.438597)         elapsed: 28.184261 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_name": "pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1"}, "changed": false}

TASK [scaling up the replicas.] ************************************************
2020-04-03T09:46:53.571230 (delta: 0.137779)         elapsed: 28.32211 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl scale deployment pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 --replicas=3 -n openebs", "delta": "0:00:01.342408", "end": "2020-04-03 09:46:55.150093", "failed_when_result": false, "rc": 0, "start": "2020-04-03 09:46:53.807685", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 scaled", "stdout_lines": ["deployment.apps/pvc-b234e711-079d-4621-b40c-ab7fec881543-rep-1 scaled"]}

TASK [Check if all the application replicas are running.] **********************
2020-04-03T09:46:55.235652 (delta: 1.66432)         elapsed: 29.986532 ******** 
FAILED - RETRYING: Check if all the application replicas are running. (60 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get deployment -n openebs --no-headers -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=pvc-b234e711-079d-4621-b40c-ab7fec881543 -o custom-columns=:..readyReplicas", "delta": "0:00:01.021425", "end": "2020-04-03 09:47:08.064418", "rc": 0, "start": "2020-04-03 09:47:07.042993", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the PV name] *****************************************************
2020-04-03T09:47:08.138002 (delta: 12.902224)         elapsed: 42.888882 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Waiting for replicas to start sync] **************************************
2020-04-03T09:47:08.220237 (delta: 0.082083)         elapsed: 42.971117 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the Controller pod name] *****************************************
2020-04-03T09:47:08.315880 (delta: 0.095577)         elapsed: 43.06676 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting controller] ***************************************************
2020-04-03T09:47:08.396285 (delta: 0.080338)         elapsed: 43.147165 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verifying successful deletion of controller] *****************************
2020-04-03T09:47:08.485353 (delta: 0.088998)         elapsed: 43.236233 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Waiting for new controller to be in running state] ***********************
2020-04-03T09:47:08.570193 (delta: 0.084767)         elapsed: 43.321073 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the replica pod name] ********************************************
2020-04-03T09:47:08.644802 (delta: 0.074524)         elapsed: 43.395682 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting replica] ******************************************************
2020-04-03T09:47:08.724579 (delta: 0.079466)         elapsed: 43.475459 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verifying successful deletion of replica] ********************************
2020-04-03T09:47:08.796171 (delta: 0.071471)         elapsed: 43.547051 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for all replicas to be in Running state] ************************
2020-04-03T09:47:08.865974 (delta: 0.069734)         elapsed: 43.616854 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the replicas access mode] ******************************************
2020-04-03T09:47:08.934903 (delta: 0.06864)         elapsed: 43.685783 ******** 
included: /funclib/openebs/access-mode-check.yml for 127.0.0.1

TASK [Get the pv name] *********************************************************
2020-04-03T09:47:09.095070 (delta: 0.160045)         elapsed: 43.84595 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n scale -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.073780", "end": "2020-04-03 09:47:10.402039", "rc": 0, "start": "2020-04-03 09:47:09.328259", "stderr": "", "stderr_lines": [], "stdout": "pvc-b234e711-079d-4621-b40c-ab7fec881543", "stdout_lines": ["pvc-b234e711-079d-4621-b40c-ab7fec881543"]}

TASK [Get the nodes count] *****************************************************
2020-04-03T09:47:10.498725 (delta: 1.403333)         elapsed: 45.249605 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | wc -l", "delta": "0:00:00.968632", "end": "2020-04-03 09:47:11.691847", "rc": 0, "start": "2020-04-03 09:47:10.723215", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the maya-apiserver pod name] *****************************************
2020-04-03T09:47:11.774492 (delta: 1.2757)         elapsed: 46.525372 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.826369", "end": "2020-04-03 09:47:12.833683", "rc": 0, "start": "2020-04-03 09:47:12.007314", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-854f7bcb8f-rb7s2", "stdout_lines": ["maya-apiserver-854f7bcb8f-rb7s2"]}

TASK [Get the volume list] *****************************************************
2020-04-03T09:47:12.903661 (delta: 1.129089)         elapsed: 47.654541 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-854f7bcb8f-rb7s2 -n openebs -- mayactl volume list", "delta": "0:00:01.515837", "end": "2020-04-03 09:47:14.639224", "rc": 0, "start": "2020-04-03 09:47:13.123387", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Namespace  Name                                      Status   Type  Capacity  StorageClass             Access Mode\n---------  ----                                      ------   ----  --------  -------------            -----------\nopenebs    pvc-b234e711-079d-4621-b40c-ab7fec881543  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-c62a9af2-a53f-4806-9403-5b196b3bafea  Running  jiva  5Gi       openebs-jiva-default     ReadWriteOnce", "stdout_lines": ["Namespace  Name                                      Status   Type  Capacity  StorageClass             Access Mode", "---------  ----                                      ------   ----  --------  -------------            -----------", "openebs    pvc-b234e711-079d-4621-b40c-ab7fec881543  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-c62a9af2-a53f-4806-9403-5b196b3bafea  Running  jiva  5Gi       openebs-jiva-default     ReadWriteOnce"]}

TASK [Get the replicas access mode] ********************************************
2020-04-03T09:47:14.737391 (delta: 1.833621)         elapsed: 49.488271 ******* 
FAILED - RETRYING: Get the replicas access mode (15 retries left).
FAILED - RETRYING: Get the replicas access mode (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it maya-apiserver-854f7bcb8f-rb7s2 -n openebs -- mayactl volume describe --volname \"pvc-b234e711-079d-4621-b40c-ab7fec881543\" -n scale | grep 'RW' | wc -l", "delta": "0:00:01.631994", "end": "2020-04-03 09:48:20.594166", "rc": 0, "start": "2020-04-03 09:48:18.962172", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [debug] *******************************************************************
2020-04-03T09:48:20.675962 (delta: 65.9385)         elapsed: 115.426842 ******* 
ok: [127.0.0.1] => {
    "msg": "All the replicas are in sync"
}

TASK [set_fact] ****************************************************************
2020-04-03T09:48:20.797639 (delta: 0.121609)         elapsed: 115.548519 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-04-03T09:48:20.942843 (delta: 0.145128)         elapsed: 115.693723 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-03T09:48:21.079663 (delta: 0.136731)         elapsed: 115.830543 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T09:48:21.152492 (delta: 0.072701)         elapsed: 115.903372 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T09:48:21.216527 (delta: 0.063972)         elapsed: 115.967407 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-03T09:48:21.282982 (delta: 0.066391)         elapsed: 116.033862 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "3b4bb83ca22cba9857f7b3e4b2e251f9632be213", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c028cd2c5d058fbe509b12e49ba88bc4", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1585907301.34-12844058157173/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-03T09:48:23.348991 (delta: 2.065948)         elapsed: 118.099871 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.768353", "end": "2020-04-03 09:48:24.339762", "rc": 0, "start": "2020-04-03 09:48:23.571409", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: scaleup-jiva-replica \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: scaleup-jiva-replica ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-03T09:48:24.405784 (delta: 1.056726)         elapsed: 119.156664 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-03T09:46:37Z", "generation": 2, "name": "scaleup-jiva-replica", "resourceVersion": "68248", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/scaleup-jiva-replica", "uid": "f9f74875-1116-4112-ae08-af8b4db30867"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=35   changed=25   unreachable=0    failed=0   

2020-04-03T09:48:25.417744 (delta: 1.011867)         elapsed: 120.168624 ****** 
=============================================================================== 
```