### PR TITLE
refactor[yaml]: Modified the test case jiva revision counter

### DIFF
--- a/experiments/chaos/revision_counter/run_litmus_test.yml
+++ b/experiments/chaos/revision_counter/run_litmus_test.yml
@@ -30,6 +30,10 @@ spec:
           - name: APP_NAMESPACE
             value: ''
 
+             # Application PVC
+          - name: APP_PVC
+            value: ''
+
             # Block Size to dump the data using dd 
           - name: BLOCK_SIZE
             value: '3000000'

--- a/experiments/chaos/revision_counter/test.yml
+++ b/experiments/chaos/revision_counter/test.yml
@@ -90,6 +90,23 @@
           wait_for:
             path: /proc/{{ p_id.stdout }}/status
             state: absent
+        
+        # Sync the dumped data in jiva replica
+        - name: Sync the dumped data in jiva replica from buffer
+          shell: >
+            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- bash 
+            -c "sync;sync;sync"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+          #### Check the replica access mode after injecting chaos using mayactl commands ####
+        - name: Check the replicas access mode
+          include_tasks: "/funclib/openebs/access-mode-check.yml"
+          vars:
+            ns: "{{ app_ns }}"
+            pvc_name: "{{ pvc }}"
 
         # Verify Revision counter values of all three replicas.
         - name: Obtain the all three jiva replica pods to verify revision counter.

--- a/experiments/chaos/revision_counter/test_vars.yml
+++ b/experiments/chaos/revision_counter/test_vars.yml
@@ -16,4 +16,6 @@ mount_path: "{{ lookup('env','MOUNT_PATH') }}"
 
 operator_ns: 'openebs'
 
+pvc: "{{ lookup('env','APP_PVC') }}"
+
 test_name: "jiva-revision-counter"

--- a/funclib/openebs/access-mode-check.yml
+++ b/funclib/openebs/access-mode-check.yml
@@ -37,7 +37,7 @@
          register: result
          until: result.stdout| int == node_count.stdout | int
          delay: 30
-         retries: 15
+         retries: 30
          changed_when: True
 
        - debug:


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified the test case jiva revision counter to include verification of sync of jiva replica

**Special notes for your reviewer**:
Logs for the test:-

