### PR TITLE
refactor[yaml]: Modified the litmus chaos experiments specific to jiva

### DIFF
--- a/chaoslib/crio_chaos/crio-crictl-chaos.yml
+++ b/chaoslib/crio_chaos/crio-crictl-chaos.yml
@@ -23,7 +23,7 @@
 
     - name: Identify the node where application pod is running
       shell: >
-        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        kubectl get pod {{ app_pod }} -n {{ target_ns }}
         --no-headers -o custom-columns=:spec.nodeName
       args:
         executable: /bin/bash

--- a/chaoslib/openebs/jiva_controller_container_kill.yml
+++ b/chaoslib/openebs/jiva_controller_container_kill.yml
@@ -13,7 +13,7 @@
 
 - name: Get jiva controller pod belonging to the PV
   shell: >
-    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }}
+    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ target_ns }}
     -o jsonpath="{.items[?(@.metadata.labels.openebs\\.io/persistent-volume==\"{{pv.stdout}}\")].metadata.name}"
   args:
     executable: /bin/bash
@@ -21,7 +21,7 @@
 
 - name: Get the restartCount of ctrl-con container
   shell: >
-    kubectl get pods {{ jiva_controller_pod.stdout }} -n {{ app_ns }}
+    kubectl get pods {{ jiva_controller_pod.stdout }} -n {{ target_ns }}
     -o=jsonpath='{.status.containerStatuses[?(@.name==''"{{ctrl_container}}"'')].restartCount}'
   args:
     executable: /bin/bash
@@ -50,7 +50,7 @@
 
 - name: Check if the controller pod is running
   shell: >
-    kubectl get pod {{ jiva_controller_pod.stdout }} -n {{ app_ns }} --no-headers
+    kubectl get pod {{ jiva_controller_pod.stdout }} -n {{ target_ns }} --no-headers
     -o custom-columns=:.status.phase    
   args:
     executable: /bin/bash
@@ -61,7 +61,7 @@
 
 - name: Check for controller container status
   shell: >
-    kubectl get pod {{ jiva_controller_pod.stdout }} -n {{ app_ns }}
+    kubectl get pod {{ jiva_controller_pod.stdout }} -n {{ target_ns }}
     -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
     grep -w running | wc -l
   args:
@@ -73,7 +73,7 @@
 
 - name: Get the restartCount of ctrl-con container
   shell: >
-    kubectl get pods {{ jiva_controller_pod.stdout }} -n {{ app_ns }}
+    kubectl get pods {{ jiva_controller_pod.stdout }} -n {{ target_ns }}
     -o=jsonpath='{.status.containerStatuses[?(@.name==''"{{ctrl_container}}"'')].restartCount}'
   args: 
     executable: /bin/bash

--- a/chaoslib/openebs/jiva_controller_network_delay.yaml
+++ b/chaoslib/openebs/jiva_controller_network_delay.yaml
@@ -30,7 +30,7 @@
 - name: Identify the jiva controller pod belonging to the PV
   shell: > 
     kubectl get pods -l openebs.io/controller=jiva-controller
-    -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
+    -n {{ operator_ns }} --no-headers | grep {{ pv.stdout }} 
     | awk '{print $1}'
   args:
     executable: /bin/bash
@@ -43,7 +43,7 @@
 
 - name: Get the node on which the jiva controller is scheduled
   shell: >
-    kubectl get pod {{ jiva_controller_pod.stdout }} -n {{ app_ns }}
+    kubectl get pod {{ jiva_controller_pod.stdout }} -n {{ operator_ns }}
     --no-headers -o custom-columns=:spec.nodeName
   args:
     executable: /bin/bash
@@ -51,8 +51,8 @@
 
 - name: Get controller svc
   shell: >
