### PR TITLE
feat[yaml]: Implemented litmusbook to validate jiva logging

### DIFF
--- a/experiments/functional/jiva-logging/README.md
+++ b/experiments/functional/jiva-logging/README.md
@@ -1,0 +1,32 @@
+## Experiment Metadata
+
+| Type       | Description                                                  | Storage | Applications | K8s Platform |
+| ---------- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Functional | Validate the enabling/disabling jiva logging. | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- OpenEBS version should be greater than 1.9 .
+- Application should be deployed using 'jiva storage engine'.
+
+## Exit-Criteria
+
+- jiva replica pods should honour enabling/disabling jiva logging. 
+- Application should be accessible seamlessly.
+
+## Notes
+
+- This functional test checks if the Jiva logging can be enabled/disabled.
+- This litmusbook accepts the parameters in form of job environmental variables.
+- This job validates the enabling/disabling jiva logging that can be achieved through jiva controller pod using `jivactl logtofile enable --maxLogFileSize 100 --retentionPeriod 180 --maxBackups 5`.
+- After disabling the logging, log file content/size should not increase.
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| APP_NAMESPACE | Namespace where application and volume is deployed.    |
+| APP_PVC       | Application pvc                                        |
+| APP_LABEL     | Label of application pod                               |
+| OPERATOR_NS   | openebs                                                |

--- a/experiments/functional/jiva-logging/run_litmus_test.yml
+++ b/experiments/functional/jiva-logging/run_litmus_test.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-logging-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-jiva-logging
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns
+            
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+ 
+            # Application Label
+          - name: APP_LABEL
+            value: 'app=busybox-sts'
+            
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/jiva-logging/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/jiva-logging/test.yml
+++ b/experiments/functional/jiva-logging/test.yml
@@ -1,0 +1,104 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        ## DISPLAY APP INFORMATION
+
+        - name: Display the app information passed via the test job
+          debug:
+            msg:
+              - "The application info is as follows:"
+              - "Namespace    : {{ app_ns }}"
+              - "Label        : {{ app_label }}"
+              - "PVC          : {{ app_pvc }}"
+
+        ## APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
+   
+        - name: Obtain the pv name of the application.
+          shell: >
+            kubectl get pvc -n "{{ app_ns }}" -o custom-columns=:.spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: pv_name
+          failed_when: "pv_name.rc != 0"
+
+        - name: Obtain the jiva controller pod in openebs namespace 
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" 
+            --no-headers -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: controller_pod
+          failed_when: "controller_pod.stdout == ''"
+        
+        ## Disable the logging of jiva replica 
+        - name: Disable the logging of jiva replicas
+          shell: >
+            kubectl exec -ti "{{ controller_pod.stdout }}" -n {{ operator_ns }} 
+            -- bash -c "jivactl logtofile disable" 
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        ## Include task to verify consistency in replica logging file size
+        - include_tasks: "verify_logging.yml"
+          vars: 
+            action: 'disable'
+
+        #### Check the replica access mode before enabling the logging ####
+        - name: Check the replicas access mode
+          include_tasks: "/funclib/openebs/access-mode-check.yml"
+          vars:
+            ns: "{{ app_ns }}"
+            pvc_name: "{{ app_pvc }}"
+
+         ## Enable the logging of jiva replica 
+        - name: Enable the logging of jiva replicas
+          shell: >
+            kubectl exec -ti "{{ controller_pod.stdout }}" -n {{ operator_ns }} 
+            -- bash -c "jivactl logtofile enable" 
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        ## Include task to verify increase in replica logging file size
+        - include_tasks: "verify_logging.yml"
+          vars: 
+            action: 'enable'
+              
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+                  
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/functional/jiva-logging/test_vars.yml
+++ b/experiments/functional/jiva-logging/test_vars.yml
@@ -1,0 +1,10 @@
+---
+test_name: jiva-logging
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"

