### PR TITLE
Added test to install zfs-controller in HA and its behaviour when replica goes down

### DIFF
--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/README.md
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/README.md
@@ -1,0 +1,29 @@
+## Experiment Metadata
+
+| Type       | Description                                             |  K8s Platform and OS        |
+| ---------- | --------------------------------------------------------|  ----------------------     |
+| Functional  Scale the zfs-controller replicas and check the zfspv behaviour when one of the replica goes down                 | K8s 1.14 + and Ubuntu 18.04 |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- Application should be deployed succesfully if there any; consuming the ZFS-localPV storage.
+- ZFS-controller and node-agent daemonset pods should be in running state.
+
+## Exit-Criteria
+
+- zfs-controller statefulset should be scaled up by one replica.
+- All the replias should be in running state.
+- All the zfs volumes should be healthy and data prior to the upgrade should not be impacted.
+- This test makes one replica to go down as a result active/master replica of zfs-controller prior to the test will be changed to some other remaining replica after the test completes.
+- Volumes provisioning / deprovisioning should not be impact if one replica goes down.
+
+## Notes
+
+- This functional test scale the zfs-controller replica and any other replica takes the place of master/active replica when the same goes down.
+- For running this litmus experiment of zfs-controller High availability test ceate the kubernetes job from run_litmus_test.yml file
+- This test checks the starting no of replicas of zfs-controller and scale it by one if a free node is present which is able to schedule the pods.
+
+
+
+

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/busybox_app.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/busybox_app.yml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-busybox-ha
+  labels:
+    app: test_ha
+spec:
+  selector:
+    matchLabels:
+      app: test_ha
+  template:
+    metadata:
+      labels:
+        app: test_ha
+    spec:
+      tolerations:
+      - key: "key"
+        operator: "Equal"
+        value: "value"
+        effect: "NoSchedule"
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: pvcha
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvcha
+spec:
+  storageClassName: sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/busybox_app.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/busybox_app.yml
@@ -38,7 +38,7 @@ apiVersion: v1
 metadata:
   name: pvcha
 spec:
-  storageClassName: sc
+  storageClassName: zfs-sc-zfs
   accessModes:
     - ReadWriteOnce
   resources:

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/run_litmus_test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/run_litmus_test.yml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: zfs-controller-high-avail
+  generateName: zfs-controller-high-availability
   namespace: litmus
 spec:
   template:
     metadata:
       labels:
-        name: zfs-controller-high-avail
+        name: zfs-controller-high-availability
     spec:
       serviceAccountName: litmus
       restartPolicy: Never

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/run_litmus_test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/run_litmus_test.yml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: zfs-controller-high-avail
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: zfs-controller-high-avail
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/run_litmus_test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/run_litmus_test.yml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: zfs-controller-high-availability
+  generateName: zfs-controller-high-availability-
   namespace: litmus
 spec:
   template:

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
@@ -31,7 +31,7 @@
 
         - name: Get the count of the nodes which don't have `NoSchedule` taints
           shell: >
-            kubectl get no --no-headers -o custom-columns=:.metadata.name,:.spec.taints
+            kubectl get nodes --no-headers -o custom-columns=:.metadata.name,:.spec.taints
             | grep -v NoSchedule | wc -l
           args:
             executable: /bin/bash
@@ -57,6 +57,10 @@
             kubectl taint node {{ item }} key=value:NoSchedule
           args:
             executable: /bin/bash