-    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc 
-    -n {{ app_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume="{{ pv.stdout }}" 
+    -n {{ operator_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
   args:
     executable: /bin/bash
   register: controller_svc
@@ -60,14 +60,14 @@
 
 - name: Install jq package inside a controller container
   shell: >
-    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} -c {{ jiva_controller_name }} 
+    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} -c {{ jiva_controller_name }} 
     -- bash -c "apt-get update && apt-get install -y jq && apt-get install -y iproute2"
   args:
     executable: /bin/bash
 
 - name: Getting the ReplicaCount before injecting delay
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
@@ -91,7 +91,7 @@
 
 - name: Verifying the Replica getting disconnected
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
@@ -118,7 +118,7 @@
 
 - name: Verifying the replicas post network recovery
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash

--- a/chaoslib/openebs/jiva_controller_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_controller_pod_failure.yaml
@@ -19,7 +19,7 @@
 
 - name: Get the resourceVersion of the target deploy before fault injection
   shell: >
-    kubectl get deploy {{ jiva_controller_deploy }} -n {{ app_ns }} 
+    kubectl get deploy {{ jiva_controller_deploy }} -n {{ target_ns }} 
     -o=custom-columns=NAME:".metadata.resourceVersion" --no-headers
   args:
     executable: /bin/bash
@@ -27,7 +27,7 @@
 
 - name: Get jiva controller pod belonging to the PV
   shell: > 
-    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }}
+    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ target_ns }}
     -o jsonpath="{.items[?(@.metadata.labels.openebs\\.io/persistent-volume==\"{{pv.stdout}}\")].metadata.name}" 
   args:
     executable: /bin/bash
@@ -35,8 +35,8 @@
 
 - name: Get controller svc
   shell: >
-    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc 
-    -n {{ app_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume="{{ pv.stdout }}" 
+    -n {{ target_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
   args:
     executable: /bin/bash
   register: controller_svc
@@ -44,14 +44,14 @@
 
 - name: Install jq package inside a controller container
   shell: >
-    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} -c {{ jiva_controller_name }} 
+    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ target_ns }} -c {{ jiva_controller_name }} 
     -- bash -c "apt-get update && apt-get install -y jq"
   args:
     executable: /bin/bash
 
 - name: Getting the Replicastatus before killing controller
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ target_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/replicas | jq -r '.data[].mode'
   args:
     executable: /bin/bash
@@ -59,13 +59,13 @@
 
 - name: Kill the jiva controller pod 
   shell: >
-    kubectl delete pod {{ jiva_controller_pod.stdout }} -n {{ app_ns }}
+    kubectl delete pod {{ jiva_controller_pod.stdout }} -n {{ target_ns }}
   args:
     executable: /bin/bash
 
 - name: Get jiva controller pod belonging to the PV
   shell: >
-    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }}
+    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ target_ns }}
     -o jsonpath="{.items[?(@.metadata.labels.openebs\\.io/persistent-volume==\"{{pv.stdout}}\")].metadata.name}"
   args:
     executable: /bin/bash
@@ -73,7 +73,7 @@
 
 - name: Check jiva controller container status
   shell: >
-    kubectl get pods {{ jctrl_pod_after.stdout }} -n {{ app_ns }} 
+    kubectl get pods {{ jctrl_pod_after.stdout }} -n {{ target_ns }} 
     -o jsonpath='{.status.containerStatuses[?(@.name=="{{ pv.stdout}}-ctrl-con")].state}' | grep running
   args:
     executable: /bin/bash
@@ -84,14 +84,14 @@
 
 - name: Install jq package inside a controller container
   shell: >
-    kubectl exec -it {{ jctrl_pod_after.stdout }} -n {{ app_ns }} -c {{ jiva_controller_name }}
+    kubectl exec -it {{ jctrl_pod_after.stdout }} -n {{ target_ns }} -c {{ jiva_controller_name }}
     -- bash -c "apt-get update && apt-get install -y jq"
   args:
     executable: /bin/bash
 
 - name: Getting the Replicastatus after killing the controller
   shell: >
-   kubectl exec -it {{ jctrl_pod_after.stdout }} -n {{ app_ns }}
+   kubectl exec -it {{ jctrl_pod_after.stdout }} -n {{ target_ns }}
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/replicas | jq -r '.data[].mode'
   args:
     executable: /bin/bash
