### PR TITLE
Refactor backup and restore test to fix missing edge case

### DIFF
--- a/experiments/functional/backup_and_restore/test.yml
+++ b/experiments/functional/backup_and_restore/test.yml
@@ -117,7 +117,7 @@
           vars:
             back_up_name: "{{ backup_name }}"
             action: 'SNAPSHOT_DELETE'
-          when: "storage_engine == 'cstor' and lookup('env','COMPONENT_FAILURE') == ''"
+          when: "storage_engine == 'cstor' and lookup('env','COMPONENT_FAILURE') == '' and lookup('env','LOCAL_SNAPSHOT') == 'false'"
 
         - block:
 


### PR DESCRIPTION
Signed-off-by: shashank855 <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Verify for local snapshot deletion when not performing backup-restore using local snapshot. 

**Following is the log of ansible test container**
```

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/backup_and_restore/test.yml

PLAY [localhost] ***************************************************************
2020-04-07T08:26:26.825048 (delta: 0.136176)         elapsed: 0.136176 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:1
2020-04-07T08:26:26.876088 (delta: 0.051)         elapsed: 0.187216 *********** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:12
2020-04-07T08:26:39.010437 (delta: 12.134302)         elapsed: 12.321565 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-04-07T08:26:39.138827 (delta: 0.128162)         elapsed: 12.449955 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-04-07T08:26:39.235890 (delta: 0.09699)         elapsed: 12.547018 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:15
2020-04-07T08:26:39.326506 (delta: 0.090537)         elapsed: 12.637634 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-07T08:26:39.480739 (delta: 0.154026)         elapsed: 12.791867 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cb23761ee0ecfea3a093f94c0443739c777b3007", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0da5664e16958d4f3c263662ebe36b5c", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1586247999.56-225147635187147/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-07T08:26:40.396271 (delta: 0.915425)         elapsed: 13.707399 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.104244", "end": "2020-04-07 08:26:41.941647", "rc": 0, "start": "2020-04-07 08:26:40.837403", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-07T08:26:42.014619 (delta: 1.618276)         elapsed: 15.325747 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-07T08:26:43Z", "generation": 1, "name": "velero-backup-restore", "resourceVersion": "21053", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "b00833bd-4fd6-4b29-9c0b-78804d6b3611"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-07T08:26:43.569193 (delta: 1.554459)         elapsed: 16.880321 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-07T08:26:43.734263 (delta: 0.164988)         elapsed: 17.045391 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-07T08:26:43.848265 (delta: 0.113817)         elapsed: 17.159393 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /experiments/functional/backup_and_restore/test.yml:19
2020-04-07T08:26:43.940556 (delta: 0.091935)         elapsed: 17.251684 ******* 
included: /utils/k8s/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /utils/k8s/check_deployment_status.yml:8
2020-04-07T08:26:44.112866 (delta: 0.170166)         elapsed: 17.423994 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.441614", "end": "2020-04-07 08:26:45.821226", "rc": 0, "start": "2020-04-07 08:26:44.379612", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /utils/k8s/check_deployment_status.yml:22
2020-04-07T08:26:45.931842 (delta: 1.818879)         elapsed: 19.24297 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /utils/k8s/check_deployment_status.yml:29
2020-04-07T08:26:46.202077 (delta: 0.270071)         elapsed: 19.513205 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:22
2020-04-07T08:26:46.313799 (delta: 0.111259)         elapsed: 19.624927 ******* 
included: /experiments/functional/backup_and_restore/setup_dependency.yml for 127.0.0.1

TASK [Downloading velero binary] ***********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:1
2020-04-07T08:26:46.571019 (delta: 0.257026)         elapsed: 19.882147 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "30e3e5cdaf2df32b84472dc0ab1fa1ae591aae40", "dest": "./velero-v1.3.0-linux-amd64.tar.gz", "gid": 0, "group": "root", "md5sum": "b45cbd835a139e4c3ed5b56309dcf22d", "mode": "0644", "msg": "OK (24524254 bytes)", "owner": "root", "size": 24524254, "src": "/root/.ansible/tmp/ansible-tmp-1586248006.66-160408936136598/tmpkdVRwN", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/vmware-tanzu/velero/releases/download/v1.3.0/velero-v1.3.0-linux-amd64.tar.gz"}

TASK [Installing velero inside litmus container] *******************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:11
2020-04-07T08:26:54.188818 (delta: 7.615457)         elapsed: 27.499946 ******* 
 [WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"changed": true, "cmd": "tar -xvf velero-v1.3.0-linux-amd64.tar.gz\n mv velero-v1.3.0-linux-amd64/velero /usr/local/bin/", "delta": "0:00:02.480438", "end": "2020-04-07 08:26:56.927631", "rc": 0, "start": "2020-04-07 08:26:54.447193", "stderr": "", "stderr_lines": [], "stdout": "velero-v1.3.0-linux-amd64/LICENSE\nvelero-v1.3.0-linux-amd64/examples/README.md\nvelero-v1.3.0-linux-amd64/examples/minio\nvelero-v1.3.0-linux-amd64/examples/minio/00-minio-deployment.yaml\nvelero-v1.3.0-linux-amd64/examples/nginx-app\nvelero-v1.3.0-linux-amd64/examples/nginx-app/README.md\nvelero-v1.3.0-linux-amd64/examples/nginx-app/base.yaml\nvelero-v1.3.0-linux-amd64/examples/nginx-app/with-pv.yaml\nvelero-v1.3.0-linux-amd64/velero", "stdout_lines": ["velero-v1.3.0-linux-amd64/LICENSE", "velero-v1.3.0-linux-amd64/examples/README.md", "velero-v1.3.0-linux-amd64/examples/minio", "velero-v1.3.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "velero-v1.3.0-linux-amd64/examples/nginx-app", "velero-v1.3.0-linux-amd64/examples/nginx-app/README.md", "velero-v1.3.0-linux-amd64/examples/nginx-app/base.yaml", "velero-v1.3.0-linux-amd64/examples/nginx-app/with-pv.yaml", "velero-v1.3.0-linux-amd64/velero"]}

TASK [Checking the velero version] *********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:16
2020-04-07T08:26:57.206023 (delta: 3.017127)         elapsed: 30.517151 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero version", "delta": "0:00:01.142038", "end": "2020-04-07 08:26:58.859211", "failed_when_result": false, "rc": 0, "start": "2020-04-07 08:26:57.717173", "stderr": "", "stderr_lines": [], "stdout": "Client:\n\tVersion: v1.3.0\n\tGit commit: 8fec8ed7fb8b4776b191753497eafeb47f2f9136\n<error getting server version: the server could not find the requested resource (post serverstatusrequests.velero.io)>", "stdout_lines": ["Client:", "\tVersion: v1.3.0", "\tGit commit: 8fec8ed7fb8b4776b191753497eafeb47f2f9136", "<error getting server version: the server could not find the requested resource (post serverstatusrequests.velero.io)>"]}

TASK [Installing minio s3-bucket] **********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:23
2020-04-07T08:26:58.945717 (delta: 1.739626)         elapsed: 32.256845 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f velero-v1.3.0-linux-amd64/examples/minio/00-minio-deployment.yaml", "delta": "0:00:01.746472", "end": "2020-04-07 08:27:00.975362", "rc": 0, "start": "2020-04-07 08:26:59.228890", "stderr": "", "stderr_lines": [], "stdout": "namespace/velero created\ndeployment.apps/minio created\nservice/minio created\njob.batch/minio-setup created", "stdout_lines": ["namespace/velero created", "deployment.apps/minio created", "service/minio created", "job.batch/minio-setup created"]}

TASK [Checking for minio pod status] *******************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:26
2020-04-07T08:27:01.103158 (delta: 2.157362)         elapsed: 34.414286 ******* 
FAILED - RETRYING: Checking for minio pod status (15 retries left).
FAILED - RETRYING: Checking for minio pod status (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod -n velero -l component=minio -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:02.044734", "end": "2020-04-07 08:27:18.382183", "rc": 0, "start": "2020-04-07 08:27:16.337449", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Waiting for minio job to create bucket] **********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:33
2020-04-07T08:27:18.714990 (delta: 17.611758)         elapsed: 52.026118 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l job-name=minio-setup -o jsonpath='{.items[*].status.phase}'", "delta": "0:00:01.188641", "end": "2020-04-07 08:27:20.249416", "rc": 0, "start": "2020-04-07 08:27:19.060775", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Fetching service account key.json from configmap] ************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:44
2020-04-07T08:27:20.348140 (delta: 1.633076)         elapsed: 53.659268 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Authenticating using gcp service account] ********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:47
2020-04-07T08:27:20.476712 (delta: 0.128493)         elapsed: 53.78784 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Setting up the project ID] ***********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:50
2020-04-07T08:27:20.595070 (delta: 0.118265)         elapsed: 53.906198 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting GCP bucket if exist] ********************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:53
2020-04-07T08:27:20.690112 (delta: 0.093589)         elapsed: 54.00124 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating gcp bucket] *****************************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:59
2020-04-07T08:27:20.823834 (delta: 0.133652)         elapsed: 54.134962 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:68
2020-04-07T08:27:20.930570 (delta: 0.106664)         elapsed: 54.241698 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:79
2020-04-07T08:27:21.026397 (delta: 0.095712)         elapsed: 54.337525 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:95
2020-04-07T08:27:21.108894 (delta: 0.082425)         elapsed: 54.420022 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:105
2020-04-07T08:27:21.198016 (delta: 0.088946)         elapsed: 54.509144 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching restic demonset for privileged access] **************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:118
2020-04-07T08:27:21.311660 (delta: 0.113575)         elapsed: 54.622788 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the number of compute nodes] *************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:123
2020-04-07T08:27:21.415996 (delta: 0.104246)         elapsed: 54.727124 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status of restic demonset pods] *****************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:127
2020-04-07T08:27:21.571228 (delta: 0.155148)         elapsed: 54.882356 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:140
2020-04-07T08:27:21.659611 (delta: 0.088314)         elapsed: 54.970739 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:150
2020-04-07T08:27:21.777160 (delta: 0.117478)         elapsed: 55.088288 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero install --provider aws --bucket velero --secret-file ./credentials-velero --use-volume-snapshots=false --plugins velero/velero-plugin-for-aws:v1.0.0 --backup-location-config region=minio,s3ForcePathStyle=\"true\",s3Url=http://minio.velero.svc:9000", "delta": "0:00:05.026003", "end": "2020-04-07 08:27:27.089878", "rc": 0, "start": "2020-04-07 08:27:22.063875", "stderr": "", "stderr_lines": [], "stdout": "CustomResourceDefinition/backups.velero.io: attempting to create resource\nCustomResourceDefinition/backups.velero.io: created\nCustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource\nCustomResourceDefinition/backupstoragelocations.velero.io: created\nCustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource\nCustomResourceDefinition/deletebackuprequests.velero.io: created\nCustomResourceDefinition/downloadrequests.velero.io: attempting to create resource\nCustomResourceDefinition/downloadrequests.velero.io: created\nCustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumebackups.velero.io: created\nCustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource\nCustomResourceDefinition/podvolumerestores.velero.io: created\nCustomResourceDefinition/resticrepositories.velero.io: attempting to create resource\nCustomResourceDefinition/resticrepositories.velero.io: created\nCustomResourceDefinition/restores.velero.io: attempting to create resource\nCustomResourceDefinition/restores.velero.io: created\nCustomResourceDefinition/schedules.velero.io: attempting to create resource\nCustomResourceDefinition/schedules.velero.io: created\nCustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource\nCustomResourceDefinition/serverstatusrequests.velero.io: created\nCustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource\nCustomResourceDefinition/volumesnapshotlocations.velero.io: created\nWaiting for resources to be ready in cluster...\nNamespace/velero: attempting to create resource\nNamespace/velero: already exists, proceeding\nNamespace/velero: created\nClusterRoleBinding/velero: attempting to create resource\nClusterRoleBinding/velero: created\nServiceAccount/velero: attempting to create resource\nServiceAccount/velero: created\nSecret/cloud-credentials: attempting to create resource\nSecret/cloud-credentials: created\nBackupStorageLocation/default: attempting to create resource\nBackupStorageLocation/default: created\nDeployment/velero: attempting to create resource\nDeployment/velero: created\nVelero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status.", "stdout_lines": ["CustomResourceDefinition/backups.velero.io: attempting to create resource", "CustomResourceDefinition/backups.velero.io: created", "CustomResourceDefinition/backupstoragelocations.velero.io: attempting to create resource", "CustomResourceDefinition/backupstoragelocations.velero.io: created", "CustomResourceDefinition/deletebackuprequests.velero.io: attempting to create resource", "CustomResourceDefinition/deletebackuprequests.velero.io: created", "CustomResourceDefinition/downloadrequests.velero.io: attempting to create resource", "CustomResourceDefinition/downloadrequests.velero.io: created", "CustomResourceDefinition/podvolumebackups.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumebackups.velero.io: created", "CustomResourceDefinition/podvolumerestores.velero.io: attempting to create resource", "CustomResourceDefinition/podvolumerestores.velero.io: created", "CustomResourceDefinition/resticrepositories.velero.io: attempting to create resource", "CustomResourceDefinition/resticrepositories.velero.io: created", "CustomResourceDefinition/restores.velero.io: attempting to create resource", "CustomResourceDefinition/restores.velero.io: created", "CustomResourceDefinition/schedules.velero.io: attempting to create resource", "CustomResourceDefinition/schedules.velero.io: created", "CustomResourceDefinition/serverstatusrequests.velero.io: attempting to create resource", "CustomResourceDefinition/serverstatusrequests.velero.io: created", "CustomResourceDefinition/volumesnapshotlocations.velero.io: attempting to create resource", "CustomResourceDefinition/volumesnapshotlocations.velero.io: created", "Waiting for resources to be ready in cluster...", "Namespace/velero: attempting to create resource", "Namespace/velero: already exists, proceeding", "Namespace/velero: created", "ClusterRoleBinding/velero: attempting to create resource", "ClusterRoleBinding/velero: created", "ServiceAccount/velero: attempting to create resource", "ServiceAccount/velero: created", "Secret/cloud-credentials: attempting to create resource", "Secret/cloud-credentials: created", "BackupStorageLocation/default: attempting to create resource", "BackupStorageLocation/default: created", "Deployment/velero: attempting to create resource", "Deployment/velero: created", "Velero is installed! ? Use 'kubectl logs deployment/velero -n velero' to view the status."]}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:165
2020-04-07T08:27:27.199779 (delta: 5.42253)         elapsed: 60.510907 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Installing velero server inside cluster] *********************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:174
2020-04-07T08:27:27.387340 (delta: 0.18747)         elapsed: 60.698468 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for velero server status] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:188
2020-04-07T08:27:27.595079 (delta: 0.207498)         elapsed: 60.906207 ******* 
FAILED - RETRYING: Checking for velero server status (20 retries left).
FAILED - RETRYING: Checking for velero server status (19 retries left).
FAILED - RETRYING: Checking for velero server status (18 retries left).
FAILED - RETRYING: Checking for velero server status (17 retries left).
FAILED - RETRYING: Checking for velero server status (16 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.227892", "end": "2020-04-07 08:28:05.493286", "rc": 0, "start": "2020-04-07 08:28:04.265394", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Creating volume snapshot location] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:197
2020-04-07T08:28:05.581035 (delta: 37.985876)         elapsed: 98.892163 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating volume snapshot location] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:203
2020-04-07T08:28:05.700327 (delta: 0.119174)         elapsed: 99.011455 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating volume snapshot location] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:209
2020-04-07T08:28:05.831944 (delta: 0.131542)         elapsed: 99.143072 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f local-volume-snapshot-location.yml", "delta": "0:00:02.326468", "end": "2020-04-07 08:28:08.549566", "failed_when_result": false, "rc": 0, "start": "2020-04-07 08:28:06.223098", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotlocation.velero.io/local created", "stdout_lines": ["volumesnapshotlocation.velero.io/local created"]}

TASK [Installing development image of OpenEBS velero-plugin] *******************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:215
2020-04-07T08:28:08.652693 (delta: 2.820662)         elapsed: 101.963821 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero plugin add openebs/velero-plugin:ci", "delta": "0:00:01.151167", "end": "2020-04-07 08:28:10.205091", "rc": 0, "start": "2020-04-07 08:28:09.053924", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Waiting for new velero server pod to come up] ****************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:219
2020-04-07T08:28:10.280412 (delta: 1.627634)         elapsed: 103.59154 ******* 
FAILED - RETRYING: Waiting for new velero server pod to come up (20 retries left).
FAILED - RETRYING: Waiting for new velero server pod to come up (19 retries left).
FAILED - RETRYING: Waiting for new velero server pod to come up (18 retries left).
FAILED - RETRYING: Waiting for new velero server pod to come up (17 retries left).
FAILED - RETRYING: Waiting for new velero server pod to come up (16 retries left).
FAILED - RETRYING: Waiting for new velero server pod to come up (15 retries left).
FAILED - RETRYING: Waiting for new velero server pod to come up (14 retries left).
changed: [127.0.0.1] => {"attempts": 8, "changed": true, "cmd": "kubectl get pod -n velero --no-headers -l deploy=velero | wc -l", "delta": "0:00:01.419376", "end": "2020-04-07 08:28:58.710534", "rc": 0, "start": "2020-04-07 08:28:57.291158", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Checking for velero server status] ***************************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:228
2020-04-07T08:28:58.831129 (delta: 48.550649)         elapsed: 152.142257 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.phase}'", "delta": "0:00:01.215886", "end": "2020-04-07 08:29:00.313292", "rc": 0, "start": "2020-04-07 08:28:59.097406", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking for velero server container status] *****************************
task path: /experiments/functional/backup_and_restore/setup_dependency.yml:235
2020-04-07T08:29:00.400637 (delta: 1.569438)         elapsed: 153.711765 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l component=velero -ojsonpath='{.items[0].status.containerStatuses[0].ready}'", "delta": "0:00:01.417486", "end": "2020-04-07 08:29:02.098094", "rc": 0, "start": "2020-04-07 08:29:00.680608", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Get Application pod details] *********************************************
task path: /experiments/functional/backup_and_restore/test.yml:24
2020-04-07T08:29:02.193559 (delta: 1.792825)         elapsed: 155.504687 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.201937", "end": "2020-04-07 08:29:03.672032", "rc": 0, "start": "2020-04-07 08:29:02.470095", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-5kqbq", "stdout_lines": ["percona-8568b6cc96-5kqbq"]}

TASK [Create new database in the mysql] ****************************************
task path: /experiments/functional/backup_and_restore/test.yml:28
2020-04-07T08:29:03.755645 (delta: 1.561993)         elapsed: 157.066773 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-04-07T08:29:03.969611 (delta: 0.213865)         elapsed: 157.280739 ****** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;') => {"changed": true, "cmd": "kubectl exec percona-8568b6cc96-5kqbq -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database backup;'", "delta": "0:00:01.628403", "end": "2020-04-07 08:29:05.885744", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "rc": 0, "start": "2020-04-07 08:29:04.257341", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup) => {"changed": true, "cmd": "kubectl exec percona-8568b6cc96-5kqbq -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "delta": "0:00:02.415995", "end": "2020-04-07 08:29:08.579019", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "rc": 0, "start": "2020-04-07 08:29:06.163024", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup) => {"changed": true, "cmd": "kubectl exec percona-8568b6cc96-5kqbq -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "delta": "0:00:01.781146", "end": "2020-04-07 08:29:10.654287", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "rc": 0, "start": "2020-04-07 08:29:08.873141", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-04-07T08:29:10.777178 (delta: 6.807491)         elapsed: 164.088306 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-04-07T08:29:11.053978 (delta: 0.276727)         elapsed: 164.365106 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-04-07T08:29:11.166708 (delta: 0.112611)         elapsed: 164.477836 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-04-07T08:29:11.249251 (delta: 0.082468)         elapsed: 164.560379 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-04-07T08:29:11.347195 (delta: 0.097871)         elapsed: 164.658323 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-04-07T08:29:11.429750 (delta: 0.082456)         elapsed: 164.740878 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-04-07T08:29:11.504455 (delta: 0.074635)         elapsed: 164.815583 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-04-07T08:29:11.580749 (delta: 0.076226)         elapsed: 164.891877 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-04-07T08:29:11.662337 (delta: 0.08146)         elapsed: 164.973465 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-04-07T08:29:11.745730 (delta: 0.083311)         elapsed: 165.056858 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application mount point] *************************************
task path: /experiments/functional/backup_and_restore/test.yml:40
2020-04-07T08:29:11.835329 (delta: 0.089508)         elapsed: 165.146457 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Writing data on application mount point] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:45
2020-04-07T08:29:11.928518 (delta: 0.093057)         elapsed: 165.239646 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application deployment name] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:52
2020-04-07T08:29:12.021913 (delta: 0.092052)         elapsed: 165.333041 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Fetching the volume name of application] *********************************
task path: /experiments/functional/backup_and_restore/test.yml:56
2020-04-07T08:29:12.112516 (delta: 0.09053)         elapsed: 165.423644 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Annotating the application pod] ******************************************
task path: /experiments/functional/backup_and_restore/test.yml:61
2020-04-07T08:29:12.212176 (delta: 0.099594)         elapsed: 165.523304 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup for the provided application] ****************************
task path: /experiments/functional/backup_and_restore/test.yml:66
2020-04-07T08:29:12.302572 (delta: 0.09028)         elapsed: 165.6137 ********* 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup using minio bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2020-04-07T08:29:12.633347 (delta: 0.330641)         elapsed: 165.944475 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:13
2020-04-07T08:29:12.733148 (delta: 0.099738)         elapsed: 166.044276 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:20
2020-04-07T08:29:12.836856 (delta: 0.103644)         elapsed: 166.147984 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero backup create percona-backup --include-namespaces=app-percona-ns --snapshot-volumes --volume-snapshot-locations=local", "delta": "0:00:01.041260", "end": "2020-04-07 08:29:14.129086", "rc": 0, "start": "2020-04-07 08:29:13.087826", "stderr": "", "stderr_lines": [], "stdout": "Backup request \"percona-backup\" submitted successfully.\nRun `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details.", "stdout_lines": ["Backup request \"percona-backup\" submitted successfully.", "Run `velero backup describe percona-backup` or `velero backup logs percona-backup` for more details."]}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:31
2020-04-07T08:29:14.208559 (delta: 1.371375)         elapsed: 167.519687 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:41
2020-04-07T08:29:14.333913 (delta: 0.125285)         elapsed: 167.645041 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using minio bucket] ************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:54
2020-04-07T08:29:14.463403 (delta: 0.129389)         elapsed: 167.774531 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using GCP bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:58
2020-04-07T08:29:14.548847 (delta: 0.085367)         elapsed: 167.859975 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:66
2020-04-07T08:29:14.643325 (delta: 0.094093)         elapsed: 167.954453 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:79
2020-04-07T08:29:14.739646 (delta: 0.096246)         elapsed: 168.050774 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:85
2020-04-07T08:29:14.889514 (delta: 0.14962)         elapsed: 168.200642 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:95
2020-04-07T08:29:15.016074 (delta: 0.12096)         elapsed: 168.327202 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:107
2020-04-07T08:29:15.133447 (delta: 0.117304)         elapsed: 168.444575 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:111
2020-04-07T08:29:15.218549 (delta: 0.084968)         elapsed: 168.529677 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:75
2020-04-07T08:29:15.312283 (delta: 0.093231)         elapsed: 168.623411 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the backup name] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:79
2020-04-07T08:29:15.403098 (delta: 0.090294)         elapsed: 168.714226 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of backup] *********************************************
task path: /experiments/functional/backup_and_restore/test.yml:83
2020-04-07T08:29:15.492255 (delta: 0.089048)         elapsed: 168.803383 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:90
2020-04-07T08:29:15.579229 (delta: 0.086905)         elapsed: 168.890357 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Waiting for completed backup] ********************************************
task path: /experiments/functional/backup_and_restore/test.yml:95
2020-04-07T08:29:15.665667 (delta: 0.086365)         elapsed: 168.976795 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the base backup name] ********************************************
task path: /experiments/functional/backup_and_restore/test.yml:102
2020-04-07T08:29:15.753981 (delta: 0.088214)         elapsed: 169.065109 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting state of backup] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:108
2020-04-07T08:29:15.856317 (delta: 0.102215)         elapsed: 169.167445 ****** 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup using minio bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2020-04-07T08:29:16.185178 (delta: 0.32879)         elapsed: 169.496306 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:13
2020-04-07T08:29:16.270431 (delta: 0.085183)         elapsed: 169.581559 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:20
2020-04-07T08:29:16.375838 (delta: 0.105334)         elapsed: 169.686966 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:31
2020-04-07T08:29:16.539253 (delta: 0.163342)         elapsed: 169.850381 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:41
2020-04-07T08:29:16.642937 (delta: 0.103618)         elapsed: 169.954065 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using minio bucket] ************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:54
2020-04-07T08:29:16.809240 (delta: 0.166233)         elapsed: 170.120368 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using GCP bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:58
2020-04-07T08:29:17.029267 (delta: 0.219947)         elapsed: 170.340395 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:66
2020-04-07T08:29:17.143797 (delta: 0.114456)         elapsed: 170.454925 ****** 
FAILED - RETRYING: Getting the state of Backup (100 retries left).
FAILED - RETRYING: Getting the state of Backup (99 retries left).
FAILED - RETRYING: Getting the state of Backup (98 retries left).
changed: [127.0.0.1] => {"attempts": 4, "changed": true, "cmd": "kubectl get backup percona-backup -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.429338", "end": "2020-04-07 08:29:38.629129", "rc": 0, "start": "2020-04-07 08:29:37.199791", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:79
2020-04-07T08:29:38.717160 (delta: 21.57328)         elapsed: 192.028288 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:85
2020-04-07T08:29:38.792125 (delta: 0.074894)         elapsed: 192.103253 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:95
2020-04-07T08:29:38.875308 (delta: 0.083112)         elapsed: 192.186436 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:107
2020-04-07T08:29:38.955405 (delta: 0.080027)         elapsed: 192.266533 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:111
2020-04-07T08:29:39.046441 (delta: 0.090962)         elapsed: 192.357569 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verifying for local snaphot deletion] ************************************
task path: /experiments/functional/backup_and_restore/test.yml:115
2020-04-07T08:29:39.124714 (delta: 0.078202)         elapsed: 192.435842 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deleting Application] ****************************************************
task path: /experiments/functional/backup_and_restore/test.yml:124
2020-04-07T08:29:39.216297 (delta: 0.091503)         elapsed: 192.527425 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking whether namespace is deleted] ***********************************
task path: /experiments/functional/backup_and_restore/test.yml:129
2020-04-07T08:29:39.338325 (delta: 0.121941)         elapsed: 192.649453 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring Application] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:146
2020-04-07T08:29:39.459453 (delta: 0.12104)         elapsed: 192.770581 ******* 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup using minio bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2020-04-07T08:29:39.639720 (delta: 0.180193)         elapsed: 192.950848 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:13
2020-04-07T08:29:39.733612 (delta: 0.093796)         elapsed: 193.04474 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:20
2020-04-07T08:29:39.814892 (delta: 0.081185)         elapsed: 193.12602 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:31
2020-04-07T08:29:39.901609 (delta: 0.086646)         elapsed: 193.212737 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:41
2020-04-07T08:29:39.985788 (delta: 0.084107)         elapsed: 193.296916 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using minio bucket] ************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:54
2020-04-07T08:29:40.072480 (delta: 0.086619)         elapsed: 193.383608 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using GCP bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:58
2020-04-07T08:29:40.180623 (delta: 0.108074)         elapsed: 193.491751 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:66
2020-04-07T08:29:40.317658 (delta: 0.136964)         elapsed: 193.628786 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:79
2020-04-07T08:29:40.449834 (delta: 0.132103)         elapsed: 193.760962 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:85
2020-04-07T08:29:40.604527 (delta: 0.154621)         elapsed: 193.915655 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:95
2020-04-07T08:29:40.695506 (delta: 0.090907)         elapsed: 194.006634 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero restore create --from-backup percona-backup --restore-volumes=true --namespace-mappings app-percona-ns:app-percona-ns-local", "delta": "0:00:01.109001", "end": "2020-04-07 08:29:42.090741", "rc": 0, "start": "2020-04-07 08:29:40.981740", "stderr": "", "stderr_lines": [], "stdout": "Restore request \"percona-backup-20200407082942\" submitted successfully.\nRun `velero restore describe percona-backup-20200407082942` or `velero restore logs percona-backup-20200407082942` for more details.", "stdout_lines": ["Restore request \"percona-backup-20200407082942\" submitted successfully.", "Run `velero restore describe percona-backup-20200407082942` or `velero restore logs percona-backup-20200407082942` for more details."]}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:107
2020-04-07T08:29:42.166156 (delta: 1.470579)         elapsed: 195.477284 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:111
2020-04-07T08:29:42.262644 (delta: 0.096405)         elapsed: 195.573772 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting state of restore] ************************************************
task path: /experiments/functional/backup_and_restore/test.yml:152
2020-04-07T08:29:42.348152 (delta: 0.085443)         elapsed: 195.65928 ******* 
included: /experiments/functional/backup_and_restore/backup-restore.yml for 127.0.0.1

