### PR TITLE
refactor[cvr-scaleup]: Modified the tasks to fetch the values from randomly selected csp

### DIFF
--- a/experiments/functional/cvr-scaleup/test.yml
+++ b/experiments/functional/cvr-scaleup/test.yml
@@ -140,11 +140,11 @@
           register: target_ip
 
         - name: Getting the Node name from CSP where CVR need to create
-          shell: kubectl get csp {{ csp_name.stdout_lines[0] }} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}'
+          shell: kubectl get csp {{ target_csp }} -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}'
           register: node_name
 
         - name: Getting csp uid 
-          shell: kubectl get csp {{ csp_name.stdout_lines[0] }} -o jsonpath='{.metadata.uid}'
+          shell: kubectl get csp {{ target_csp }} -o jsonpath='{.metadata.uid}'
           register: uid
 
         - name: Replacing the storage class in cvr yml
@@ -163,7 +163,7 @@
           replace:
             path: "./cvr.yml"
             regexp: "<csp-name>"
-            replace: "{{ csp_name.stdout_lines[0] }}"
+            replace: "{{ target_csp }}"
 
         - name: Replacing the uid in cvr yml
           replace:
@@ -250,7 +250,7 @@
               register: target_name
 
             - name: Checking for reconstructing state of newly created cvr 
-              shell: kubectl get cvr {{ pv.stdout }}-{{ csp_name.stdout_lines[0] }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
+              shell: kubectl get cvr {{ pv.stdout }}-{{ target_csp }} -n {{ operator_ns }} -o jsonpath='{.status.phase}'
               register: new_cvr_state
               until: "'ReconstructingNewReplica' in new_cvr_state.stdout"
               delay: 10


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified and updated the tasks to fetch the details of cvr and volumes from the targeted csp

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