@@ -102,7 +102,7 @@
 
 - name: Get the resourceVersion of the target deploy after fault injection
   shell: >
-    kubectl get deploy {{ jiva_controller_deploy }} -n {{ app_ns }}
+    kubectl get deploy {{ jiva_controller_deploy }} -n {{ target_ns }}
     -o=custom-columns=NAME:".metadata.resourceVersion" --no-headers 
   args:
     executable: /bin/bash

--- a/chaoslib/openebs/jiva_replica_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_replica_pod_failure.yaml
@@ -7,14 +7,23 @@
     executable: /bin/bash
   register: pv
 
+- name: Randomly pick a jiva replica deployment belonging to the PV
+  shell: > 
+    kubectl get deployment -l openebs.io/replica=jiva-replica
+    -n {{ operator_ns }} --no-headers | grep {{ pv.stdout }} 
+    | shuf -n1 | awk '{print $1}'
+  args:
+    executable: /bin/bash
+  register: jiva_replica_deployment
+
 - name: Record the jiva replica deployment of the PV
   set_fact: 
     # Depends on the naming convention in maya-apiserver (<pv-id>-rep)  
-    jiva_replica_deploy: "{{ pv.stdout }}-rep"
+    jiva_replica_deploy: "{{ jiva_replica_deployment.stdout }}"
 
 - name: Obtain the number of replicas in the deployment
   shell: >
-    kubectl get deployment {{ jiva_replica_deploy }} -n {{ app_ns }}
+    kubectl get deployment {{ jiva_replica_deploy }} -n {{ operator_ns }}
     --no-headers -o custom-columns=:spec.replicas
   args:
     executable: /bin/bash
@@ -22,7 +31,7 @@
 
 - name: Get the resourceVersion of the replica deploy before fault injection
   shell: >
-    kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
+    kubectl get deploy {{ jiva_replica_deploy }} -n {{ operator_ns }} 
     --no-headers -o custom-columns=:metadata.resourceVersion
   args:
     executable: /bin/bash
@@ -31,7 +40,7 @@
 - name: Randomly pick a jiva replica pod belonging to the PV
   shell: > 
     kubectl get pods -l openebs.io/replica=jiva-replica
-    -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
+    -n {{ operator_ns }} --no-headers | grep {{ jiva_replica_deploy }} 
     | shuf -n1 | awk '{print $1}'
   args:
     executable: /bin/bash
@@ -39,13 +48,13 @@
 
 - name: Kill the jiva replica pod 
   shell: >
-    kubectl delete pod {{ jiva_replica_pod.stdout }} -n {{ app_ns }}
+    kubectl delete pod {{ jiva_replica_pod.stdout }} -n {{ operator_ns }}
   args:
     executable: /bin/bash
 
 - name: Check if the replica pod is scheduled back.
   shell: >
-    kubectl get deployment {{ jiva_replica_deploy }} -n {{ app_ns }}
+    kubectl get deployment {{ jiva_replica_deploy }} -n {{ operator_ns }}
     --no-headers -o custom-columns=:..readyReplicas
   args:
     executable: /bin/bash
@@ -56,7 +65,7 @@
 
 - name: Get the resourceVersion of the replica deploy after fault injection
   shell: >
-    kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
+    kubectl get deploy {{ jiva_replica_deploy }} -n {{ operator_ns }} 
     --no-headers -o custom-columns=:metadata.resourceVersion
   args:
     executable: /bin/bash

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/patch.j2
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/patch.j2
@@ -1,0 +1,16 @@
+{
+ "spec": {
+  "template": {
+    "spec": {
+     "containers": [
+      {
+       "name": "{{ pv.stdout }}-ctrl-con",
+       "securityContext": {
+          "privileged": true
+       }
+      }
+     ]
+    }
+  }
+ }
+}

--- a/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml
+++ b/experiments/chaos/nfs_chaos/nfs_openebs_target_failure/test.yml
@@ -57,6 +57,74 @@
             executable: /bin/bash
           register: app_pod_name
 