TASK [Creating Backup using minio bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:6
2020-04-07T08:29:42.518407 (delta: 0.169917)         elapsed: 195.829535 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:13
2020-04-07T08:29:42.609447 (delta: 0.090718)         elapsed: 195.920575 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup using GCP bucket] ****************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:20
2020-04-07T08:29:42.742641 (delta: 0.130094)         elapsed: 196.053769 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:31
2020-04-07T08:29:42.895868 (delta: 0.153085)         elapsed: 196.206996 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating Backup] *********************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:41
2020-04-07T08:29:43.061550 (delta: 0.165609)         elapsed: 196.372678 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using minio bucket] ************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:54
2020-04-07T08:29:43.444222 (delta: 0.382592)         elapsed: 196.75535 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating schedule using GCP bucket] **************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:58
2020-04-07T08:29:43.770248 (delta: 0.323758)         elapsed: 197.081376 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the state of Backup] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:66
2020-04-07T08:29:43.893125 (delta: 0.1228)         elapsed: 197.204253 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Creating application namespace] ******************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:79
2020-04-07T08:29:44.007392 (delta: 0.114196)         elapsed: 197.31852 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:85
2020-04-07T08:29:44.097696 (delta: 0.09023)         elapsed: 197.408824 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restoring application] ***************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:95
2020-04-07T08:29:44.259193 (delta: 0.161426)         elapsed: 197.570321 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting restore name] ****************************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:107
2020-04-07T08:29:44.356725 (delta: 0.097449)         elapsed: 197.667853 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "velero get restore | grep percona-backup | awk '{print $1}'", "delta": "0:00:01.345605", "end": "2020-04-07 08:29:46.199573", "rc": 0, "start": "2020-04-07 08:29:44.853968", "stderr": "", "stderr_lines": [], "stdout": "percona-backup-20200407082942", "stdout_lines": ["percona-backup-20200407082942"]}