--- a/experiments/functional/jiva-logging/verify_logging.yml
+++ b/experiments/functional/jiva-logging/verify_logging.yml
@@ -1,0 +1,60 @@
+## To obtain jiva replica logging file size
+- name: Obtain the one of jiva replica pod in openebs namespace
+  shell: >
+    kubectl get pod -n {{ operator_ns }} -l openebs.io/persistent-volume="{{ pv_name.stdout }}",openebs.io/replica=jiva-replica 
+    --no-headers -o custom-columns=:.metadata.name | awk 'FNR==1{print $1}'
+  args:
+    executable: /bin/bash
+  register: replica_pod
+  failed_when: "replica_pod.stdout == ''"
+
+- name: Obtain the jiva logging file size
+  shell: >
+    kubectl exec -it "{{ replica_pod.stdout }}" -n {{ operator_ns }} 
+    -- bash -c "du -h /openebs/replica.log" | awk '{print $1}'
+  args:
+    executable: /bin/bash
+  register: file_size_before
+  failed_when: "file_size_before.stdout == ''"  
+
+## Delete the jiva replicas to verify increase in logging file size
+- name: Delete the jiva replica pods in openebs namespace
+  shell: >
+    kubectl delete pod -n {{ operator_ns }} -l openebs.io/persistent-volume="{{ pv_name.stdout }}",openebs.io/replica=jiva-replica && sleep 10
+  args:
+    executable: /bin/bash
+  register: status
+  failed_when: "status.rc != 0"
+  loop: "{{ range(0, 5 | int, 1)|list }}"  
+
+## Verify increase in jiva replica logging file size
+- name: Obtain the one of jiva replica pod in openebs namespace
+  shell: >
+    kubectl get pod -n {{ operator_ns }} -l openebs.io/persistent-volume="{{ pv_name.stdout }}",openebs.io/replica=jiva-replica 
+    --no-headers -o custom-columns=:.metadata.name | awk 'FNR==1{print $1}'
+  args:
+    executable: /bin/bash
+  register: replica_pod
+  failed_when: "replica_pod.stdout == ''"
+
+- block: 
+    - name: Obtain the jiva logging file size
+      shell: >
+        kubectl exec -it "{{ replica_pod.stdout }}" -n {{ operator_ns }} 
+        -- bash -c "du -h /openebs/replica.log" | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: file_size_after
+      failed_when: "file_size_before.stdout == file_size_after.stdout"
+  when: action == 'enable'
+
+- block: 
+    - name: Obtain the jiva logging file size
+      shell: >
+        kubectl exec -it "{{ replica_pod.stdout }}" -n {{ operator_ns }} 
+        -- bash -c "du -h /openebs/replica.log" | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: file_size_after
+      failed_when: "file_size_before.stdout != file_size_after.stdout"
+  when: action == 'disable'


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented litmusbook to validate jiva logging/flushing logs to file.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #277 

**Special notes for your reviewer**:
Logs for the test:-
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/jiva-logging/test.yml

PLAY [localhost] ***************************************************************
2020-04-28T14:34:56.669899 (delta: 0.068379)         elapsed: 0.068379 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/jiva-logging/test.yml:3
2020-04-28T14:34:56.684644 (delta: 0.014659)         elapsed: 0.083124 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-logging/test.yml:12
2020-04-28T14:35:06.761159 (delta: 10.076443)         elapsed: 10.159639 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-04-28T14:35:06.862816 (delta: 0.101576)         elapsed: 10.261296 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-04-28T14:35:06.946679 (delta: 0.083798)         elapsed: 10.345159 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-logging/test.yml:15
2020-04-28T14:35:07.049338 (delta: 0.102594)         elapsed: 10.447818 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-28T14:35:07.241127 (delta: 0.191691)         elapsed: 10.639607 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "1e8302d348eaaa0cee2b713547fd7429993fb154", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3a70eadc2ab7be48e070f1f9daeed541", "mode": "0644", "owner": "root", "size": 413, "src": "/root/.ansible/tmp/ansible-tmp-1588084507.37-129782278399073/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-28T14:35:08.389739 (delta: 1.148502)         elapsed: 11.788219 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.956757", "end": "2020-04-28 14:35:09.852059", "rc": 0, "start": "2020-04-28 14:35:08.895302", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-logging \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-logging ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-28T14:35:09.917216 (delta: 1.52735)         elapsed: 13.315696 ******** 
ok: [127.0.0.1] => {"changed": false, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-28T12:43:42Z", "generation": 2, "name": "jiva-logging", "resourceVersion": "1930124", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-logging", "uid": "df577cdb-ced2-4454-bd99-23408be847df"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-28T14:35:11.446842 (delta: 1.529571)         elapsed: 14.845322 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-28T14:35:11.542821 (delta: 0.095916)         elapsed: 14.941301 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-28T14:35:11.633854 (delta: 0.09095)         elapsed: 15.032334 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/functional/jiva-logging/test.yml:21
2020-04-28T14:35:11.723807 (delta: 0.089866)         elapsed: 15.122287 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : bb", 
        "Label        : app=busybox-sts", 
        "PVC          : openebs-busybox"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/functional/jiva-logging/test.yml:30
2020-04-28T14:35:11.887019 (delta: 0.163129)         elapsed: 15.285499 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-04-28T14:35:12.009070 (delta: 0.121983)         elapsed: 15.40755 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n bb -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.519632", "end": "2020-04-28 14:35:13.790960", "rc": 0, "start": "2020-04-28 14:35:12.271328", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-04-28T08:21:13Z]]", "stdout_lines": ["map[running:map[startedAt:2020-04-28T08:21:13Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-04-28T14:35:13.874261 (delta: 1.865126)         elapsed: 17.272741 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n bb -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.137435", "end": "2020-04-28 14:35:15.356335", "rc": 0, "start": "2020-04-28 14:35:14.218900", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the pv name of the application.] **********************************
task path: /experiments/functional/jiva-logging/test.yml:38
2020-04-28T14:35:15.433262 (delta: 1.55893)         elapsed: 18.831742 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n \"bb\" -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.171905", "end": "2020-04-28 14:35:16.895293", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:35:15.723388", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710"]}

