### PR TITLE
refactor[yaml]: Verified value of revision counter file in all jiva replica pods

### DIFF
--- a/experiments/chaos/revision_counter/test.yml
+++ b/experiments/chaos/revision_counter/test.yml
@@ -91,6 +91,27 @@
             path: /proc/{{ p_id.stdout }}/status
             state: absent
 
+        # Verify Revision counter values of all three replicas.
+        - name: Obtain the all three jiva replica pods to verify revision counter.
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv.stdout }}" 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: jiva_replica_pods
+          failed_when: "jiva_replica_pods.rc != 0"
+
+        - name: Verify the revision counter value
+          shell: >
+            kubectl exec -ti "{{ item }}" -n {{ operator_ns }} 
+            -- bash -c "du -h /openebs/revision.counter"
+          args:
+            executable: /bin/bash
+          with_items:
+            - "{{ jiva_replica_pods.stdout_lines }}"
+          register: status
+          failed_when: "'4.0K' not in status.stdout"
+          
         # Verify that each replica consumes same storage
 
         - name: Obtain one replica pod to verify consumed storage


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Verified value of revision counter file in all jiva replica pods as a corner case
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #250 
Logs:
```
PLAY [localhost] ***************************************************************
2020-04-08T08:58:13.712793 (delta: 0.068174)         elapsed: 0.068174 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-08T08:58:13.731959 (delta: 0.018365)         elapsed: 0.08734 ********* 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-04-08T08:58:25.171408 (delta: 11.439403)         elapsed: 11.526789 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-04-08T08:58:25.279038 (delta: 0.107543)         elapsed: 11.634419 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-04-08T08:58:25.363094 (delta: 0.08397)         elapsed: 11.718475 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-08T08:58:25.462370 (delta: 0.09915)         elapsed: 11.817751 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-08T08:58:25.621528 (delta: 0.159048)         elapsed: 11.976909 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8547cdfbcbe6f4961a11da2034dd0716c0b1849d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "db5e5822c56e2db4a14a7729e0f7c8d2", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1586336305.7-152545561148629/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-08T08:58:26.681373 (delta: 1.059758)         elapsed: 13.036754 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.966207", "end": "2020-04-08 08:58:28.190040", "rc": 0, "start": "2020-04-08 08:58:27.223833", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-revision-counter \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-revision-counter ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-08T08:58:28.276614 (delta: 1.595175)         elapsed: 14.631995 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-08T07:09:25Z", "generation": 3, "name": "jiva-revision-counter", "resourceVersion": "48137", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-revision-counter", "uid": "430f5219-ef69-4574-8e59-e78bdb4868b8"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-08T08:58:29.951496 (delta: 1.674811)         elapsed: 16.306877 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-08T08:58:30.033703 (delta: 0.082137)         elapsed: 16.389084 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-08T08:58:30.113368 (delta: 0.079534)         elapsed: 16.468749 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT (Application Under Test) is running] *****************
2020-04-08T08:58:30.189016 (delta: 0.075555)         elapsed: 16.544397 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n \"sam\" -l \"name=percona\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.521501", "end": "2020-04-08 08:58:32.079915", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:30.558414", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
2020-04-08T08:58:32.225431 (delta: 2.036321)         elapsed: 18.580812 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l name=percona --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.156541", "end": "2020-04-08 08:58:33.801196", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:32.644655", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-k5l5h", "stdout_lines": ["percona-8568b6cc96-k5l5h"]}

TASK [Obtain the persistent volume] ********************************************
2020-04-08T08:58:33.879390 (delta: 1.653868)         elapsed: 20.234771 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n sam --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.243320", "end": "2020-04-08 08:58:35.435894", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:34.192574", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142"]}

TASK [Check for all replicas to be in Running state] ***************************
2020-04-08T08:58:35.544813 (delta: 1.665363)         elapsed: 21.900194 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.205994", "end": "2020-04-08 08:58:36.992630", "rc": 0, "start": "2020-04-08 08:58:35.786636", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain the nodes on which jiva replica pods are scheduled] ***************
2020-04-08T08:58:37.110300 (delta: 1.565412)         elapsed: 23.465681 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:.spec.nodeName", "delta": "0:00:01.161674", "end": "2020-04-08 08:58:38.552134", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:37.390460", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node2\ne2e1-node1\ne2e1-node3", "stdout_lines": ["e2e1-node2", "e2e1-node1", "e2e1-node3"]}

TASK [Store the nodes on which jiva replica pods are scheduled] ****************
2020-04-08T08:58:38.634547 (delta: 1.524167)         elapsed: 24.989928 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"delete_rep_node": "e2e1-node2", "test_rep_node": "e2e1-node1"}, "changed": false}

TASK [Load some data to perform chaos with dd] *********************************
2020-04-08T08:58:38.747280 (delta: 0.112654)         elapsed: 25.102661 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"percona-8568b6cc96-k5l5h\" -n \"sam\" -- bash -c \"dd if=/dev/urandom of=/var/lib/mysql/abc.txt bs=3000000 count=4k\" &", "delta": "0:00:02.255898", "end": "2020-04-08 08:58:41.283968", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:39.028070", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Obtain the process ID for dumping data] **********************************
2020-04-08T08:58:41.457411 (delta: 2.710033)         elapsed: 27.812792 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "ps -aux | grep urandom | awk 'FNR==1{printf $2}'", "delta": "0:00:01.127222", "end": "2020-04-08 08:58:42.941377", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:41.814155", "stderr": "", "stderr_lines": [], "stdout": "331", "stdout_lines": ["331"]}

TASK [include_tasks] ***********************************************************
2020-04-08T08:58:43.032128 (delta: 1.574609)         elapsed: 29.387509 ******* 
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=0)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=1)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=2)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=3)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=4)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=5)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=6)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=7)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=8)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=9)

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T08:58:43.404639 (delta: 0.372443)         elapsed: 29.76002 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.209954", "end": "2020-04-08 08:58:44.870555", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:43.660601", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-xcllv", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-xcllv"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T08:58:44.977031 (delta: 1.57233)         elapsed: 31.332412 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-xcllv\" -n openebs", "delta": "0:00:13.567463", "end": "2020-04-08 08:58:58.768113", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:58:45.200650", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-xcllv\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-xcllv\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T08:58:58.858115 (delta: 13.880984)         elapsed: 45.213496 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.694472", "end": "2020-04-08 08:59:12.329952", "rc": 0, "start": "2020-04-08 08:59:10.635480", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T08:59:12.438951 (delta: 13.580767)         elapsed: 58.794332 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.169972", "end": "2020-04-08 08:59:13.863370", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:12.693398", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T08:59:13.976627 (delta: 1.537601)         elapsed: 60.332008 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.703011", "end": "2020-04-08 08:59:15.907536", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:14.204525", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T08:59:16.031339 (delta: 2.054603)         elapsed: 62.38672 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.173499", "end": "2020-04-08 08:59:17.599583", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:16.426084", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gm6s9", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gm6s9"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T08:59:17.687896 (delta: 1.656465)         elapsed: 64.043277 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gm6s9\" -n openebs", "delta": "0:00:10.705678", "end": "2020-04-08 08:59:28.725165", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:18.019487", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gm6s9\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gm6s9\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T08:59:28.832261 (delta: 11.144269)         elapsed: 75.187642 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.623500", "end": "2020-04-08 08:59:42.470236", "rc": 0, "start": "2020-04-08 08:59:40.846736", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T08:59:42.620594 (delta: 13.787958)         elapsed: 88.975975 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.280564", "end": "2020-04-08 08:59:44.198287", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:42.917723", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T08:59:44.286909 (delta: 1.66622)         elapsed: 90.64229 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.637372", "end": "2020-04-08 08:59:46.242158", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:44.604786", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T08:59:46.386407 (delta: 2.099423)         elapsed: 92.741788 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.238894", "end": "2020-04-08 08:59:47.944621", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:46.705727", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-4gc4j", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-4gc4j"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T08:59:48.033583 (delta: 1.647098)         elapsed: 94.388964 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-4gc4j\" -n openebs", "delta": "0:00:10.221426", "end": "2020-04-08 08:59:58.714665", "failed_when_result": false, "rc": 0, "start": "2020-04-08 08:59:48.493239", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-4gc4j\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-4gc4j\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T08:59:58.807060 (delta: 10.773145)         elapsed: 105.162441 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.426851", "end": "2020-04-08 09:00:12.083874", "rc": 0, "start": "2020-04-08 09:00:10.657023", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:00:12.257910 (delta: 13.450741)         elapsed: 118.613291 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.290903", "end": "2020-04-08 09:00:13.917884", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:12.626981", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:00:14.012500 (delta: 1.754522)         elapsed: 120.367881 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.774448", "end": "2020-04-08 09:00:16.065072", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:14.290624", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:00:16.252578 (delta: 2.239743)         elapsed: 122.607959 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.243487", "end": "2020-04-08 09:00:17.806251", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:16.562764", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-dfcqr", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-dfcqr"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:00:17.931290 (delta: 1.678616)         elapsed: 124.286671 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-dfcqr\" -n openebs", "delta": "0:00:04.511714", "end": "2020-04-08 09:00:22.799934", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:18.288220", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-dfcqr\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-dfcqr\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:00:22.906094 (delta: 4.9746)         elapsed: 129.261475 ******** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.235605", "end": "2020-04-08 09:00:36.024025", "rc": 0, "start": "2020-04-08 09:00:34.788420", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:00:36.135826 (delta: 13.229663)         elapsed: 142.491207 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.337712", "end": "2020-04-08 09:00:37.786158", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:36.448446", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:00:37.888432 (delta: 1.752251)         elapsed: 144.243813 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.966383", "end": "2020-04-08 09:00:40.190307", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:38.223924", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:00:40.360697 (delta: 2.471944)         elapsed: 146.716078 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.537266", "end": "2020-04-08 09:00:42.236777", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:40.699511", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-5ntgz", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-5ntgz"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:00:42.420051 (delta: 2.05897)         elapsed: 148.775432 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-5ntgz\" -n openebs", "delta": "0:00:05.985465", "end": "2020-04-08 09:00:48.715999", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:00:42.730534", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-5ntgz\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-5ntgz\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:00:48.833516 (delta: 6.413361)         elapsed: 155.188897 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.712379", "end": "2020-04-08 09:01:02.416637", "rc": 0, "start": "2020-04-08 09:01:00.704258", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:01:02.523868 (delta: 13.690239)         elapsed: 168.879249 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.258266", "end": "2020-04-08 09:01:04.077345", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:02.819079", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:01:04.174067 (delta: 1.65006)         elapsed: 170.529448 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.796829", "end": "2020-04-08 09:01:06.253687", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:04.456858", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:01:06.428600 (delta: 2.254442)         elapsed: 172.783981 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.218767", "end": "2020-04-08 09:01:07.933992", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:06.715225", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-mgfph", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-mgfph"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:01:08.045770 (delta: 1.617037)         elapsed: 174.401151 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-mgfph\" -n openebs", "delta": "0:00:10.405499", "end": "2020-04-08 09:01:18.715492", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:08.309993", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-mgfph\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-mgfph\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:01:18.869595 (delta: 10.823716)         elapsed: 185.224976 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.597618", "end": "2020-04-08 09:01:32.472645", "rc": 0, "start": "2020-04-08 09:01:30.875027", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:01:32.593109 (delta: 13.72344)         elapsed: 198.94849 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.314926", "end": "2020-04-08 09:01:34.222141", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:32.907215", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:01:34.361111 (delta: 1.767866)         elapsed: 200.716492 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.818976", "end": "2020-04-08 09:01:36.548500", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:34.729524", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:01:36.753814 (delta: 2.392117)         elapsed: 203.109195 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.361182", "end": "2020-04-08 09:01:38.410161", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:37.048979", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-m8b7z", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-m8b7z"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:01:38.535759 (delta: 1.781765)         elapsed: 204.89114 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-m8b7z\" -n openebs", "delta": "0:00:09.883907", "end": "2020-04-08 09:01:48.711502", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:01:38.827595", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-m8b7z\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-m8b7z\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:01:48.807848 (delta: 10.271945)         elapsed: 215.163229 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.619358", "end": "2020-04-08 09:02:02.290876", "rc": 0, "start": "2020-04-08 09:02:00.671518", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:02:02.500335 (delta: 13.692401)         elapsed: 228.855716 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.329140", "end": "2020-04-08 09:02:04.179797", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:02.850657", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:02:04.263603 (delta: 1.763035)         elapsed: 230.618984 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.773678", "end": "2020-04-08 09:02:06.366569", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:04.592891", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:02:06.522176 (delta: 2.258474)         elapsed: 232.877557 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.263583", "end": "2020-04-08 09:02:08.171741", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:06.908158", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-2p46x", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-2p46x"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:02:08.281354 (delta: 1.759038)         elapsed: 234.636735 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-2p46x\" -n openebs", "delta": "0:00:04.208437", "end": "2020-04-08 09:02:12.792572", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:08.584135", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-2p46x\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-2p46x\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:02:12.899771 (delta: 4.618261)         elapsed: 239.255152 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.312317", "end": "2020-04-08 09:02:26.012213", "rc": 0, "start": "2020-04-08 09:02:24.699896", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:02:26.169671 (delta: 13.269833)         elapsed: 252.525052 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.189736", "end": "2020-04-08 09:02:27.787766", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:26.598030", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:02:27.887066 (delta: 1.717299)         elapsed: 254.242447 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.750299", "end": "2020-04-08 09:02:29.931982", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:28.181683", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:02:30.056441 (delta: 2.169298)         elapsed: 256.411822 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.594204", "end": "2020-04-08 09:02:31.975566", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:30.381362", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gchfd", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gchfd"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:02:32.139545 (delta: 2.082999)         elapsed: 258.494926 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gchfd\" -n openebs", "delta": "0:00:04.755506", "end": "2020-04-08 09:02:37.315239", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:32.559733", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gchfd\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-gchfd\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:02:37.436252 (delta: 5.296625)         elapsed: 263.791633 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.325159", "end": "2020-04-08 09:02:50.733080", "rc": 0, "start": "2020-04-08 09:02:49.407921", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:02:50.856531 (delta: 13.420102)         elapsed: 277.211912 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.551845", "end": "2020-04-08 09:02:52.731362", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:51.179517", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:02:52.832842 (delta: 1.97623)         elapsed: 279.188223 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.706549", "end": "2020-04-08 09:02:54.808004", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:53.101455", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-08T09:02:54.923057 (delta: 2.090132)         elapsed: 281.278438 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.244851", "end": "2020-04-08 09:02:56.469607", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:55.224756", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-z4brf", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-z4brf"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-08T09:02:56.613286 (delta: 1.690128)         elapsed: 282.968667 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-z4brf\" -n openebs", "delta": "0:00:11.850447", "end": "2020-04-08 09:03:08.739171", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:02:56.888724", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-z4brf\" deleted", "stdout_lines": ["pod \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-z4brf\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-08T09:03:08.844415 (delta: 12.231061)         elapsed: 295.199796 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.325427", "end": "2020-04-08 09:03:22.037617", "rc": 0, "start": "2020-04-08 09:03:20.712190", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-08T09:03:22.231981 (delta: 13.387471)         elapsed: 308.587362 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.321092", "end": "2020-04-08 09:03:23.895310", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:03:22.574218", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:03:23.997188 (delta: 1.765092)         elapsed: 310.352569 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.849821", "end": "2020-04-08 09:03:26.122343", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:03:24.272522", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Wait until the dumping process is finished and pid was destroyed] ********
2020-04-08T09:03:26.253709 (delta: 2.256392)         elapsed: 312.60909 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 80, "path": "/proc/331/status", "port": null, "search_regex": null, "state": "absent"}

TASK [Obtain the all three jiva replica pods to verify revision counter.] ******
2020-04-08T09:04:47.133008 (delta: 80.879227)         elapsed: 393.488389 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.273783", "end": "2020-04-08 09:04:48.771695", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:04:47.497912", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq\npvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\npvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-3-767759d44-kd489", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq", "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-3-767759d44-kd489"]}

TASK [Verify the revision counter value] ***************************************
2020-04-08T09:04:48.890537 (delta: 1.757437)         elapsed: 395.245918 ****** 
changed: [127.0.0.1] => (item=pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq) => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.948953", "end": "2020-04-08 09:04:51.243869", "failed_when_result": false, "item": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq", "rc": 0, "start": "2020-04-08 09:04:49.294916", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}
changed: [127.0.0.1] => (item=pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs) => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.934821", "end": "2020-04-08 09:04:53.521605", "failed_when_result": false, "item": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "rc": 0, "start": "2020-04-08 09:04:51.586784", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}
changed: [127.0.0.1] => (item=pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-3-767759d44-kd489) => {"changed": true, "cmd": "kubectl exec -ti \"pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-3-767759d44-kd489\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:02.358705", "end": "2020-04-08 09:04:56.298196", "failed_when_result": false, "item": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-3-767759d44-kd489", "rc": 0, "start": "2020-04-08 09:04:53.939491", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain one replica pod to verify consumed storage] ***********************
2020-04-08T09:04:56.413164 (delta: 7.522549)         elapsed: 402.768545 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.344343", "end": "2020-04-08 09:04:58.070568", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:04:56.726225", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs"]}

TASK [Obtain consumed storage size in one replica] *****************************
2020-04-08T09:04:58.183513 (delta: 1.770266)         elapsed: 404.538894 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-2-7f6f649594-cz7bs -n openebs -- bash -c \"du -h openebs\"", "delta": "0:00:01.667887", "end": "2020-04-08 09:05:00.245611", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:04:58.577724", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "12G\topenebs", "stdout_lines": ["12G\topenebs"]}

TASK [Obtain the replica pod which was being deleted] **************************
2020-04-08T09:05:00.391222 (delta: 2.207632)         elapsed: 406.746603 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-a0a43066-bc87-4933-90b5-26663e8c3142\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node2'\")].metadata.name}'", "delta": "0:00:01.602048", "end": "2020-04-08 09:05:02.311708", "failed_when_result": false, "rc": 0, "start": "2020-04-08 09:05:00.709660", "stderr": "", "stderr_lines": [], "stdout": "pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq", "stdout_lines": ["pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq"]}

TASK [Verify consumed storage size in replica] *********************************
2020-04-08T09:05:02.463492 (delta: 2.072193)         elapsed: 408.818873 ****** 
FAILED - RETRYING: Verify consumed storage size in replica (60 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (59 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (58 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (57 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (56 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (55 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (54 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (53 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (52 retries left).
FAILED - RETRYING: Verify consumed storage size in replica (51 retries left).
changed: [127.0.0.1] => {"attempts": 11, "changed": true, "cmd": "kubectl exec -ti pvc-a0a43066-bc87-4933-90b5-26663e8c3142-rep-1-54696b649f-rwgrq -n openebs -- bash -c \"du -h openebs\"", "delta": "0:00:01.722340", "end": "2020-04-08 09:15:26.375110", "rc": 0, "start": "2020-04-08 09:15:24.652770", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "12G\topenebs", "stdout_lines": ["12G\topenebs"]}

TASK [set_fact] ****************************************************************
2020-04-08T09:15:26.466385 (delta: 624.002826)         elapsed: 1032.821766 *** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-04-08T09:15:26.596798 (delta: 0.130327)         elapsed: 1032.952179 ***** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-08T09:15:26.780685 (delta: 0.183791)         elapsed: 1033.136066 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-08T09:15:26.888034 (delta: 0.107279)         elapsed: 1033.243415 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-08T09:15:26.994066 (delta: 0.105624)         elapsed: 1033.349447 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-08T09:15:27.105376 (delta: 0.111217)         elapsed: 1033.460757 ***** 
changed: [127.0.0.1] => {"changed": true, "checksum": "c7bb453ba95ef8088d0ef7c98077677950db905c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f84c1414b1d6a85910ec1a182e205f1f", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1586337327.24-118062561532112/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-08T09:15:29.950337 (delta: 2.844885)         elapsed: 1036.305718 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.955256", "end": "2020-04-08 09:15:31.286128", "rc": 0, "start": "2020-04-08 09:15:30.330872", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-revision-counter \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-revision-counter ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-08T09:15:31.404002 (delta: 1.453552)         elapsed: 1037.759383 ***** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-08T07:09:25Z", "generation": 4, "name": "jiva-revision-counter", "resourceVersion": "52488", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-revision-counter", "uid": "430f5219-ef69-4574-8e59-e78bdb4868b8"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=86   changed=69   unreachable=0    failed=0   

2020-04-08T09:15:32.962189 (delta: 1.558114)         elapsed: 1039.31757 ****** 
=============================================================================== 
```