### PR TITLE
feat[yaml]: Implemented litmusbook to validate jiva volume cleanup job policies

### DIFF
--- a/experiments/functional/jiva-cleanup-job/README.md
+++ b/experiments/functional/jiva-cleanup-job/README.md
@@ -1,0 +1,55 @@
+## Experiment Metadata
+
+| Type       | Description                                                  | Storage | Applications | K8s Platform |
+| ---------- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Functional | Create the cleanup jobs for jiva volume and validate its completion even after adding taints to nodes. | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- OpenEBS >=1.9 should be installed to create storage classes with
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}"
+  annotations:
+    openebs.io/cas-type: jiva
+    cas.openebs.io/config: |
+      - name: ReplicaCount
+        value: "3"
+      - name: StoragePool
+        value: default
+      - name: ReplicaTolerations
+        value: |
+          t1:
+            key: "{{ taint_key }}"
+            operator: "Equal"
+            value: "{{ taint_value }}"
+            effect: "NoSchedule"
+provisioner: openebs.io/provisioner-iscsi
+```
+
+## Exit-Criteria
+
+- Jiva cleanup jobs should be created and completed successfully in openebs namespace.
+
+## Notes
+
+- This functional test checks if the Jiva volume cleanup jobs can be created successfully even after tainting the nodes.
+- This litmusbook accepts the parameters in form of job environmental variables.
+- This job adds the tolerations into the storage class spec itself.
+- This job itself creates a pvc and deploys a busybox application on top of that. Later, it deletes the jiva volume to create volume cleanup jobs.
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| APP_NAMESPACE | Namespace where application and volume to be deployed  |
+| APP_PVC       | Name of PVC to be created                              |
+| APP_LABEL     | Label of application pod                               |
+| PV_CAPACITY   | Storage capacity of volume to be created               |
+| TAINT_KEY     | Key in the key-value pair of taints                    |
+| TAINT_VALUE   | Value in the key-value pair of taints                  |
+| OPERATOR_NS   | openebs                                                |
+| PROVIDER_STORAGE_CLASS   | Name of storage class to be created               |

--- a/experiments/functional/jiva-cleanup-job/busybox_deployment.yml
+++ b/experiments/functional/jiva-cleanup-job/busybox_deployment.yml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    lkey: lvalue
+  name: busybox
+spec:
+  clusterIP: None
+  selector:
+    lkey: lvalue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-busybox
+  labels:
+    lkey: lvalue
+spec:
+  serviceName: busybox
+  selector:
+    matchLabels:
+      lkey: lvalue
+  template:
+    metadata:
+      labels:
+        lkey: lvalue
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: testclaim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: teststorage

--- a/experiments/functional/jiva-cleanup-job/run_litmus_test.yml
+++ b/experiments/functional/jiva-cleanup-job/run_litmus_test.yml
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-cleanup-job-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-jiva-cleanup-job
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: jiva-cleanup-job
+
+            # Storage Class name to be created
+          - name: PROVIDER_STORAGE_CLASS
+            value: jiva-3r
+ 
+            # Key in the key-value pair of taints
+          - name: TAINT_KEY
+            value: nodeKey
+
+            # Value in the key-value pair of taints
+          - name: TAINT_VALUE
+            value: storage
+
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+ 
+            # Application Label
+          - name: APP_LABEL
+            value: 'app=busybox-sts'
+
+            # Persistent Volume size
+          - name: PV_CAPACITY
+            value: 5Gi
+           
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/jiva-cleanup-job/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/jiva-cleanup-job/sc.j2
+++ b/experiments/functional/jiva-cleanup-job/sc.j2
@@ -1,0 +1,19 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}"
+  annotations:
+    openebs.io/cas-type: jiva
+    cas.openebs.io/config: |
+      - name: ReplicaCount
+        value: "3"
+      - name: StoragePool
+        value: default
+      - name: ReplicaTolerations
+        value: |
+          t1:
+            key: "{{ taint_key }}"
+            operator: "Equal"
+            value: "{{ taint_value }}"
+            effect: "NoSchedule"
+provisioner: openebs.io/provisioner-iscsi

--- a/experiments/functional/jiva-cleanup-job/test.yml
+++ b/experiments/functional/jiva-cleanup-job/test.yml
@@ -92,7 +92,7 @@
           args:
             executable: /bin/bash
           register: cleanup_jobs
-          failed_when: "cleanup_jobs.rc != 0"
+          failed_when: "cleanup_jobs.stdout == ''"
 
         - name: Check if the cleanup jobs completed successfully
           shell: >

--- a/experiments/functional/jiva-cleanup-job/test.yml
+++ b/experiments/functional/jiva-cleanup-job/test.yml
@@ -1,0 +1,137 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+          ## Creating the storage class with tolerations enabled
+        - name: generating yaml file for storage class
+          template: 
+            src: sc.j2
+            dest: storage.yml
+
+        - name: Create the storage class
+          shell: kubectl apply -f storage.yml
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+          ## Creating namespaces and making the application for deployment
+        - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+
+        - name: Replace the volume capacity placeholder with provider
+          replace:
+              path: "{{ application_deployment }}"
+              regexp: "teststorage"
+              replace: "{{ lookup('env','PV_CAPACITY') }}"
+
+          ## Deploying the application
+        - include_tasks: /utils/k8s/deploy_single_app.yml
+          vars:
+            check_app_pod: 'yes'
+            delay: 10
+            retries: 20
+
+        - name: Obtain the pv name of the application.
+          shell: >
+            kubectl get pvc -n "{{ app_ns }}" -o custom-columns=:.spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: pv_name
+          failed_when: "pv_name.rc != 0"
+
+        - name: Obtain the node names on which jiva replica pods are scheduled
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ pv_name.stdout }}" 
+            --no-headers -o custom-columns=:.spec.nodeName
+          args:
+            executable: /bin/bash
+          register: replica_nodes
+          failed_when: "replica_nodes.rc != 0"
+                
+        - name: Taint all the replica nodes
+          shell: kubectl taint node "{{ item }}" "{{ taint_key }}"="{{ taint_value }}":NoSchedule
+          args:
+            executable: /bin/bash
+          with_items:
+            - "{{ replica_nodes.stdout_lines }}"
+
+        - name: Delete the application deployment
+          shell: > 
+            kubectl delete deployment -n {{ app_ns }} -l {{ app_label }}
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Delete the application pvc
+          shell: >
+            kubectl delete pvc {{ app_pvc }} -n {{ app_ns }}
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Obtain the cleanup jobs pod name in operator namespace
+          shell: >
+            kubectl get pod -n {{ operator_ns }} --no-headers 
+            -o custom-columns=:.metadata.name | grep sjr-"{{ pv_name.stdout }}"
+          args:
+            executable: /bin/bash
+          register: cleanup_jobs
+          failed_when: "cleanup_jobs.rc != 0"
+
+        - name: Check if the cleanup jobs completed successfully
+          shell: >
+            kubectl get pods "{{ item }}" -n "{{ operator_ns }}" 
+            -o custom-columns=:.status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: status
+          with_items:
+              - "{{ cleanup_jobs.stdout_lines }}"
+          until: "((status.stdout_lines|unique)|length) == 1 and 'Succeeded' in status.stdout"
+          delay: 5
+          retries: 12              
+
+        - name: Deleting the Application Namespace
+          shell: >
+            kubectl delete namespace {{ app_ns }} 
+          args:
+            executable: /bin/bash
+          register: status    
+          failed_when: "status.rc !=0 "
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+        
+        - name: Remove taints from all the jiva replica nodes
+          shell: kubectl taint node "{{ item }}" "{{ taint_key }}"-
+          args:
+            executable: /bin/bash
+          with_items:
+            - "{{ replica_nodes.stdout_lines }}"
+
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/jiva-cleanup-job/test_vars.yml
+++ b/experiments/functional/jiva-cleanup-job/test_vars.yml
@@ -1,0 +1,10 @@
+---
+test_name: jiva-cleanup-job
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+application_deployment: busybox_deployment.yml
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+app_label: "{{ lookup('env','APP_LABEL') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+taint_key: "{{ lookup('env','TAINT_KEY') }}"
+taint_value: "{{ lookup('env','TAINT_VALUE') }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented litmusbook to validate jiva volume cleanup job policies.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #270 

**Special notes for your reviewer**:
Logs for the test:-
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/jiva-cleanup-job/test.yml

PLAY [localhost] ***************************************************************
2020-04-22T08:27:04.275215 (delta: 0.07423)         elapsed: 0.07423 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:3
2020-04-22T08:27:04.290779 (delta: 0.015519)         elapsed: 0.089794 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:12
2020-04-22T08:27:14.017017 (delta: 9.726209)         elapsed: 9.816032 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-04-22T08:27:14.171278 (delta: 0.154179)         elapsed: 9.970293 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-04-22T08:27:14.263473 (delta: 0.092083)         elapsed: 10.062488 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:15
2020-04-22T08:27:14.342750 (delta: 0.079093)         elapsed: 10.141765 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-22T08:27:14.470757 (delta: 0.127955)         elapsed: 10.269772 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ac4d0cd2e630596808a0c2e74c1f12f6c1ea4d44", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bf7f71722d0e64faba6b3a5d49c6fb53", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1587544034.57-250223708738244/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-22T08:27:15.423158 (delta: 0.952342)         elapsed: 11.222173 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.815126", "end": "2020-04-22 08:27:16.780356", "rc": 0, "start": "2020-04-22 08:27:15.965230", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-cleanup-job \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-cleanup-job ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-22T08:27:16.875316 (delta: 1.452104)         elapsed: 12.674331 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-20T17:33:17Z", "generation": 8, "name": "jiva-cleanup-job", "resourceVersion": "1071994", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-cleanup-job", "uid": "9456e2e2-7773-400f-ad07-5ec6d4ff5978"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-22T08:27:18.593378 (delta: 1.718013)         elapsed: 14.392393 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-22T08:27:18.666224 (delta: 0.072791)         elapsed: 14.465239 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-22T08:27:18.744011 (delta: 0.077731)         elapsed: 14.543026 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [generating yaml file for storage class] **********************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:20
2020-04-22T08:27:18.817730 (delta: 0.07364)         elapsed: 14.616745 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b2ddfa19cc95a24ab27306feed029a5a346d662a", "dest": "./storage.yml", "gid": 0, "group": "root", "md5sum": "8f3a587e54c5eba344f1022262995efa", "mode": "0644", "owner": "root", "size": 470, "src": "/root/.ansible/tmp/ansible-tmp-1587544038.87-273965981281332/source", "state": "file", "uid": 0}

TASK [Create the storage class] ************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:25
2020-04-22T08:27:19.394215 (delta: 0.576421)         elapsed: 15.19323 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f storage.yml", "delta": "0:00:01.607976", "end": "2020-04-22 08:27:21.291455", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:27:19.683479", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/jiva-3r created", "stdout_lines": ["storageclass.storage.k8s.io/jiva-3r created"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:33
2020-04-22T08:27:21.409011 (delta: 2.014673)         elapsed: 17.208026 ******* 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
task path: /utils/k8s/pre_create_app_deploy.yml:3
2020-04-22T08:27:21.627613 (delta: 0.218527)         elapsed: 17.426628 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc \"jiva-3r\"", "delta": "0:00:01.277747", "end": "2020-04-22 08:27:23.337486", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:27:22.059739", "stderr": "", "stderr_lines": [], "stdout": "NAME      PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE\njiva-3r   openebs.io/provisioner-iscsi   Delete          Immediate           false                  2s", "stdout_lines": ["NAME      PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE", "jiva-3r   openebs.io/provisioner-iscsi   Delete          Immediate           false                  2s"]}

TASK [Replace the pvc placeholder with provider] *******************************
task path: /utils/k8s/pre_create_app_deploy.yml:10
2020-04-22T08:27:23.419180 (delta: 1.791495)         elapsed: 19.218195 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
task path: /utils/k8s/pre_create_app_deploy.yml:16
2020-04-22T08:27:24.065062 (delta: 0.645785)         elapsed: 19.864077 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/pre_create_app_deploy.yml:22
2020-04-22T08:27:24.374117 (delta: 0.308387)         elapsed: 20.173132 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
task path: /utils/k8s/pre_create_app_deploy.yml:25
2020-04-22T08:27:24.448746 (delta: 0.07458)         elapsed: 20.247761 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "app", "app_lvalue": "busybox-sts"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
task path: /utils/k8s/pre_create_app_deploy.yml:30
2020-04-22T08:27:24.620240 (delta: 0.17143)         elapsed: 20.419255 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
task path: /utils/k8s/pre_create_app_deploy.yml:36
2020-04-22T08:27:24.961675 (delta: 0.341371)         elapsed: 20.76069 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/pre_create_app_deploy.yml:45
2020-04-22T08:27:25.052052 (delta: 0.090316)         elapsed: 20.851067 ******* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
task path: /utils/k8s/create_ns.yml:2
2020-04-22T08:27:25.169872 (delta: 0.117758)         elapsed: 20.968887 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.250696", "end": "2020-04-22 08:27:26.624102", "rc": 0, "start": "2020-04-22 08:27:25.373406", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-node-lease\nkube-public\nkube-system\nlitmus\nopenebs\nsam", "stdout_lines": ["default", "kube-node-lease", "kube-public", "kube-system", "litmus", "openebs", "sam"]}

TASK [Create test specific namespace.] *****************************************
task path: /utils/k8s/create_ns.yml:11
2020-04-22T08:27:26.723125 (delta: 1.553204)         elapsed: 22.52214 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns busybox", "delta": "0:00:01.252298", "end": "2020-04-22 08:27:28.219861", "rc": 0, "start": "2020-04-22 08:27:26.967563", "stderr": "", "stderr_lines": [], "stdout": "namespace/busybox created", "stdout_lines": ["namespace/busybox created"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/create_ns.yml:17
2020-04-22T08:27:28.299118 (delta: 1.575921)         elapsed: 24.098133 ******* 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
task path: /utils/k8s/status_testns.yml:2
2020-04-22T08:27:28.411195 (delta: 0.112017)         elapsed: 24.21021 ******** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2020-04-22T08:27:28Z", "name": "busybox", "resourceVersion": "1072043", "selfLink": "/api/v1/namespaces/busybox", "uid": "d5fe48f6-7403-4233-b076-fc869f01448a"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [Replace the volume capacity placeholder with provider] *******************
task path: /experiments/functional/jiva-cleanup-job/test.yml:35
2020-04-22T08:27:29.894260 (delta: 1.482984)         elapsed: 25.693275 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:42
2020-04-22T08:27:30.243250 (delta: 0.348905)         elapsed: 26.042265 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying {{ application_name }}] ****************************************
task path: /utils/k8s/deploy_single_app.yml:4
2020-04-22T08:27:30.398458 (delta: 0.155036)         elapsed: 26.197473 ******* 
changed: [127.0.0.1] => {"changed": true, "result": {"results": [{"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "Service", "metadata": {"creationTimestamp": "2020-04-22T08:27:31Z", "labels": {"app": "busybox-sts"}, "name": "busybox", "namespace": "busybox", "resourceVersion": "1072064", "selfLink": "/api/v1/namespaces/busybox/services/busybox", "uid": "db9dd5c9-5da3-4bef-8564-61a6bfe284a2"}, "spec": {"clusterIP": "None", "selector": {"app": "busybox-sts"}, "sessionAffinity": "None", "type": "ClusterIP"}, "status": {"loadBalancer": {}}}}, {"changed": true, "method": "create", "result": {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"creationTimestamp": "2020-04-22T08:27:31Z", "generation": 1, "labels": {"app": "busybox-sts"}, "name": "app-busybox", "namespace": "busybox", "resourceVersion": "1072066", "selfLink": "/apis/apps/v1/namespaces/busybox/deployments/app-busybox", "uid": "79d56228-6696-4dfa-bd25-6f7e73169e85"}, "spec": {"progressDeadlineSeconds": 600, "replicas": 1, "revisionHistoryLimit": 10, "selector": {"matchLabels": {"app": "busybox-sts"}}, "strategy": {"rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"}, "type": "RollingUpdate"}, "template": {"metadata": {"creationTimestamp": null, "labels": {"app": "busybox-sts"}}, "spec": {"containers": [{"args": ["-c", "while true; do sleep 10;done"], "command": ["/bin/sh"], "image": "busybox", "imagePullPolicy": "IfNotPresent", "name": "app-busybox", "resources": {}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/busybox", "name": "data-vol"}]}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "terminationGracePeriodSeconds": 30, "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "openebs-busybox"}}]}}}, "status": {}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"creationTimestamp": "2020-04-22T08:27:31Z", "finalizers": ["kubernetes.io/pvc-protection"], "name": "openebs-busybox", "namespace": "busybox", "resourceVersion": "1072075", "selfLink": "/api/v1/namespaces/busybox/persistentvolumeclaims/openebs-busybox", "uid": "2c30d114-5ad0-462c-86fa-6490cf139bfe"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "5Gi"}}, "storageClassName": "jiva-3r", "volumeMode": "Filesystem"}, "status": {"phase": "Pending"}}}]}}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/deploy_single_app.yml:12
2020-04-22T08:27:31.974500 (delta: 1.575916)         elapsed: 27.773515 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-04-22T08:27:32.157871 (delta: 0.183292)         elapsed: 27.956886 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
changed: [127.0.0.1] => {"attempts": 7, "changed": true, "cmd": "kubectl get pod -n busybox -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.048991", "end": "2020-04-22 08:27:55.817960", "rc": 0, "start": "2020-04-22 08:27:54.768969", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-04-22T08:27:53Z]]", "stdout_lines": ["map[running:map[startedAt:2020-04-22T08:27:53Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-04-22T08:27:55.953040 (delta: 23.79509)         elapsed: 51.752055 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n busybox -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.023072", "end": "2020-04-22 08:27:57.344315", "rc": 0, "start": "2020-04-22 08:27:56.321243", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /utils/k8s/deploy_single_app.yml:15
2020-04-22T08:27:57.459429 (delta: 1.506324)         elapsed: 53.258444 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the pv name of the application.] **********************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:48
2020-04-22T08:27:57.597886 (delta: 0.138401)         elapsed: 53.396901 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n \"busybox\" -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.124841", "end": "2020-04-22 08:27:59.154235", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:27:58.029394", "stderr": "", "stderr_lines": [], "stdout": "pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe", "stdout_lines": ["pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe"]}

TASK [Obtain the node names on which jiva replica pods are scheduled] **********
task path: /experiments/functional/jiva-cleanup-job/test.yml:56
2020-04-22T08:27:59.249782 (delta: 1.651828)         elapsed: 55.048797 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe\" --no-headers -o custom-columns=:.spec.nodeName", "delta": "0:00:01.155778", "end": "2020-04-22 08:28:00.704846", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:27:59.549068", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1\ne2e1-node3\ne2e1-node2", "stdout_lines": ["e2e1-node1", "e2e1-node3", "e2e1-node2"]}

TASK [Taint all the replica nodes] *********************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:65
2020-04-22T08:28:00.844307 (delta: 1.594455)         elapsed: 56.643322 ******* 
changed: [127.0.0.1] => (item=e2e1-node1) => {"changed": true, "cmd": "kubectl taint node \"e2e1-node1\" \"nodeKey\"=\"storage\":NoSchedule", "delta": "0:00:01.172170", "end": "2020-04-22 08:28:02.300211", "item": "e2e1-node1", "rc": 0, "start": "2020-04-22 08:28:01.128041", "stderr": "", "stderr_lines": [], "stdout": "node/e2e1-node1 tainted", "stdout_lines": ["node/e2e1-node1 tainted"]}
changed: [127.0.0.1] => (item=e2e1-node3) => {"changed": true, "cmd": "kubectl taint node \"e2e1-node3\" \"nodeKey\"=\"storage\":NoSchedule", "delta": "0:00:01.129562", "end": "2020-04-22 08:28:03.708095", "item": "e2e1-node3", "rc": 0, "start": "2020-04-22 08:28:02.578533", "stderr": "", "stderr_lines": [], "stdout": "node/e2e1-node3 tainted", "stdout_lines": ["node/e2e1-node3 tainted"]}
changed: [127.0.0.1] => (item=e2e1-node2) => {"changed": true, "cmd": "kubectl taint node \"e2e1-node2\" \"nodeKey\"=\"storage\":NoSchedule", "delta": "0:00:01.267502", "end": "2020-04-22 08:28:05.214824", "item": "e2e1-node2", "rc": 0, "start": "2020-04-22 08:28:03.947322", "stderr": "", "stderr_lines": [], "stdout": "node/e2e1-node2 tainted", "stdout_lines": ["node/e2e1-node2 tainted"]}

TASK [Delete the application deployment] ***************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:72
2020-04-22T08:28:05.321549 (delta: 4.477149)         elapsed: 61.120564 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete deployment -n busybox -l app=busybox-sts", "delta": "0:00:01.065614", "end": "2020-04-22 08:28:06.780392", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:28:05.714778", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"app-busybox\" deleted", "stdout_lines": ["deployment.apps \"app-busybox\" deleted"]}

TASK [Delete the application pvc] **********************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:80
2020-04-22T08:28:06.899326 (delta: 1.577692)         elapsed: 62.698341 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc openebs-busybox -n busybox", "delta": "0:00:37.918192", "end": "2020-04-22 08:28:45.081797", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:28:07.163605", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"openebs-busybox\" deleted", "stdout_lines": ["persistentvolumeclaim \"openebs-busybox\" deleted"]}

TASK [Obtain the cleanup jobs pod name in operator namespace] ******************
task path: /experiments/functional/jiva-cleanup-job/test.yml:88
2020-04-22T08:28:45.236705 (delta: 38.337274)         elapsed: 101.03572 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs --no-headers -o custom-columns=:.metadata.name | grep sjr-\"pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe\"", "delta": "0:00:01.682967", "end": "2020-04-22 08:28:47.376062", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:28:45.693095", "stderr": "", "stderr_lines": [], "stdout": "sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-1ahk-z4k4k\nsjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-4r0r-dwkbs\nsjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-79sv-tz5pz", "stdout_lines": ["sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-1ahk-z4k4k", "sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-4r0r-dwkbs", "sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-79sv-tz5pz"]}

TASK [Check if the cleanup jobs completed successfully] ************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:97
2020-04-22T08:28:47.532100 (delta: 2.295306)         elapsed: 103.331115 ****** 
FAILED - RETRYING: Check if the cleanup jobs completed successfully (12 retries left).
changed: [127.0.0.1] => (item=sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-1ahk-z4k4k) => {"attempts": 2, "changed": true, "cmd": "kubectl get pods \"sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-1ahk-z4k4k\" -n \"openebs\" -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.231814", "end": "2020-04-22 08:28:57.074371", "item": "sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-1ahk-z4k4k", "rc": 0, "start": "2020-04-22 08:28:55.842557", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}
changed: [127.0.0.1] => (item=sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-4r0r-dwkbs) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods \"sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-4r0r-dwkbs\" -n \"openebs\" -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.447773", "end": "2020-04-22 08:28:58.720776", "item": "sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-4r0r-dwkbs", "rc": 0, "start": "2020-04-22 08:28:57.273003", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}
changed: [127.0.0.1] => (item=sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-79sv-tz5pz) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods \"sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-79sv-tz5pz\" -n \"openebs\" -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.157489", "end": "2020-04-22 08:29:00.132813", "item": "sjr-pvc-2c30d114-5ad0-462c-86fa-6490cf139bfe-79sv-tz5pz", "rc": 0, "start": "2020-04-22 08:28:58.975324", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Deleting the Application Namespace] **************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:110
2020-04-22T08:29:00.233895 (delta: 12.70172)         elapsed: 116.03291 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete namespace busybox", "delta": "0:00:06.430525", "end": "2020-04-22 08:29:06.995985", "failed_when_result": false, "rc": 0, "start": "2020-04-22 08:29:00.565460", "stderr": "", "stderr_lines": [], "stdout": "namespace \"busybox\" deleted", "stdout_lines": ["namespace \"busybox\" deleted"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:118
2020-04-22T08:29:07.164636 (delta: 6.930674)         elapsed: 122.963651 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Remove taints from all the jiva replica nodes] ***************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:127
2020-04-22T08:29:07.299657 (delta: 0.134918)         elapsed: 123.098672 ****** 
changed: [127.0.0.1] => (item=e2e1-node1) => {"changed": true, "cmd": "kubectl taint node \"e2e1-node1\" \"nodeKey\"-", "delta": "0:00:01.105213", "end": "2020-04-22 08:29:08.744643", "item": "e2e1-node1", "rc": 0, "start": "2020-04-22 08:29:07.639430", "stderr": "", "stderr_lines": [], "stdout": "node/e2e1-node1 untainted", "stdout_lines": ["node/e2e1-node1 untainted"]}
changed: [127.0.0.1] => (item=e2e1-node3) => {"changed": true, "cmd": "kubectl taint node \"e2e1-node3\" \"nodeKey\"-", "delta": "0:00:01.018424", "end": "2020-04-22 08:29:10.039370", "item": "e2e1-node3", "rc": 0, "start": "2020-04-22 08:29:09.020946", "stderr": "", "stderr_lines": [], "stdout": "node/e2e1-node3 untainted", "stdout_lines": ["node/e2e1-node3 untainted"]}
changed: [127.0.0.1] => (item=e2e1-node2) => {"changed": true, "cmd": "kubectl taint node \"e2e1-node2\" \"nodeKey\"-", "delta": "0:00:01.152666", "end": "2020-04-22 08:29:11.486906", "item": "e2e1-node2", "rc": 0, "start": "2020-04-22 08:29:10.334240", "stderr": "", "stderr_lines": [], "stdout": "node/e2e1-node2 untainted", "stdout_lines": ["node/e2e1-node2 untainted"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-cleanup-job/test.yml:135
2020-04-22T08:29:11.592119 (delta: 4.292399)         elapsed: 127.391134 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-22T08:29:11.759206 (delta: 0.166815)         elapsed: 127.558221 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-22T08:29:11.836865 (delta: 0.077602)         elapsed: 127.63588 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-22T08:29:11.950696 (delta: 0.113251)         elapsed: 127.749711 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-22T08:29:12.044672 (delta: 0.0939)         elapsed: 127.843687 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "7d98b015798c5939e8efc6638be7c2ed80636471", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2b1776da03e6ed29526aac26e29c5678", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1587544152.12-189813889725801/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-22T08:29:14.241675 (delta: 2.196929)         elapsed: 130.04069 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.947407", "end": "2020-04-22 08:29:15.420669", "rc": 0, "start": "2020-04-22 08:29:14.473262", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-cleanup-job \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-cleanup-job ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-22T08:29:15.497980 (delta: 1.256228)         elapsed: 131.296995 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-20T17:33:17Z", "generation": 9, "name": "jiva-cleanup-job", "resourceVersion": "1072976", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-cleanup-job", "uid": "9456e2e2-7773-400f-ad07-5ec6d4ff5978"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=39   changed=27   unreachable=0    failed=0   

2020-04-22T08:29:16.727973 (delta: 1.229935)         elapsed: 132.526988 ****** 
=============================================================================== 
```