TASK [Obtain the jiva controller pod in openebs namespace] *********************
task path: /experiments/functional/jiva-logging/test.yml:46
2020-04-28T14:35:16.978464 (delta: 1.545137)         elapsed: 20.376944 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\" --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.010390", "end": "2020-04-28 14:35:18.276550", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:35:17.266160", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x"]}

TASK [Disable the logging of jiva replicas] ************************************
task path: /experiments/functional/jiva-logging/test.yml:56
2020-04-28T14:35:18.366875 (delta: 1.388306)         elapsed: 21.765355 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x\" -n openebs -- bash -c \"jivactl logtofile disable\"", "delta": "0:00:01.476347", "end": "2020-04-28 14:35:20.125764", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:35:18.649417", "stderr": "Defaulting container name to pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-con.\nUse 'kubectl describe pod/pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-con.", "Use 'kubectl describe pod/pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-logging/test.yml:66
2020-04-28T14:35:20.273008 (delta: 1.905976)         elapsed: 23.671488 ******* 
included: /experiments/functional/jiva-logging/verify_logging.yml for 127.0.0.1

TASK [Obtain the one of jiva replica pod in openebs namespace] *****************
task path: /experiments/functional/jiva-logging/verify_logging.yml:2
2020-04-28T14:35:20.530266 (delta: 0.257064)         elapsed: 23.928746 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica --no-headers -o custom-columns=:.metadata.name | awk 'FNR==1{print $1}'", "delta": "0:00:01.091675", "end": "2020-04-28 14:35:21.840607", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:35:20.748932", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dbmch", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dbmch"]}

TASK [Obtain the jiva logging file size] ***************************************
task path: /experiments/functional/jiva-logging/verify_logging.yml:11
2020-04-28T14:35:21.920497 (delta: 1.390168)         elapsed: 25.318977 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dbmch\" -n openebs -- bash -c \"du -h /openebs/replica.log\" | awk '{print $1}'", "delta": "0:00:01.635037", "end": "2020-04-28 14:35:23.846645", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:35:22.211608", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "144K", "stdout_lines": ["144K"]}

TASK [Delete the jiva replica pods in openebs namespace] ***********************
task path: /experiments/functional/jiva-logging/verify_logging.yml:21
2020-04-28T14:35:23.932020 (delta: 2.011453)         elapsed: 27.3305 ********* 
changed: [127.0.0.1] => (item=0) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:14.411947", "end": "2020-04-28 14:35:38.593125", "failed_when_result": false, "item": 0, "rc": 0, "start": "2020-04-28 14:35:24.181178", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dbmch\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-xpkkj\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-h4dcs\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dbmch\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-xpkkj\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-h4dcs\" deleted"]}
changed: [127.0.0.1] => (item=1) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:22.323253", "end": "2020-04-28 14:36:01.242414", "failed_when_result": false, "item": 1, "rc": 0, "start": "2020-04-28 14:35:38.919161", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-2f9b4\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-lsdzk\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-xwn62\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-2f9b4\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-lsdzk\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-xwn62\" deleted"]}
changed: [127.0.0.1] => (item=2) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:20.257287", "end": "2020-04-28 14:36:21.695202", "failed_when_result": false, "item": 2, "rc": 0, "start": "2020-04-28 14:36:01.437915", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dzr4b\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-npc2c\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-wrx9j\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-dzr4b\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-npc2c\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-wrx9j\" deleted"]}
changed: [127.0.0.1] => (item=3) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:18.544794", "end": "2020-04-28 14:36:40.518336", "failed_when_result": false, "item": 3, "rc": 0, "start": "2020-04-28 14:36:21.973542", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-p88cj\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-ffd47\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-76885\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-p88cj\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-ffd47\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-76885\" deleted"]}
changed: [127.0.0.1] => (item=4) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:20.846388", "end": "2020-04-28 14:37:01.737274", "failed_when_result": false, "item": 4, "rc": 0, "start": "2020-04-28 14:36:40.890886", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-q4gml\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-287k5\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-nbfhm\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-q4gml\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-287k5\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-nbfhm\" deleted"]}

TASK [Obtain the one of jiva replica pod in openebs namespace] *****************
task path: /experiments/functional/jiva-logging/verify_logging.yml:31
2020-04-28T14:37:01.895921 (delta: 97.963838)         elapsed: 125.294401 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica --no-headers -o custom-columns=:.metadata.name | awk 'FNR==1{print $1}'", "delta": "0:00:01.304556", "end": "2020-04-28 14:37:03.528039", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:37:02.223483", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r"]}

TASK [Obtain the jiva logging file size] ***************************************
task path: /experiments/functional/jiva-logging/verify_logging.yml:41
2020-04-28T14:37:03.658911 (delta: 1.762847)         elapsed: 127.057391 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the jiva logging file size] ***************************************
task path: /experiments/functional/jiva-logging/verify_logging.yml:52
2020-04-28T14:37:03.776984 (delta: 0.117969)         elapsed: 127.175464 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r\" -n openebs -- bash -c \"du -h /openebs/replica.log\" | awk '{print $1}'", "delta": "0:00:01.688187", "end": "2020-04-28 14:37:05.929445", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:37:04.241258", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "144K", "stdout_lines": ["144K"]}

TASK [Check the replicas access mode] ******************************************
task path: /experiments/functional/jiva-logging/test.yml:71
2020-04-28T14:37:06.023336 (delta: 2.246054)         elapsed: 129.421816 ****** 
included: /funclib/openebs/access-mode-check.yml for 127.0.0.1

TASK [Get the pv name] *********************************************************
task path: /funclib/openebs/access-mode-check.yml:2
2020-04-28T14:37:06.168536 (delta: 0.14512)         elapsed: 129.567016 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n bb -o jsonpath='{.spec.volumeName}'", "delta": "0:00:00.954648", "end": "2020-04-28 14:37:07.341744", "rc": 0, "start": "2020-04-28 14:37:06.387096", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710"]}

TASK [Get the nodes count] *****************************************************
task path: /funclib/openebs/access-mode-check.yml:9
2020-04-28T14:37:07.430430 (delta: 1.261826)         elapsed: 130.82891 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | wc -l", "delta": "0:00:01.033896", "end": "2020-04-28 14:37:08.783570", "rc": 0, "start": "2020-04-28 14:37:07.749674", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the maya-apiserver pod name] *****************************************
task path: /funclib/openebs/access-mode-check.yml:15
2020-04-28T14:37:08.860945 (delta: 1.430426)         elapsed: 132.259425 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.069960", "end": "2020-04-28 14:37:10.204213", "rc": 0, "start": "2020-04-28 14:37:09.134253", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-854f7bcb8f-rb7s2", "stdout_lines": ["maya-apiserver-854f7bcb8f-rb7s2"]}

TASK [Get the volume list] *****************************************************
task path: /funclib/openebs/access-mode-check.yml:22
2020-04-28T14:37:10.296952 (delta: 1.435938)         elapsed: 133.695432 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-854f7bcb8f-rb7s2 -n openebs -- mayactl volume list", "delta": "0:00:01.630192", "end": "2020-04-28 14:37:12.381186", "rc": 0, "start": "2020-04-28 14:37:10.750994", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Namespace  Name                                      Status   Type  Capacity  StorageClass          Access Mode\n---------  ----                                      ------   ----  --------  -------------         -----------\nopenebs    pvc-20654cc7-c17d-4183-a488-8b5a87fd9710  Running  jiva  5Gi       openebs-jiva-default  ReadWriteOnce\nopenebs    pvc-8aa24ccb-42a0-4717-bf16-ad0278cce2fe  Running  jiva  5Gi       openebs-jiva-default  ReadWriteOnce", "stdout_lines": ["Namespace  Name                                      Status   Type  Capacity  StorageClass          Access Mode", "---------  ----                                      ------   ----  --------  -------------         -----------", "openebs    pvc-20654cc7-c17d-4183-a488-8b5a87fd9710  Running  jiva  5Gi       openebs-jiva-default  ReadWriteOnce", "openebs    pvc-8aa24ccb-42a0-4717-bf16-ad0278cce2fe  Running  jiva  5Gi       openebs-jiva-default  ReadWriteOnce"]}