```
PLAY [localhost] ***************************************************************
2020-04-19T14:47:09.735998 (delta: 0.066575)         elapsed: 0.066575 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-19T14:47:09.750299 (delta: 0.014221)         elapsed: 0.080876 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-04-19T14:47:19.115366 (delta: 9.365004)         elapsed: 9.445943 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-04-19T14:47:19.214498 (delta: 0.099086)         elapsed: 9.545075 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-04-19T14:47:19.315293 (delta: 0.10074)         elapsed: 9.64587 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-19T14:47:19.389729 (delta: 0.074247)         elapsed: 9.720306 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-19T14:47:19.538419 (delta: 0.148631)         elapsed: 9.868996 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8547cdfbcbe6f4961a11da2034dd0716c0b1849d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "db5e5822c56e2db4a14a7729e0f7c8d2", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1587307639.63-168132949059934/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-19T14:47:20.500861 (delta: 0.962378)         elapsed: 10.831438 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.775510", "end": "2020-04-19 14:47:21.809897", "rc": 0, "start": "2020-04-19 14:47:21.034387", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-revision-counter \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-revision-counter ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-19T14:47:21.871914 (delta: 1.370981)         elapsed: 12.202491 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-19T14:47:23Z", "generation": 1, "name": "jiva-revision-counter", "resourceVersion": "31547", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-revision-counter", "uid": "81115f49-b3bf-4db9-a1b7-25e9bc4b1c34"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-19T14:47:23.408213 (delta: 1.53625)         elapsed: 13.73879 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-19T14:47:23.496992 (delta: 0.088699)         elapsed: 13.827569 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-19T14:47:23.573017 (delta: 0.075954)         elapsed: 13.903594 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT (Application Under Test) is running] *****************
2020-04-19T14:47:23.657474 (delta: 0.084258)         elapsed: 13.988051 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n \"sam\" -l \"name=percona\" --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.136835", "end": "2020-04-19 14:47:25.066747", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:23.929912", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
2020-04-19T14:47:25.160045 (delta: 1.502501)         elapsed: 15.490622 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l name=percona --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.985382", "end": "2020-04-19 14:47:26.393343", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:25.407961", "stderr": "", "stderr_lines": [], "stdout": "percona-8568b6cc96-6cskw", "stdout_lines": ["percona-8568b6cc96-6cskw"]}

TASK [Obtain the persistent volume] ********************************************
2020-04-19T14:47:26.473817 (delta: 1.313703)         elapsed: 16.804394 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n sam --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.963886", "end": "2020-04-19 14:47:27.703621", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:26.739735", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93"]}

TASK [Check for all replicas to be in Running state] ***************************
2020-04-19T14:47:27.770160 (delta: 1.296279)         elapsed: 18.100737 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.916485", "end": "2020-04-19 14:47:28.873177", "rc": 0, "start": "2020-04-19 14:47:27.956692", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain the nodes on which jiva replica pods are scheduled] ***************
2020-04-19T14:47:28.990839 (delta: 1.220622)         elapsed: 19.321416 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:.spec.nodeName", "delta": "0:00:00.922859", "end": "2020-04-19 14:47:30.281206", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:29.358347", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node3\ne2e1-node1\ne2e1-node2", "stdout_lines": ["e2e1-node3", "e2e1-node1", "e2e1-node2"]}

TASK [Store the nodes on which jiva replica pods are scheduled] ****************
2020-04-19T14:47:30.368497 (delta: 1.377566)         elapsed: 20.699074 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"delete_rep_node": "e2e1-node3", "test_rep_node": "e2e1-node1"}, "changed": false}

TASK [Load some data to perform chaos with dd] *********************************
2020-04-19T14:47:30.501511 (delta: 0.132943)         elapsed: 20.832088 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"percona-8568b6cc96-6cskw\" -n \"sam\" -- bash -c \"dd if=/dev/urandom of=/var/lib/mysql/abc.txt bs=3000000 count=4k\" &", "delta": "0:00:02.178105", "end": "2020-04-19 14:47:33.051755", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:30.873650", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Obtain the process ID for dumping data] **********************************
2020-04-19T14:47:33.190853 (delta: 2.689273)         elapsed: 23.52143 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "ps -aux | grep urandom | awk 'FNR==1{printf $2}'", "delta": "0:00:00.783774", "end": "2020-04-19 14:47:34.350721", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:33.566947", "stderr": "", "stderr_lines": [], "stdout": "331", "stdout_lines": ["331"]}

TASK [include_tasks] ***********************************************************
2020-04-19T14:47:34.440164 (delta: 1.249215)         elapsed: 24.770741 ******* 
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=0)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=1)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=2)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=3)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=4)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=5)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=6)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=7)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=8)
included: /experiments/chaos/revision_counter/delete_replica.yml for 127.0.0.1 => (item=9)

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:47:34.751636 (delta: 0.311361)         elapsed: 25.082213 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:01.125348", "end": "2020-04-19 14:47:36.072673", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:34.947325", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-n26xm", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-n26xm"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:47:36.147028 (delta: 1.395331)         elapsed: 26.477605 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-n26xm\" -n openebs", "delta": "0:00:04.467828", "end": "2020-04-19 14:47:40.969128", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:36.501300", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-n26xm\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-n26xm\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:47:41.079449 (delta: 4.932361)         elapsed: 31.410026 ******* 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.918537", "end": "2020-04-19 14:47:53.462782", "rc": 0, "start": "2020-04-19 14:47:52.544245", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:47:53.564773 (delta: 12.485089)         elapsed: 43.89535 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.117205", "end": "2020-04-19 14:47:55.020765", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:53.903560", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:47:55.101451 (delta: 1.536551)         elapsed: 45.432028 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.748968", "end": "2020-04-19 14:47:57.187045", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:55.438077", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:47:57.278138 (delta: 2.17656)         elapsed: 47.608715 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.952000", "end": "2020-04-19 14:47:58.459948", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:57.507948", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6q2ss", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6q2ss"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:47:58.546185 (delta: 1.267992)         elapsed: 48.876762 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6q2ss\" -n openebs", "delta": "0:00:08.037518", "end": "2020-04-19 14:48:06.801028", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:47:58.763510", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6q2ss\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6q2ss\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:48:06.917696 (delta: 8.37145)         elapsed: 57.248273 ******** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.066093", "end": "2020-04-19 14:48:19.570708", "rc": 0, "start": "2020-04-19 14:48:18.504615", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:48:19.649931 (delta: 12.732154)         elapsed: 69.980508 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.941602", "end": "2020-04-19 14:48:20.862307", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:19.920705", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:48:20.953697 (delta: 1.303706)         elapsed: 71.284274 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.520458", "end": "2020-04-19 14:48:22.741242", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:21.220784", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:48:22.871403 (delta: 1.917612)         elapsed: 73.20198 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.913819", "end": "2020-04-19 14:48:24.060936", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:23.147117", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-5896p", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-5896p"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:48:24.185403 (delta: 1.313907)         elapsed: 74.51598 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-5896p\" -n openebs", "delta": "0:00:12.297794", "end": "2020-04-19 14:48:36.804970", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:24.507176", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-5896p\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-5896p\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:48:36.877772 (delta: 12.692298)         elapsed: 87.208349 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.877766", "end": "2020-04-19 14:48:49.053396", "rc": 0, "start": "2020-04-19 14:48:48.175630", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:48:49.141525 (delta: 12.263673)         elapsed: 99.472102 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.903581", "end": "2020-04-19 14:48:50.368148", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:49.464567", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:48:50.483875 (delta: 1.342153)         elapsed: 100.814452 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.409818", "end": "2020-04-19 14:48:52.160067", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:50.750249", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:48:52.276997 (delta: 1.792958)         elapsed: 102.607574 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.894031", "end": "2020-04-19 14:48:53.472679", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:52.578648", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-f25kz", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-f25kz"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:48:53.554289 (delta: 1.277196)         elapsed: 103.884866 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-f25kz\" -n openebs", "delta": "0:00:03.446252", "end": "2020-04-19 14:48:57.219892", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:48:53.773640", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-f25kz\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-f25kz\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:48:57.301520 (delta: 3.747169)         elapsed: 107.632097 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.052357", "end": "2020-04-19 14:49:09.765032", "rc": 0, "start": "2020-04-19 14:49:08.712675", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:49:09.883371 (delta: 12.581784)         elapsed: 120.213948 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.998942", "end": "2020-04-19 14:49:11.209690", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:10.210748", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:49:11.312305 (delta: 1.428854)         elapsed: 121.642882 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.296881", "end": "2020-04-19 14:49:12.870332", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:11.573451", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:49:12.979400 (delta: 1.667014)         elapsed: 123.309977 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:01.109601", "end": "2020-04-19 14:49:14.365656", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:13.256055", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-4lpcf", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-4lpcf"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:49:14.458706 (delta: 1.47923)         elapsed: 124.789283 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-4lpcf\" -n openebs", "delta": "0:00:12.114234", "end": "2020-04-19 14:49:26.806289", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:14.692055", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-4lpcf\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-4lpcf\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:49:26.938887 (delta: 12.480109)         elapsed: 137.269464 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.942263", "end": "2020-04-19 14:49:39.168393", "rc": 0, "start": "2020-04-19 14:49:38.226130", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:49:39.249439 (delta: 12.310104)         elapsed: 149.580016 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.924430", "end": "2020-04-19 14:49:40.429070", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:39.504640", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:49:40.511346 (delta: 1.261806)         elapsed: 150.841923 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.601684", "end": "2020-04-19 14:49:42.385155", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:40.783471", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:49:42.491539 (delta: 1.980129)         elapsed: 152.822116 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.942462", "end": "2020-04-19 14:49:43.668803", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:42.726341", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6hcv5", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6hcv5"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:49:43.757910 (delta: 1.266248)         elapsed: 154.088487 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6hcv5\" -n openebs", "delta": "0:00:12.761142", "end": "2020-04-19 14:49:56.797922", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:49:44.036780", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6hcv5\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-6hcv5\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:49:56.937669 (delta: 13.178244)         elapsed: 167.268246 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.122623", "end": "2020-04-19 14:50:09.495409", "rc": 0, "start": "2020-04-19 14:50:08.372786", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:50:09.601588 (delta: 12.663851)         elapsed: 179.932165 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.231297", "end": "2020-04-19 14:50:11.080708", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:09.849411", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:50:11.154250 (delta: 1.55256)         elapsed: 181.484827 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.532181", "end": "2020-04-19 14:50:12.930693", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:11.398512", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:50:13.040395 (delta: 1.885057)         elapsed: 183.370972 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:01.118714", "end": "2020-04-19 14:50:14.474330", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:13.355616", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-t5fj6", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-t5fj6"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:50:14.551816 (delta: 1.511343)         elapsed: 184.882393 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-t5fj6\" -n openebs", "delta": "0:00:04.103334", "end": "2020-04-19 14:50:18.970886", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:14.867552", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-t5fj6\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-t5fj6\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:50:19.040640 (delta: 4.488767)         elapsed: 189.371217 ****** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.059774", "end": "2020-04-19 14:50:31.501344", "rc": 0, "start": "2020-04-19 14:50:30.441570", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:50:31.582972 (delta: 12.541975)         elapsed: 201.913549 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.979839", "end": "2020-04-19 14:50:32.817174", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:31.837335", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:50:32.895697 (delta: 1.311735)         elapsed: 203.226274 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.378302", "end": "2020-04-19 14:50:34.519489", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:33.141187", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:50:34.592618 (delta: 1.696856)         elapsed: 204.923195 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.974504", "end": "2020-04-19 14:50:35.779625", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:34.805121", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-kgc78", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-kgc78"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:50:35.896503 (delta: 1.303826)         elapsed: 206.22708 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-kgc78\" -n openebs", "delta": "0:00:10.608878", "end": "2020-04-19 14:50:46.806455", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:36.197577", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-kgc78\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-kgc78\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:50:46.881815 (delta: 10.985249)         elapsed: 217.212392 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.848182", "end": "2020-04-19 14:50:59.093745", "rc": 0, "start": "2020-04-19 14:50:58.245563", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:50:59.167619 (delta: 12.285623)         elapsed: 229.498196 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.848288", "end": "2020-04-19 14:51:00.281744", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:50:59.433456", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:51:00.369203 (delta: 1.201147)         elapsed: 230.69978 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.444843", "end": "2020-04-19 14:51:02.066174", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:00.621331", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:51:02.216874 (delta: 1.84726)         elapsed: 232.547451 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.936191", "end": "2020-04-19 14:51:03.358985", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:02.422794", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-7dk4c", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-7dk4c"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:51:03.443867 (delta: 1.224521)         elapsed: 233.774444 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-7dk4c\" -n openebs", "delta": "0:00:13.138264", "end": "2020-04-19 14:51:16.816617", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:03.678353", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-7dk4c\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-7dk4c\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:51:16.938951 (delta: 13.495022)         elapsed: 247.269528 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.046461", "end": "2020-04-19 14:51:29.353413", "rc": 0, "start": "2020-04-19 14:51:28.306952", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:51:29.444060 (delta: 12.505012)         elapsed: 259.774637 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.130023", "end": "2020-04-19 14:51:30.812561", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:29.682538", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:51:30.904783 (delta: 1.460658)         elapsed: 261.23536 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.467608", "end": "2020-04-19 14:51:32.623487", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:31.155879", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain the jiva replica pod scheduled on one node] ***********************
2020-04-19T14:51:32.717555 (delta: 1.812696)         elapsed: 263.048132 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:00.983046", "end": "2020-04-19 14:51:33.970505", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:32.987459", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-mh5p7", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-mh5p7"]}

TASK [Delete the replica pod of one node] **************************************
2020-04-19T14:51:34.067034 (delta: 1.349403)         elapsed: 264.397611 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-mh5p7\" -n openebs", "delta": "0:00:12.399434", "end": "2020-04-19 14:51:46.816699", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:34.417265", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-mh5p7\" deleted", "stdout_lines": ["pod \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-mh5p7\" deleted"]}

TASK [Verify if all the replica pods are in running state] *********************
2020-04-19T14:51:46.890266 (delta: 12.823162)         elapsed: 277.220843 ***** 
FAILED - RETRYING: Verify if all the replica pods are in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.965568", "end": "2020-04-19 14:51:59.104407", "rc": 0, "start": "2020-04-19 14:51:58.138839", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Obtain one replica pod to check the revision counter value] **************
2020-04-19T14:51:59.192529 (delta: 12.30215)         elapsed: 289.523106 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:01.062117", "end": "2020-04-19 14:52:00.529726", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:51:59.467609", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T14:52:00.619391 (delta: 1.426793)         elapsed: 290.949968 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.514205", "end": "2020-04-19 14:52:02.353388", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:52:00.839183", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Wait until the dumping process is finished and pid was destroyed] ********
2020-04-19T14:52:02.494493 (delta: 1.874972)         elapsed: 292.82507 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 50, "path": "/proc/331/status", "port": null, "search_regex": null, "state": "absent"}

TASK [Sync the dumped data in jiva replica from buffer] ************************
2020-04-19T14:52:53.250212 (delta: 50.755418)         elapsed: 343.580789 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"percona-8568b6cc96-6cskw\" -n \"sam\" -- bash -c \"sync;sync;sync\"", "delta": "0:00:25.684956", "end": "2020-04-19 14:53:19.330994", "failed_when_result": false, "rc": 0, "start": "2020-04-19 14:52:53.646038", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Check the replicas access mode] ******************************************
2020-04-19T14:53:19.445747 (delta: 26.195378)         elapsed: 369.776324 ***** 
included: /funclib/openebs/access-mode-check.yml for 127.0.0.1

TASK [Get the pv name] *********************************************************
2020-04-19T14:53:19.644647 (delta: 0.198818)         elapsed: 369.975224 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n sam -o jsonpath='{.spec.volumeName}'", "delta": "0:00:00.930922", "end": "2020-04-19 14:53:20.793976", "rc": 0, "start": "2020-04-19 14:53:19.863054", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93"]}

TASK [Get the nodes count] *****************************************************
2020-04-19T14:53:20.916278 (delta: 1.271571)         elapsed: 371.246855 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | wc -l", "delta": "0:00:01.079127", "end": "2020-04-19 14:53:22.325575", "rc": 0, "start": "2020-04-19 14:53:21.246448", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the maya-apiserver pod name] *****************************************
2020-04-19T14:53:22.403829 (delta: 1.487465)         elapsed: 372.734406 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.928189", "end": "2020-04-19 14:53:23.582457", "rc": 0, "start": "2020-04-19 14:53:22.654268", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-854f7bcb8f-rb7s2", "stdout_lines": ["maya-apiserver-854f7bcb8f-rb7s2"]}

TASK [Get the volume list] *****************************************************
2020-04-19T14:53:23.674620 (delta: 1.270724)         elapsed: 374.005197 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-854f7bcb8f-rb7s2 -n openebs -- mayactl volume list", "delta": "0:00:01.742570", "end": "2020-04-19 14:53:25.718757", "rc": 0, "start": "2020-04-19 14:53:23.976187", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Namespace  Name                                      Status   Type  Capacity  StorageClass          Access Mode\n---------  ----                                      ------   ----  --------  -------------         -----------\nopenebs    pvc-54fac9d7-665e-4401-a94e-06b088e1cc93  Running  jiva  20Gi      openebs-jiva-default  ReadWriteOnce", "stdout_lines": ["Namespace  Name                                      Status   Type  Capacity  StorageClass          Access Mode", "---------  ----                                      ------   ----  --------  -------------         -----------", "openebs    pvc-54fac9d7-665e-4401-a94e-06b088e1cc93  Running  jiva  20Gi      openebs-jiva-default  ReadWriteOnce"]}

TASK [Get the replicas access mode] ********************************************
2020-04-19T14:53:25.883395 (delta: 2.208714)         elapsed: 376.213972 ****** 
FAILED - RETRYING: Get the replicas access mode (30 retries left).
FAILED - RETRYING: Get the replicas access mode (29 retries left).
FAILED - RETRYING: Get the replicas access mode (28 retries left).
FAILED - RETRYING: Get the replicas access mode (27 retries left).
FAILED - RETRYING: Get the replicas access mode (26 retries left).
FAILED - RETRYING: Get the replicas access mode (25 retries left).
FAILED - RETRYING: Get the replicas access mode (24 retries left).
FAILED - RETRYING: Get the replicas access mode (23 retries left).
FAILED - RETRYING: Get the replicas access mode (22 retries left).
FAILED - RETRYING: Get the replicas access mode (21 retries left).
FAILED - RETRYING: Get the replicas access mode (20 retries left).
FAILED - RETRYING: Get the replicas access mode (19 retries left).
FAILED - RETRYING: Get the replicas access mode (18 retries left).
FAILED - RETRYING: Get the replicas access mode (17 retries left).
FAILED - RETRYING: Get the replicas access mode (16 retries left).
FAILED - RETRYING: Get the replicas access mode (15 retries left).
FAILED - RETRYING: Get the replicas access mode (14 retries left).
changed: [127.0.0.1] => {"attempts": 18, "changed": true, "cmd": "kubectl exec -it maya-apiserver-854f7bcb8f-rb7s2 -n openebs -- mayactl volume describe --volname \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -n sam | grep 'RW' | wc -l", "delta": "0:00:01.739973", "end": "2020-04-19 15:02:32.020877", "rc": 0, "start": "2020-04-19 15:02:30.280904", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [debug] *******************************************************************
2020-04-19T15:02:32.187707 (delta: 546.296318)         elapsed: 922.518284 **** 
ok: [127.0.0.1] => {
    "msg": "All the replicas are in sync"
}

TASK [Obtain the all three jiva replica pods to verify revision counter.] ******
2020-04-19T15:02:32.309070 (delta: 0.121263)         elapsed: 922.639647 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.058685", "end": "2020-04-19 15:02:33.574441", "failed_when_result": false, "rc": 0, "start": "2020-04-19 15:02:32.515756", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp\npvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\npvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-3-5978d48b9c-tn68j", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp", "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-3-5978d48b9c-tn68j"]}

TASK [Verify the revision counter value] ***************************************
2020-04-19T15:02:33.681603 (delta: 1.372435)         elapsed: 924.01218 ******* 
changed: [127.0.0.1] => (item=pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp) => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.457950", "end": "2020-04-19 15:02:35.446575", "failed_when_result": false, "item": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp", "rc": 0, "start": "2020-04-19 15:02:33.988625", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}
changed: [127.0.0.1] => (item=pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h) => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.290670", "end": "2020-04-19 15:02:36.919895", "failed_when_result": false, "item": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "rc": 0, "start": "2020-04-19 15:02:35.629225", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}
changed: [127.0.0.1] => (item=pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-3-5978d48b9c-tn68j) => {"changed": true, "cmd": "kubectl exec -ti \"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-3-5978d48b9c-tn68j\" -n openebs -- bash -c \"du -h /openebs/revision.counter\"", "delta": "0:00:01.270339", "end": "2020-04-19 15:02:38.381969", "failed_when_result": false, "item": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-3-5978d48b9c-tn68j", "rc": 0, "start": "2020-04-19 15:02:37.111630", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "4.0K\t/openebs/revision.counter", "stdout_lines": ["4.0K\t/openebs/revision.counter"]}

TASK [Obtain one replica pod to verify consumed storage] ***********************
2020-04-19T15:02:38.462333 (delta: 4.780655)         elapsed: 928.79291 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node1'\")].metadata.name}'", "delta": "0:00:00.858984", "end": "2020-04-19 15:02:39.540903", "failed_when_result": false, "rc": 0, "start": "2020-04-19 15:02:38.681919", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h"]}

TASK [Obtain consumed storage size in one replica] *****************************
2020-04-19T15:02:39.623512 (delta: 1.161092)         elapsed: 929.954089 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-2-6fd8bcdbd4-rxw6h -n openebs -- bash -c \"du -h openebs\"", "delta": "0:00:01.509108", "end": "2020-04-19 15:02:41.398811", "failed_when_result": false, "rc": 0, "start": "2020-04-19 15:02:39.889703", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "12G\topenebs", "stdout_lines": ["12G\topenebs"]}

TASK [Obtain the replica pod which was being deleted] **************************
2020-04-19T15:02:41.495416 (delta: 1.871812)         elapsed: 931.825993 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-54fac9d7-665e-4401-a94e-06b088e1cc93\" -o jsonpath='{.items[?(@.spec.nodeName==\"'e2e1-node3'\")].metadata.name}'", "delta": "0:00:01.024926", "end": "2020-04-19 15:02:42.913597", "failed_when_result": false, "rc": 0, "start": "2020-04-19 15:02:41.888671", "stderr": "", "stderr_lines": [], "stdout": "pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp", "stdout_lines": ["pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp"]}

TASK [Verify consumed storage size in replica] *********************************
2020-04-19T15:02:42.993940 (delta: 1.498453)         elapsed: 933.324517 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti pvc-54fac9d7-665e-4401-a94e-06b088e1cc93-rep-1-5f5997f9db-wmzdp -n openebs -- bash -c \"du -h openebs\"", "delta": "0:00:01.598710", "end": "2020-04-19 15:02:44.852609", "rc": 0, "start": "2020-04-19 15:02:43.253899", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "12G\topenebs", "stdout_lines": ["12G\topenebs"]}

TASK [set_fact] ****************************************************************
2020-04-19T15:02:44.919490 (delta: 1.925443)         elapsed: 935.250067 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-04-19T15:02:45.029439 (delta: 0.109823)         elapsed: 935.360016 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-19T15:02:45.187464 (delta: 0.157959)         elapsed: 935.518041 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-19T15:02:45.257360 (delta: 0.069771)         elapsed: 935.587937 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-19T15:02:45.345903 (delta: 0.088474)         elapsed: 935.67648 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-19T15:02:45.425085 (delta: 0.079096)         elapsed: 935.755662 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "c7bb453ba95ef8088d0ef7c98077677950db905c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f84c1414b1d6a85910ec1a182e205f1f", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1587308565.5-61541545259701/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-19T15:02:47.210176 (delta: 1.785033)         elapsed: 937.540753 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.707619", "end": "2020-04-19 15:02:48.170334", "rc": 0, "start": "2020-04-19 15:02:47.462715", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-revision-counter \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-revision-counter ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-19T15:02:48.234716 (delta: 1.024425)         elapsed: 938.565293 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-19T14:47:23Z", "generation": 2, "name": "jiva-revision-counter", "resourceVersion": "35509", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-revision-counter", "uid": "81115f49-b3bf-4db9-a1b7-25e9bc4b1c34"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=94   changed=75   unreachable=0    failed=0   

2020-04-19T15:02:49.333791 (delta: 1.099003)         elapsed: 939.664368 ****** 
=============================================================================== 
```