+        - name: Derive PV from application PVC 
+          shell: >
+            kubectl get pvc {{ pvc }}
+            -o custom-columns=:spec.volumeName -n {{ namespace }}
+            --no-headers
+          args:
+            executable: /bin/bash
+          register: pv
+
+        - block:
+
+            - name: Identify the patch to be invoked
+              template:
+                src: patch.j2
+                dest: patch.yml
+
+            - name: Identify the jiva controller pod name
+              shell: >
+                kubectl get pods -l openebs.io/controller=jiva-controller
+                -n {{ target_namespace }} --no-headers | grep {{ pv.stdout }} 
+                | awk '{print $1}' 
+              args:
+                executable: /bin/bash
+              register: controller_pod_before
+
+            - name: Patching jiva controller deployment to allow security privileged
+              shell: >
+                kubectl patch deployment {{ pv.stdout }}-ctrl -n {{ target_namespace }}
+                --patch "$(cat patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"
+            
+            - name: Wait for 10s post fault injection 
+              wait_for:
+                timeout: 10
+
+            - name: Verify if the jiva controller pod is terminated
+              shell: kubectl get pods -n {{ target_namespace }}
+              args:
+                executable: /bin/bash
+              register: pod_status
+              until: '"{{ controller_pod_before.stdout }}" not in pod_status.stdout' 
+              delay: 5
+              retries: 60
+              when: "'no change' not in patch_status.stdout"
+              
+            - name: Identify the new jiva controller pod belonging to the PV
+              shell: > 
+                kubectl get pods -l openebs.io/controller=jiva-controller
+                -n {{ target_namespace }} --no-headers | grep {{ pv.stdout }} 
+                | awk '{print $1}'
+              args:
+                executable: /bin/bash
+              register: controller_pod_after
+
+            - name: Check for the jiva controller container status
+              shell: >
+                kubectl get pods {{ controller_pod_after.stdout }} -n {{ target_namespace }} 
+                -o jsonpath='{.status.containerStatuses[?(@.name=="{{ pv.stdout}}-ctrl-con")].state}' | grep running
+              args:
+                executable: /bin/bash
+              register: container_status
+              until: "'running' in container_status.stdout"
+              delay: 3
+              retries: 20
+                                      
+          when: stg_engine == 'jiva'
+
         ## STORAGE FAULT INJECTION
 
         - include: "{{ chaos_util_path }}"

--- a/experiments/chaos/openebs_target_failure/patch.j2
+++ b/experiments/chaos/openebs_target_failure/patch.j2
@@ -1,0 +1,16 @@
+{
+ "spec": {
+  "template": {
+    "spec": {
+     "containers": [
+      {
+       "name": "{{ pv.stdout }}-ctrl-con",
+       "securityContext": {
+          "privileged": true
+       }
+      }
+     ]
+    }
+  }
+ }
+}

--- a/experiments/chaos/openebs_target_failure/test.yml
+++ b/experiments/chaos/openebs_target_failure/test.yml
@@ -69,6 +69,74 @@
             executable: /bin/bash
           register: app_pod_name    
 