+          register: taint_status
+          until: "'tainted' in taint_status.stdout "
+          retries: 20
+          delay: 5
           with_items: "{{ node_list.stdout_lines }}"
 
         - name: Delete the {{ active_replica_name.stdout }} replica pod

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
@@ -1,0 +1,123 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+        - name: Get the no of replicas in zfs-controller statefulset 
+          shell: >
+            kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.status.replicas}'
+          args:
+            executable: /bin/bash
+          register: zfs_ctrl_replicas
+
+        - name: Get the list of names of all the nodes in cluster
+          shell: >
+            kubectl get nodes --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: node_list
+
+        - name: Get the count of the nodes which don't have `NoSchedule` taints
+          shell: >
+            kubectl get no --no-headers -o custom-columns=:.metadata.name,:.spec.taints
+            | grep -v NoSchedule | wc -l
+          args:
+            executable: /bin/bash
+          register: no_of_Schedulable_nodes
+        
+        - name: scale the replicas of zfs-controller statefulset
+          shell: >
+            kubectl scale sts openebs-zfs-controller -n kube-system
+            --replicas="{{ zfs_ctrl_replicas.stdout|int + 1 }}"
+          args:
+            executable: /bin/bash
+          when: "{{ zfs_ctrl_replicas.stdout|int + 1 }} <= {{no_of_Schedulable_nodes.stdout|int}}"
+
+        - name: Get the name of the controller pod replica which is active as master at present
+          shell: >
+            kubectl get lease zfs-csi-openebs-io -n kube-system -o jsonpath='{.spec.holderIdentity}'
+          args: 
+            executable: /bin/bash
+          register: active_replica_name
+
+        - name: Taint all nodes with `NoSchedule` to keep replica {{ active_replica_name.stdout }} out of action
+          shell: >
+            kubectl taint node {{ item }} key=value:NoSchedule
+          args:
+            executable: /bin/bash
+          with_items: "{{ node_list.stdout_lines }}"
+
+        - name: Delete the {{ active_replica_name.stdout }} replica pod
+          shell: >
+            kubectl delete pod {{ active_replica_name.stdout }} -n kube-system
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Get the new replica name which is in action as master for zfs-controller
+          shell: >
+            kubectl get lease zfs-csi-openebs-io -n kube-system -o jsonpath='{.spec.holderIdentity}'
+          args: 
+            executable: /bin/bash
+          register: new_active_replica
+          retries: 30
+          delay: 5
+          until: active_replica_name.stdout != new_active_replica.stdout
+
+        - name: Provision volume to check zfs-controller in HA working fine when one replica is down
+          shell: >
+            kubectl apply -f busybox_app.yml
+          args: 
+            executable: /bin/bash
+          
+        - name: Check if the PVC is Bound
+          shell: >
+            kubectl get pvc pvcha -n litmus -o jsonpath='{.status.phase}'
+          args:
+            executable: /bin/bash
+          register: pvc_status
+          until: "'Bound' in pvc_status.stdout"
+          delay: 5
+          retries: 30
+          
+        - name: Check if the application pod is in running state.
+          shell: >
+            kubectl get pods -n litmus -o jsonpath='{.items[?(@.metadata.labels.app=="test_ha")].status.phase}'
+          register: pod_status
+          until: "'Running' in pod_status.stdout"
+          delay: 5
+          retries: 20
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+
+        - name: Remove the taint from the nodes
+          shell: >
+            kubectl taint node {{ item }} key-
+          args:
+            executable: /bin/bash
+          with_items: "{{ node_list.stdout_lines }}"
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
@@ -113,7 +113,7 @@
             flag: "Fail"
 
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          ## RECORD END-OF-TEST IN LITMUS RESULT CR
 
         - name: Remove the taint from the nodes
           shell: >

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/test_vars.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/test_vars.yml
@@ -1,0 +1,1 @@
+test_name: zfs-controller-high-avail

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/test_vars.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/test_vars.yml
@@ -1,1 +1,1 @@
-test_name: zfs-controller-high-avail
+test_name: zfs-controller-high-availability

--- a/providers/zfs-localpv-provisioner/run_litmus_test.yml
+++ b/providers/zfs-localpv-provisioner/run_litmus_test.yml
@@ -31,7 +31,7 @@ spec:
             ## Give full image name (for e.g. quay.io/openebs/zfs-driver:<tag>)
             ## For versioned branch (other than master) leave this empty
             ## This env will be used only when master branch is used with custom-images or tags other than ci
-          - name: ZFS_DRIVER_TAG
+          - name: ZFS_DRIVER_IMAGE
             value: ''
 
             ## Storage class will be created with the name provided here

--- a/providers/zfs-localpv-provisioner/test.yml
+++ b/providers/zfs-localpv-provisioner/test.yml
@@ -34,8 +34,8 @@
             replace:
               path: ./zfs_operator.yml
               regexp: quay.io/openebs/zfs-driver:ci
-              replace: "{{ lookup('env','ZFS_DRIVER_TAG') }}"
-            when: lookup('env','ZFS_DRIVER_TAG') | length > 0
+              replace: "{{ lookup('env','ZFS_DRIVER_IMAGE') }}"
+            when: lookup('env','ZFS_DRIVER_IMAGE') | length > 0
 
           - name: Apply the zfs_operator file to deploy zfs-driver components
             shell: 

--- a/providers/zfs-localpv-provisioner/test_vars.yml
+++ b/providers/zfs-localpv-provisioner/test_vars.yml
@@ -18,6 +18,6 @@ vol_block_size: "{{ lookup('env','VOLBLOCKSIZE') }}"
 
 snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"
 
-zfs_driver_tag: "{{ lookup('env','ZFS_DRIVER_TAG') }}"
+zfs_driver_image: "{{ lookup('env','ZFS_DRIVER_IMAGE') }}"
 
 zfs_branch: "{{ lookup('env','ZFS_BRANCH') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR scale up the zfs-controller statefulset.
- when the controller replica which is in action for all tasks related zfspv goes down at that time the new replica takes places of it.
 Reference: https://github.com/openebs/zfs-localpv/blob/master/docs/faq.md#3-how-to-install-the-provisioner-in-ha

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/openebs/e2e-tests/issues/275


