### PR TITLE
refactor(yaml): Modified the app_pod_failure test to add variable in calling utils

### DIFF
--- a/experiments/chaos/app_pod_failure/test.yml
+++ b/experiments/chaos/app_pod_failure/test.yml
@@ -99,6 +99,7 @@
                 action: "killapp"
                 app_pod: "{{ app_pod_name.stdout }}"
                 namespace: "{{ app_ns }}"
+                target_ns: "{{ app_ns }}"
                 label: "{{ app_label }}"
               when: cri == 'cri-o'
 


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

-  taking app_ns as target_ns variable to match with the vatibale in util /chaoslib/cri-chaos/cri-crictl-chaos.yml