TASK [Get the replicas access mode] ********************************************
task path: /funclib/openebs/access-mode-check.yml:32
2020-04-28T14:37:12.537206 (delta: 2.240032)         elapsed: 135.935686 ****** 
FAILED - RETRYING: Get the replicas access mode (30 retries left).
FAILED - RETRYING: Get the replicas access mode (29 retries left).
FAILED - RETRYING: Get the replicas access mode (28 retries left).
FAILED - RETRYING: Get the replicas access mode (27 retries left).
FAILED - RETRYING: Get the replicas access mode (26 retries left).
FAILED - RETRYING: Get the replicas access mode (25 retries left).
FAILED - RETRYING: Get the replicas access mode (24 retries left).
changed: [127.0.0.1] => {"attempts": 8, "changed": true, "cmd": "kubectl exec -it maya-apiserver-854f7bcb8f-rb7s2 -n openebs -- mayactl volume describe --volname \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\" -n bb | grep 'RW' | wc -l", "delta": "0:00:01.673048", "end": "2020-04-28 14:41:06.080958", "rc": 0, "start": "2020-04-28 14:41:04.407910", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [debug] *******************************************************************
task path: /funclib/openebs/access-mode-check.yml:43
2020-04-28T14:41:06.225575 (delta: 233.68829)         elapsed: 369.624055 ***** 
ok: [127.0.0.1] => {
    "msg": "All the replicas are in sync"
}

TASK [Enable the logging of jiva replicas] *************************************
task path: /experiments/functional/jiva-logging/test.yml:78
2020-04-28T14:41:06.436467 (delta: 0.210743)         elapsed: 369.834947 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x\" -n openebs -- bash -c \"jivactl logtofile enable\"", "delta": "0:00:01.274282", "end": "2020-04-28 14:41:07.958813", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:41:06.684531", "stderr": "Defaulting container name to pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-con.\nUse 'kubectl describe pod/pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-con.", "Use 'kubectl describe pod/pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-ctrl-5b99d9888b-rfq4x -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-logging/test.yml:88
2020-04-28T14:41:08.054636 (delta: 1.61805)         elapsed: 371.453116 ******* 
included: /experiments/functional/jiva-logging/verify_logging.yml for 127.0.0.1

TASK [Obtain the one of jiva replica pod in openebs namespace] *****************
task path: /experiments/functional/jiva-logging/verify_logging.yml:2
2020-04-28T14:41:08.183476 (delta: 0.128766)         elapsed: 371.581956 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica --no-headers -o custom-columns=:.metadata.name | awk 'FNR==1{print $1}'", "delta": "0:00:01.049481", "end": "2020-04-28 14:41:09.462283", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:41:08.412802", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r"]}

TASK [Obtain the jiva logging file size] ***************************************
task path: /experiments/functional/jiva-logging/verify_logging.yml:11
2020-04-28T14:41:09.561539 (delta: 1.377931)         elapsed: 372.960019 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r\" -n openebs -- bash -c \"du -h /openebs/replica.log\" | awk '{print $1}'", "delta": "0:00:01.537408", "end": "2020-04-28 14:41:11.369956", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:41:09.832548", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "144K", "stdout_lines": ["144K"]}

TASK [Delete the jiva replica pods in openebs namespace] ***********************
task path: /experiments/functional/jiva-logging/verify_logging.yml:21
2020-04-28T14:41:11.449988 (delta: 1.888364)         elapsed: 374.848468 ****** 
changed: [127.0.0.1] => (item=0) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:19.388229", "end": "2020-04-28 14:41:31.191463", "failed_when_result": false, "item": 0, "rc": 0, "start": "2020-04-28 14:41:11.803234", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-bcq82\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-rfxxk\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-qlm4r\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-bcq82\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-rfxxk\" deleted"]}
changed: [127.0.0.1] => (item=1) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:20.292414", "end": "2020-04-28 14:41:51.689419", "failed_when_result": false, "item": 1, "rc": 0, "start": "2020-04-28 14:41:31.397005", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-c75sb\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-jz7fx\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-ppf9m\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-c75sb\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-jz7fx\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-ppf9m\" deleted"]}
changed: [127.0.0.1] => (item=2) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:18.433353", "end": "2020-04-28 14:42:10.518922", "failed_when_result": false, "item": 2, "rc": 0, "start": "2020-04-28 14:41:52.085569", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-hdjgc\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-dx2j5\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-xgjlg\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-hdjgc\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-dx2j5\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-xgjlg\" deleted"]}
changed: [127.0.0.1] => (item=3) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:20.741735", "end": "2020-04-28 14:42:31.732503", "failed_when_result": false, "item": 3, "rc": 0, "start": "2020-04-28 14:42:10.990768", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-j85bj\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-blw54\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-tjr67\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-j85bj\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-blw54\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-tjr67\" deleted"]}
changed: [127.0.0.1] => (item=4) => {"changed": true, "cmd": "kubectl delete pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica && sleep 10", "delta": "0:00:19.554529", "end": "2020-04-28 14:42:51.686708", "failed_when_result": false, "item": 4, "rc": 0, "start": "2020-04-28 14:42:32.132179", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-4mjhg\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-22p46\" deleted\npod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-nmk7s\" deleted", "stdout_lines": ["pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-4mjhg\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-2-5c7cc89549-22p46\" deleted", "pod \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-3-77b46c9454-nmk7s\" deleted"]}

TASK [Obtain the one of jiva replica pod in openebs namespace] *****************
task path: /experiments/functional/jiva-logging/verify_logging.yml:31
2020-04-28T14:42:51.770197 (delta: 100.320109)         elapsed: 475.168677 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/persistent-volume=\"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710\",openebs.io/replica=jiva-replica --no-headers -o custom-columns=:.metadata.name | awk 'FNR==1{print $1}'", "delta": "0:00:01.458841", "end": "2020-04-28 14:42:53.484102", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:42:52.025261", "stderr": "", "stderr_lines": [], "stdout": "pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-zqfwk", "stdout_lines": ["pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-zqfwk"]}

TASK [Obtain the jiva logging file size] ***************************************
task path: /experiments/functional/jiva-logging/verify_logging.yml:41
2020-04-28T14:42:53.595206 (delta: 1.824888)         elapsed: 476.993686 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it \"pvc-20654cc7-c17d-4183-a488-8b5a87fd9710-rep-1-846d8f746d-zqfwk\" -n openebs -- bash -c \"du -h /openebs/replica.log\" | awk '{print $1}'", "delta": "0:00:01.615783", "end": "2020-04-28 14:42:55.469265", "failed_when_result": false, "rc": 0, "start": "2020-04-28 14:42:53.853482", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "164K", "stdout_lines": ["164K"]}

TASK [Obtain the jiva logging file size] ***************************************
task path: /experiments/functional/jiva-logging/verify_logging.yml:52
2020-04-28T14:42:55.591732 (delta: 1.9963)         elapsed: 478.990212 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/jiva-logging/test.yml:92
2020-04-28T14:42:55.684418 (delta: 0.092611)         elapsed: 479.082898 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/jiva-logging/test.yml:102
2020-04-28T14:42:55.802613 (delta: 0.118061)         elapsed: 479.201093 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-04-28T14:42:55.937859 (delta: 0.135108)         elapsed: 479.336339 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-04-28T14:42:56.014986 (delta: 0.077028)         elapsed: 479.413466 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-04-28T14:42:56.121953 (delta: 0.106885)         elapsed: 479.520433 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-04-28T14:42:56.240666 (delta: 0.118638)         elapsed: 479.639146 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "5be25fd7f347e97c06d82e3842e41ac7cb32eea8", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f9031dc7a70fae1e8bab336347fe4306", "mode": "0644", "owner": "root", "size": 411, "src": "/root/.ansible/tmp/ansible-tmp-1588084976.32-195209475994991/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-04-28T14:42:58.635065 (delta: 2.394292)         elapsed: 482.033545 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.963768", "end": "2020-04-28 14:42:59.871925", "rc": 0, "start": "2020-04-28 14:42:58.908157", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-logging \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-logging ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-04-28T14:42:59.939252 (delta: 1.304104)         elapsed: 483.337732 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-28T12:43:42Z", "generation": 3, "name": "jiva-logging", "resourceVersion": "1961471", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-logging", "uid": "df577cdb-ced2-4454-bd99-23408be847df"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=38   changed=26   unreachable=0    failed=0   

2020-04-28T14:43:01.094656 (delta: 1.155309)         elapsed: 484.493136 ****** 
=============================================================================== 
```