+        - name: Derive PV from application PVC 
+          shell: >
+            kubectl get pvc {{ pvc }}
+            -o custom-columns=:spec.volumeName -n {{ namespace }}
+            --no-headers
+          args:
+            executable: /bin/bash
+          register: pv
+
+        - block:
+
+            - name: Identify the patch to be invoked
+              template:
+                src: patch.j2
+                dest: patch.yml
+
+            - name: Identify the jiva controller pod name
+              shell: >
+                kubectl get pods -l openebs.io/controller=jiva-controller
+                -n {{ target_namespace }} --no-headers | grep {{ pv.stdout }} 
+                | awk '{print $1}' 
+              args:
+                executable: /bin/bash
+              register: controller_pod_before
+
+            - name: Patching jiva controller deployment to allow security privileged
+              shell: >
+                kubectl patch deployment {{ pv.stdout }}-ctrl -n {{ target_namespace }}
+                --patch "$(cat patch.yml)"
+              register: patch_status
+              failed_when: "'patched' not in patch_status.stdout"
+            
+            - name: Wait for 10s post fault injection 
+              wait_for:
+                timeout: 10
+
+            - name: Verify if the jiva controller pod is terminated
+              shell: kubectl get pods -n {{ target_namespace }}
+              args:
+                executable: /bin/bash
+              register: pod_status
+              until: '"{{ controller_pod_before.stdout }}" not in pod_status.stdout' 
+              delay: 5
+              retries: 60
+              when: "'no change' not in patch_status.stdout"
+              
+            - name: Identify the new jiva controller pod belonging to the PV
+              shell: > 
+                kubectl get pods -l openebs.io/controller=jiva-controller
+                -n {{ target_namespace }} --no-headers | grep {{ pv.stdout }} 
+                | awk '{print $1}'
+              args:
+                executable: /bin/bash
+              register: controller_pod_after
+
+            - name: Check for the jiva controller container status
+              shell: >
+                kubectl get pods {{ controller_pod_after.stdout }} -n {{ target_namespace }} 
+                -o jsonpath='{.status.containerStatuses[?(@.name=="{{ pv.stdout}}-ctrl-con")].state}' | grep running
+              args:
+                executable: /bin/bash
+              register: container_status
+              until: "'running' in container_status.stdout"
+              delay: 3
+              retries: 20
+                                      
+          when: stg_engine == 'jiva'
+
         - name: Create some test data
           include: "{{ data_consistency_util_path }}"
           vars:

--- a/experiments/chaos/openebs_target_network_delay/test.yml
+++ b/experiments/chaos/openebs_target_network_delay/test.yml
@@ -107,7 +107,7 @@
             - name: Identify the jiva controller pod name
               shell: >
                 kubectl get pods -l openebs.io/controller=jiva-controller
-                -n {{ namespace }} --no-headers | grep {{ pv.stdout }} 
+                -n {{ operator_ns }} --no-headers | grep {{ pv.stdout }} 
                 | awk '{print $1}' 
               args:
                 executable: /bin/bash
@@ -115,7 +115,7 @@
 
             - name: Patching jiva controller deployment to allow security privileged
               shell: >
-                kubectl patch deployment {{ pv.stdout }}-ctrl -n {{ namespace }}
+                kubectl patch deployment {{ pv.stdout }}-ctrl -n {{ operator_ns }}
                 --patch "$(cat patch.yml)"
               register: patch_status
               failed_when: "'patched' not in patch_status.stdout"
@@ -125,7 +125,7 @@
                 timeout: 10
 
             - name: Verify if the jiva controller pod is terminated
-              shell: kubectl get pods -n {{ namespace }}
+              shell: kubectl get pods -n {{ operator_ns }}
               args:
                 executable: /bin/bash
               register: pod_status
@@ -137,7 +137,7 @@
             - name: Identify the new jiva controller pod belonging to the PV
               shell: > 
                 kubectl get pods -l openebs.io/controller=jiva-controller
-                -n {{ namespace }} --no-headers | grep {{ pv.stdout }} 
+                -n {{ operator_ns }} --no-headers | grep {{ pv.stdout }} 
                 | awk '{print $1}'
               args:
                 executable: /bin/bash
@@ -145,7 +145,7 @@
 
             - name: Check for the jiva controller container status
               shell: >
-                kubectl get pods {{ controller_pod_after.stdout }} -n {{ namespace }} 
+                kubectl get pods {{ controller_pod_after.stdout }} -n {{ operator_ns }} 
                 -o jsonpath='{.status.containerStatuses[?(@.name=="{{ pv.stdout}}-ctrl-con")].state}' | grep running
               args:
                 executable: /bin/bash
@@ -180,7 +180,7 @@
           vars:
             status: "induce"
             target_pod: "{{ controller_pod_after.stdout }}"
-            operator_namespace: "{{ namespace }}"
+            operator_namespace: "{{ operator_ns }}"
             containername: "{{ pv.stdout }}-ctrl-con"
           when: 
             - cri == 'containerd' or cri =='cri-o'  
@@ -204,7 +204,7 @@
           vars:
             status: "remove"
             target_pod: "{{ controller_pod_after.stdout }}"
