### PR TITLE
fix[yaml]: Modified scale app replica to fix undefined variable operator_namespace

### DIFF
--- a/experiments/functional/jiva-volume-resize/test.yml
+++ b/experiments/functional/jiva-volume-resize/test.yml
@@ -78,15 +78,6 @@
           register: node_ip
           failed_when: "node_ip.rc != 0"
 
-        - name: Obtain the IP address of jiva controller pod
-          shell: >
-            kubectl get pod -n {{ app_ns }} -l openebs.io/controller=jiva-controller 
-            --no-headers -o custom-columns=:.status.podIP
-          args:
-            executable: /bin/bash
-          register: controller_ip
-          failed_when: "controller_ip.rc != 0"
-                  
         - name: Getting PV name from the pvc
           shell: >
             kubectl get pvc {{ app_pvc }} -n {{ app_ns }} 
@@ -96,6 +87,15 @@
           register: app_pv
           failed_when: "app_pv.rc != 0"
 
+        - name: Obtain the IP address of jiva controller pod
+          shell: >
+            kubectl get pod -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+            --no-headers -o custom-columns=:.status.podIP
+          args:
+            executable: /bin/bash
+          register: controller_ip
+          failed_when: "controller_ip.rc != 0"
+         
         - name: Obtain the daemonset pod corresponding to application pod
           shell: >
             kubectl get pod -l app=jiva-resize -o wide --no-headers -o 
@@ -169,7 +169,7 @@
         
         - name: Restart all the replica pods of jiva volume
           shell: >
-            kubectl delete pods -n "{{ app_ns }}" -l openebs.io/replica=jiva-replica --force --grace-period=0 
+            kubectl delete pods -n "{{ operator_ns }}" -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ app_pv.stdout }}" --force --grace-period=0 
           args:
             executable: /bin/bash
           register: status
@@ -177,7 +177,7 @@
 
         - name: Checking for all replicas to be in Running state
           shell: >
-            kubectl get pod -n {{ app_ns }} -l openebs.io/replica=jiva-replica 
+            kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
             --no-headers -o custom-columns=:status.phase
           register: running_rep_status
           until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
@@ -186,7 +186,7 @@
 
         - name: Obtain the iSCSI Target IP (controller service IP address)
           shell: >
-            kubectl get svc -n {{ app_ns }} -l openebs.io/controller-service=jiva-controller-svc 
+            kubectl get svc -n {{ operator_ns }} -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
             --no-headers -o custom-columns=:.spec.clusterIP
           args:
             executable: /bin/bash

--- a/experiments/functional/jiva-volume-resize/test_vars.yml
+++ b/experiments/functional/jiva-volume-resize/test_vars.yml
@@ -9,4 +9,6 @@ desired_size: "{{ lookup('env','NEW_CAPACITY') }}"
 
 vol_size: "{{ lookup('env','PV_CAPACITY') }}"
 
+operator_ns: 'openebs'
+
 test_name: jiva-volume-resize

--- a/experiments/functional/scale_app_replica/test.yml
+++ b/experiments/functional/scale_app_replica/test.yml
@@ -27,6 +27,8 @@
           # Including the scaleup_replicas utility from litmus funclib that handles scaling up the replicas.
 
         - include: /funclib/kubectl/scale_replicas.yml
+          vars:
+            operator_namespace: "{{ app_ns }}"
 
         - name: Forming one of the replicas name statefulset application name.
           set_fact:


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1. Modified scale app replica to fix undefined variable operator_namespace
Logs:
```
PLAY [localhost] ***************************************************************
2020-04-06T10:24:57.547028 (delta: 0.067685)         elapsed: 0.067685 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-06T10:24:57.562110 (delta: 0.015011)         elapsed: 0.082767 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID.] ********************************************
2020-04-06T10:25:06.121824 (delta: 8.559651)         elapsed: 8.642481 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID.] *********************************
2020-04-06T10:25:06.196629 (delta: 0.07473)         elapsed: 8.717286 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-06T10:25:06.273316 (delta: 0.076596)         elapsed: 8.793973 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-06T10:25:06.390836 (delta: 0.117309)         elapsed: 8.911493 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "eb81ff3aa351f54eae4d5a996b04f339d91af7ce", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8c03f44c2068ed656eb1156d1ab6e81b", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1586168706.46-214213654745664/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-06T10:25:07.219456 (delta: 0.828556)         elapsed: 9.740113 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.957517", "end": "2020-04-06 10:25:08.755506", "rc": 0, "start": "2020-04-06 10:25:07.797989", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: scale-app-replicas \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: scale-app-replicas ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-06T10:25:08.852589 (delta: 1.633048)         elapsed: 11.373246 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-06T10:08:43Z", "generation": 3, "name": "scale-app-replicas", "resourceVersion": "68277", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/scale-app-replicas", "uid": "f72f7599-b951-43af-a0ff-d41ae508e2df"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-06T10:25:10.199213 (delta: 1.346557)         elapsed: 12.71987 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-06T10:25:10.296010 (delta: 0.096715)         elapsed: 12.816667 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-06T10:25:10.373085 (delta: 0.076983)         elapsed: 12.893742 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtaining the application pod name.] *************************************
2020-04-06T10:25:10.458556 (delta: 0.085385)         elapsed: 12.979213 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get statefulset -n sam --no-headers -l app=busybox-sts -o custom-columns=:metadata.name", "delta": "0:00:01.158452", "end": "2020-04-06 10:25:11.857459", "rc": 0, "start": "2020-04-06 10:25:10.699007", "stderr": "", "stderr_lines": [], "stdout": "busybox", "stdout_lines": ["busybox"]}

TASK [Recording the application pod name.] *************************************
2020-04-06T10:25:11.921891 (delta: 1.463239)         elapsed: 14.442548 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_name": "busybox"}, "changed": false}

TASK [scaling up the replicas.] ************************************************
2020-04-06T10:25:12.040155 (delta: 0.118201)         elapsed: 14.560812 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl scale statefulset busybox --replicas=2 -n sam", "delta": "0:00:00.860951", "end": "2020-04-06 10:25:13.158340", "failed_when_result": false, "rc": 0, "start": "2020-04-06 10:25:12.297389", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps/busybox scaled", "stdout_lines": ["statefulset.apps/busybox scaled"]}

TASK [Check if all the application replicas are running.] **********************
2020-04-06T10:25:13.240488 (delta: 1.200268)         elapsed: 15.761145 ******* 
FAILED - RETRYING: Check if all the application replicas are running. (60 retries left).
FAILED - RETRYING: Check if all the application replicas are running. (59 retries left).
FAILED - RETRYING: Check if all the application replicas are running. (58 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get statefulset -n sam --no-headers -l app=busybox-sts -o custom-columns=:..readyReplicas", "delta": "0:00:01.122375", "end": "2020-04-06 10:25:48.816023", "rc": 0, "start": "2020-04-06 10:25:47.693648", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Forming one of the replicas name statefulset application name.] **********
2020-04-06T10:25:48.911986 (delta: 35.671385)         elapsed: 51.432643 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "busybox-0"}, "changed": false}

TASK [Obtaining the rack name from nodetool.] **********************************
2020-04-06T10:25:49.042047 (delta: 0.130001)         elapsed: 51.562704 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec busybox-0 -n sam -- nodetool info | grep 'Rack' | awk '{print $3}'", "delta": "0:00:01.077277", "end": "2020-04-06 10:25:50.342233", "rc": 0, "start": "2020-04-06 10:25:49.264956", "stderr": "command terminated with exit code 126", "stderr_lines": ["command terminated with exit code 126"], "stdout": "", "stdout_lines": []}

TASK [Checking data distribution percentage using nodetool.] *******************
2020-04-06T10:25:50.420986 (delta: 1.37887)         elapsed: 52.941643 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec busybox-0 -n sam -- nodetool status | grep  | awk '{print $6}'", "delta": "0:00:01.240814", "end": "2020-04-06 10:25:51.927720", "rc": 0, "start": "2020-04-06 10:25:50.686906", "stderr": "Usage: grep [OPTION]... PATTERN [FILE]...\nTry 'grep --help' for more information.", "stderr_lines": ["Usage: grep [OPTION]... PATTERN [FILE]...", "Try 'grep --help' for more information."], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2020-04-06T10:25:52.003005 (delta: 1.581915)         elapsed: 54.523662 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-04-06T10:25:52.114049 (delta: 0.110988)         elapsed: 54.634706 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-06T10:25:52.238487 (delta: 0.124369)         elapsed: 54.759144 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-06T10:25:52.309379 (delta: 0.070823)         elapsed: 54.830036 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-06T10:25:52.381702 (delta: 0.072238)         elapsed: 54.902359 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-06T10:25:52.449696 (delta: 0.067917)         elapsed: 54.970353 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "90a2e4a4074c38e4d5bb4fe105499a658e239490", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "82752bf2568927931ebf9833eeefc41d", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1586168752.52-9129768492831/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-06T10:25:54.533682 (delta: 2.083908)         elapsed: 57.054339 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.793264", "end": "2020-04-06 10:25:55.551229", "rc": 0, "start": "2020-04-06 10:25:54.757965", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: scale-app-replicas \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: scale-app-replicas ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-06T10:25:55.619574 (delta: 1.085802)         elapsed: 58.140231 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-06T10:08:43Z", "generation": 4, "name": "scale-app-replicas", "resourceVersion": "68618", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/scale-app-replicas", "uid": "f72f7599-b951-43af-a0ff-d41ae508e2df"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=17   changed=11   unreachable=0    failed=0   

2020-04-06T10:25:56.761156 (delta: 1.140519)         elapsed: 59.281813 ******* 
=============================================================================== 
```