TASK [Checking the restore status] *********************************************
task path: /experiments/functional/backup_and_restore/backup-restore.yml:111
2020-04-07T08:29:46.278136 (delta: 1.92134)         elapsed: 199.589264 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get restore percona-backup-20200407082942 -n velero -o jsonpath='{.status.phase}'", "delta": "0:00:01.755872", "end": "2020-04-07 08:29:48.389501", "rc": 0, "start": "2020-04-07 08:29:46.633629", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Restoring Application] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:162
2020-04-07T08:29:48.467805 (delta: 2.1896)         elapsed: 201.778933 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting state of restore] ************************************************
task path: /experiments/functional/backup_and_restore/test.yml:168
2020-04-07T08:29:48.565016 (delta: 0.09712)         elapsed: 201.876144 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the volume name] *************************************************
task path: /experiments/functional/backup_and_restore/test.yml:178
2020-04-07T08:29:48.658969 (delta: 0.093882)         elapsed: 201.970097 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the target IP] ***************************************************
task path: /experiments/functional/backup_and_restore/test.yml:182
2020-04-07T08:29:48.758954 (delta: 0.099914)         elapsed: 202.070082 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the CVR name from the corresponding PV] **************************
task path: /experiments/functional/backup_and_restore/test.yml:189
2020-04-07T08:29:48.869250 (delta: 0.110226)         elapsed: 202.180378 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Geting the CSP name corresponding to CVR] ********************************
task path: /experiments/functional/backup_and_restore/test.yml:193
2020-04-07T08:29:49.026692 (delta: 0.157373)         elapsed: 202.33782 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the pool pod name] ***********************************************
task path: /experiments/functional/backup_and_restore/test.yml:198
2020-04-07T08:29:49.263072 (delta: 0.236312)         elapsed: 202.5742 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the volume name inside cstor pool] *******************************
task path: /experiments/functional/backup_and_restore/test.yml:203
2020-04-07T08:29:49.498191 (delta: 0.235043)         elapsed: 202.809319 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Assigning the cstor-pool volume name to variable] ************************
task path: /experiments/functional/backup_and_restore/test.yml:208
2020-04-07T08:29:49.759722 (delta: 0.261458)         elapsed: 203.07085 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Setting target IP for volume inside cstor pool] **************************
task path: /experiments/functional/backup_and_restore/test.yml:212
2020-04-07T08:29:49.915446 (delta: 0.155625)         elapsed: 203.226574 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Waiting for application to be in running state] **************************
task path: /experiments/functional/backup_and_restore/test.yml:222
2020-04-07T08:29:50.151900 (delta: 0.236385)         elapsed: 203.463028 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verifying Data persistense] **********************************************
task path: /experiments/functional/backup_and_restore/test.yml:229
2020-04-07T08:29:50.352869 (delta: 0.200877)         elapsed: 203.663997 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Waiting for application to be in running state] **************************
task path: /experiments/functional/backup_and_restore/test.yml:244
2020-04-07T08:29:50.494688 (delta: 0.141717)         elapsed: 203.805816 ****** 
FAILED - RETRYING: Waiting for application to be in running state (30 retries left).
FAILED - RETRYING: Waiting for application to be in running state (29 retries left).
FAILED - RETRYING: Waiting for application to be in running state (28 retries left).
FAILED - RETRYING: Waiting for application to be in running state (27 retries left).
FAILED - RETRYING: Waiting for application to be in running state (26 retries left).
FAILED - RETRYING: Waiting for application to be in running state (25 retries left).
FAILED - RETRYING: Waiting for application to be in running state (24 retries left).
FAILED - RETRYING: Waiting for application to be in running state (23 retries left).
FAILED - RETRYING: Waiting for application to be in running state (22 retries left).
FAILED - RETRYING: Waiting for application to be in running state (21 retries left).
FAILED - RETRYING: Waiting for application to be in running state (20 retries left).
FAILED - RETRYING: Waiting for application to be in running state (19 retries left).
FAILED - RETRYING: Waiting for application to be in running state (18 retries left).
FAILED - RETRYING: Waiting for application to be in running state (17 retries left).
FAILED - RETRYING: Waiting for application to be in running state (16 retries left).
changed: [127.0.0.1] => {"attempts": 16, "changed": true, "cmd": "kubectl get pod percona-8568b6cc96-5kqbq -n app-percona-ns-local -o jsonpath='{.status.phase}'", "delta": "0:00:01.241277", "end": "2020-04-07 08:31:45.084755", "rc": 0, "start": "2020-04-07 08:31:43.843478", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying Data persistense] **********************************************
task path: /experiments/functional/backup_and_restore/test.yml:251
2020-04-07T08:31:45.219148 (delta: 114.724382)         elapsed: 318.530276 **** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-04-07T08:31:45.396449 (delta: 0.176945)         elapsed: 318.707577 ****** 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database backup;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database backup;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' backup", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' backup)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' backup", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-04-07T08:31:45.530045 (delta: 0.133524)         elapsed: 318.841173 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-8568b6cc96-5kqbq -n app-percona-ns-local", "delta": "0:00:07.331529", "end": "2020-04-07 08:31:53.132605", "rc": 0, "start": "2020-04-07 08:31:45.801076", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-8568b6cc96-5kqbq\" deleted", "stdout_lines": ["pod \"percona-8568b6cc96-5kqbq\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-04-07T08:31:53.227290 (delta: 7.697173)         elapsed: 326.538418 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns-local", "delta": "0:00:01.184748", "end": "2020-04-07 08:31:54.687969", "rc": 0, "start": "2020-04-07 08:31:53.503221", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS    RESTARTS   AGE\npercona-8568b6cc96-ssgng   1/1     Running   0          7s", "stdout_lines": ["NAME                       READY   STATUS    RESTARTS   AGE", "percona-8568b6cc96-ssgng   1/1     Running   0          7s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-04-07T08:31:54.797939 (delta: 1.570575)         elapsed: 328.109067 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns-local -l name=percona -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.738611", "end": "2020-04-07 08:31:56.837700", "rc": 0, "start": "2020-04-07 08:31:55.099089", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-ssgng", "stdout_lines": ["percona-8568b6cc96-ssgng"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-04-07T08:31:56.935305 (delta: 2.13725)         elapsed: 330.246433 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns-local -o jsonpath='{.items[?(@.metadata.name==\"percona-8568b6cc96-ssgng\")].status.phase}'", "delta": "0:00:01.475064", "end": "2020-04-07 08:31:59.004572", "rc": 0, "start": "2020-04-07 08:31:57.529508", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-04-07T08:31:59.089869 (delta: 2.154499)         elapsed: 332.400997 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns-local -o jsonpath='{.items[?(@.metadata.name==\"percona-8568b6cc96-ssgng\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.167373", "end": "2020-04-07 08:32:00.560836", "rc": 0, "start": "2020-04-07 08:31:59.393463", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-04-07T08:31:50Z]]", "stdout_lines": ["map[running:map[startedAt:2020-04-07T08:31:50Z]]"]}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-04-07T08:32:00.647378 (delta: 1.557439)         elapsed: 333.958506 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-8568b6cc96-ssgng -n app-percona-ns-local | grep 'ready for connections'", "delta": "0:00:01.563337", "end": "2020-04-07 08:32:02.506673", "rc": 0, "start": "2020-04-07 08:32:00.943336", "stderr": "", "stderr_lines": [], "stdout": "2020-04-07T08:31:53.017231Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2020-04-07T08:31:53.017231Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-04-07T08:32:02.593357 (delta: 1.945907)         elapsed: 335.904485 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-8568b6cc96-ssgng -n app-percona-ns-local -- mysqlcheck -c backup -uroot -pk8sDem0", "delta": "0:00:01.828633", "end": "2020-04-07 08:32:04.779907", "failed_when_result": false, "rc": 0, "start": "2020-04-07 08:32:02.951274", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "backup.ttbl                                        OK", "stdout_lines": ["backup.ttbl                                        OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-04-07T08:32:04.906248 (delta: 2.31282)         elapsed: 338.217376 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-8568b6cc96-ssgng -n app-percona-ns-local -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' backup;", "delta": "0:00:01.914175", "end": "2020-04-07 08:32:07.155197", "failed_when_result": false, "rc": 0, "start": "2020-04-07 08:32:05.241022", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-04-07T08:32:07.253769 (delta: 2.347452)         elapsed: 340.564897 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-04-07T08:32:07.354640 (delta: 0.100803)         elapsed: 340.665768 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/backup_and_restore/test.yml:265
2020-04-07T08:32:07.507667 (delta: 0.152957)         elapsed: 340.818795 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/backup_and_restore/test.yml:273
2020-04-07T08:32:07.665091 (delta: 0.157338)         elapsed: 340.976219 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-07T08:32:07.911997 (delta: 0.246819)         elapsed: 341.223125 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-07T08:32:08.016621 (delta: 0.104553)         elapsed: 341.327749 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-07T08:32:08.126946 (delta: 0.110254)         elapsed: 341.438074 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-07T08:32:08.218836 (delta: 0.09182)         elapsed: 341.529964 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "218cc4cd06f4a20f4ce3c234b033d66800aa02b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9f2161a292cb589ce3599bf99ea6818b", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1586248328.32-259354963295775/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-07T08:32:11.114282 (delta: 2.8943)         elapsed: 344.42541 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.062373", "end": "2020-04-07 08:32:12.433434", "rc": 0, "start": "2020-04-07 08:32:11.371061", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: velero-backup-restore \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: velero-backup-restore ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-07T08:32:12.506106 (delta: 1.390175)         elapsed: 345.817234 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-07T08:26:43Z", "generation": 2, "name": "velero-backup-restore", "resourceVersion": "22792", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/velero-backup-restore", "uid": "b00833bd-4fd6-4b29-9c0b-78804d6b3611"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

TASK [Deleting GCP bucket] *****************************************************
task path: /experiments/functional/backup_and_restore/test.yml:277
2020-04-07T08:32:13.880716 (delta: 1.37453)         elapsed: 347.191844 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning Velero server] ********************************************
task path: /experiments/functional/backup_and_restore/test.yml:281
2020-04-07T08:32:13.985324 (delta: 0.104537)         elapsed: 347.296452 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=49   changed=36   unreachable=0    failed=0   

2020-04-07T08:32:14.054247 (delta: 0.068852)         elapsed: 347.365375 ****** 
===============================================================================
```
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