-            operator_namespace: "{{ namespace }}"
+            operator_namespace: "{{ operator_ns }}"
             containername: "{{ pv.stdout }}-ctrl-con"
           when: 
             - cri == 'containerd' or cri =='cri-o'  

--- a/experiments/chaos/replica_node_affinity/test.yml
+++ b/experiments/chaos/replica_node_affinity/test.yml
@@ -16,39 +16,52 @@
           vars:
             status: 'SOT'
 
+        - name: Obtain the volume name
+          shell: > 
+            kubectl get pvc {{ pvc_name }} -n {{ namespace }} --no-headers -o custom-columns=:.spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv_name
+
         - name: Getting replica-pod name
           shell: >
-            kubectl get pod -n {{ namespace }} -l openebs.io/replica=jiva-replica 
+            kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv_name.stdout }}" 
             -o jsonpath='{.items[0].metadata.name}'
+          args:
+            executable: /bin/bash
           register: rep_pod
 
         - name: Checking the status of replica pod
-          shell: kubectl get pod {{ rep_pod.stdout }} -n {{ namespace }} -o jsonpath='{.status.phase}'
+          shell: kubectl get pod {{ rep_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
           register: status
           until: "'Running' in status.stdout"
           delay: 30
           retries: 10
  
         - name: Getting the Node name on which replica-pod is scheduled
-          shell: kubectl get pod {{ rep_pod.stdout }} -n {{ namespace }} -o jsonpath='{.spec.nodeName}' 
+          shell: kubectl get pod {{ rep_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}' 
+          args:
+            executable: /bin/bash
           register: node
 
         - name: Obtaining the deployment name for the replica pod
           shell: >
-             kubectl get deployments -n {{ namespace }} -l openebs.io/replica=jiva-replica 
+             kubectl get deployments -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv_name.stdout }}" 
              -o jsonpath='{.items[0].metadata.name}' 
+          args:
+            executable: /bin/bash
           register: deployment_name
     
         - name: Checking the node affinity for replica-pod
           include_tasks: "/funclib/kubectl/pod_node_affinity.yml"
           vars:
-              ns: "{{ namespace }}"
+              ns: "{{ operator_ns }}"
               pod_name: "{{ rep_pod.stdout }}"
-              pod_label: "openebs.io/replica=jiva-replica"
+              pod_label: "openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name.stdout }}"
 
         - name: Checking the status of replica-pod
           shell: >
-             kubectl get pod {{ new_pod_name.stdout }} -n {{ namespace }} -o jsonpath='{.status.phase}'
+             kubectl get pod {{ new_pod_name.stdout }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
           until: "'Running' in status.stdout"
           delay: 30
           retries: 10      

--- a/experiments/chaos/replica_node_affinity/test_vars.yml
+++ b/experiments/chaos/replica_node_affinity/test_vars.yml
@@ -2,4 +2,4 @@ test_name: replica-pod-stickiness
 namespace: "{{ lookup('env','APP_NAMESPACE') }}" 
 app_label: "{{ lookup('env','APPLICATION_LABEL') }}"
 pvc_name: "{{ lookup('env','PVC_NAME') }}"
-
+operator_ns: 'openebs'

--- a/experiments/chaos/revision_counter/delete_replica.yml
+++ b/experiments/chaos/revision_counter/delete_replica.yml
@@ -1,6 +1,6 @@
 - name: Obtain the jiva replica pod scheduled on one node
   shell: >
-    kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+    kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
     -o jsonpath='{.items[?(@.spec.nodeName=="'{{ delete_rep_node }}'")].metadata.name}'
   args:
     executable: /bin/bash
@@ -9,7 +9,7 @@
 
 - name: Delete the replica pod of one node
   shell: >
-    kubectl delete pod "{{ replica_pod.stdout }}" -n {{ app_ns }}
+    kubectl delete pod "{{ replica_pod.stdout }}" -n {{ operator_ns }}
   args:
     executable: /bin/bash
   register: status
@@ -17,7 +17,7 @@
 
 - name: Verify if all the replica pods are in running state
   shell: >
-    kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+    kubectl get pods -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
     --no-headers -o custom-columns=:status.phase
   register: running_rep_status
   until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
@@ -26,7 +26,7 @@
 
 - name: Obtain one replica pod to check the revision counter value
   shell: >
-    kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+    kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
     -o jsonpath='{.items[?(@.spec.nodeName=="'{{ test_rep_node }}'")].metadata.name}'
   args:
     executable: /bin/bash
@@ -35,7 +35,7 @@
 
 - name: Verify the revision counter value
   shell: >
-    kubectl exec -ti "{{ replica_pod.stdout }}" -n {{ app_ns }} 
+    kubectl exec -ti "{{ replica_pod.stdout }}" -n {{ operator_ns }} 
     -- bash -c "du -h /openebs/revision.counter"
   args:
     executable: /bin/bash

--- a/experiments/chaos/revision_counter/test.yml
+++ b/experiments/chaos/revision_counter/test.yml
@@ -34,9 +34,17 @@
           register: app_pod
           failed_when: "app_pod.rc != 0"
 
+        - name: Obtain the persistent volume 
+          shell: >
+            kubectl get pvc -n {{ app_ns }} --no-headers -o custom-columns=:.spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv
+          failed_when: "pv.rc != 0"
+
         - name: Check for all replicas to be in Running state
           shell: >
-            kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
             --no-headers -o custom-columns=:status.phase
           register: running_rep_status
           until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
@@ -45,7 +53,7 @@
 
         - name: Obtain the nodes on which jiva replica pods are scheduled 
           shell: >
-            kubectl get pods -n {{ app_ns }} -l openebs.io/replica=jiva-replica
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
             --no-headers -o custom-columns=:.spec.nodeName
           args:
             executable: /bin/bash
@@ -87,7 +95,7 @@
 
         - name: Obtain one replica pod to verify consumed storage
           shell: >
-            kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
             -o jsonpath='{.items[?(@.spec.nodeName=="'{{ test_rep_node }}'")].metadata.name}'
           args:
             executable: /bin/bash
@@ -95,7 +103,7 @@
           failed_when: "replica_pod.rc != 0"
 
         - name: Obtain consumed storage size in one replica
-          shell: kubectl exec -ti {{ replica_pod.stdout }} -n {{ app_ns }} -- bash -c "du -h openebs"
+          shell: kubectl exec -ti {{ replica_pod.stdout }} -n {{ operator_ns }} -- bash -c "du -h openebs"
           args:
             executable: /bin/bash
           register: rep_pod_storage
@@ -103,7 +111,7 @@
 
         - name: Obtain the replica pod which was being deleted
           shell: >
-            kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
             -o jsonpath='{.items[?(@.spec.nodeName=="'{{ delete_rep_node }}'")].metadata.name}'
           args:
             executable: /bin/bash
@@ -111,7 +119,7 @@
           failed_when: "replica_pod_chaos.rc != 0"
                 
         - name: Verify consumed storage size in replica
-          shell: kubectl exec -ti {{ replica_pod_chaos.stdout }} -n {{ app_ns }} -- bash -c "du -h openebs"
+          shell: kubectl exec -ti {{ replica_pod_chaos.stdout }} -n {{ operator_ns }} -- bash -c "du -h openebs"
           args:
             executable: /bin/bash
           register: rep_size

--- a/experiments/chaos/revision_counter/test_vars.yml
+++ b/experiments/chaos/revision_counter/test_vars.yml
@@ -14,4 +14,6 @@ file_name: "{{ lookup('env','FILE_NAME') }}"
 
 mount_path: "{{ lookup('env','MOUNT_PATH') }}"
 
+operator_ns: 'openebs'
+
 test_name: "jiva-revision-counter"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified the litmus chaos experiments specific to jiva to incorporate following changes of jiva.

- All the jiva replica pod and controller pod will be in openebs namespace.
- Earlier jiva replica pods were controlled by single deployment now each jiva replica pod is controlled by separate deployment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #239
**Special notes for your reviewer**:
