### PR TITLE
add(litmusbook): Added litmusbook for zfs-localpv components upgrade

### DIFF
--- a/providers/upgrade-zfsLocalPV/README.md
+++ b/providers/upgrade-zfsLocalPV/README.md
@@ -1,0 +1,36 @@
+## Experiment Metadata
+
+| Type       | Description                                             |  K8s Platform and OS        |
+| ---------- | --------------------------------------------------------|  ----------------------     |
+| Upgrade    | Upgrade the zfs-driver for zfs-localpv                  | K8s 1.14 + and Ubuntu 18.04 |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- Application should be deployed succesfully if there any consuming the ZFS-localPV storage.
+- ZFS-controller and node-agent daemonset pods should be in running state.
+
+## Exit-Criteria
+
+- zfs-driver should be upgraded to desired version.
+- All the components related to zfs-localpv including zfs-controller and node-agents should be running and
+  upraded to desired version as well.
+- All the zfs volumes should be healthy and data prior to the upgrade should not be impacted.
+- After upgrade we should be able to provision the volume and other related task with no regressions.
+
+## Notes
+
+- This upgrade test upgrade the zfs-driver to the desired latest version.
+- This litmusbook accepts the parameters in form of job environmental variables.
+- For running this litmus experiment of upgrade test give the required env's in the run_litmus_test.yml file and create the kubernetes job.
+
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| TO_VERSION_ZFS_BRANCH | give the branch name in openebs/zfs-localpv repo to which you want to upgrade the zfs-driver as we get the zfs-operator file from that branch for versioned upgrades. To upgrade to developement changes use master branch instead of versioned branch     |
+| TO_VERSION_ZFS_DRIVER_IMAGE   | Provide the full image name of zfs-driver including its tag also. If using master branch to upgrade use ci image. for e.g. `quay.io/openebs/zfs-driver:ci`|
+| OPERATOR_NAMESPACE| It is the namespace where all the ZF-localpv CRs are created like zvolume. by default its value is openebs|
+
+

--- a/providers/upgrade-zfsLocalPV/run_litmus_test.yml
+++ b/providers/upgrade-zfsLocalPV/run_litmus_test.yml
@@ -37,5 +37,4 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./providers/upgrade-zfsLocalPV/test.yml -i /etc/ansible/hosts -v; exit 0"]
-    
-                  
+        

--- a/providers/upgrade-zfsLocalPV/run_litmus_test.yml
+++ b/providers/upgrade-zfsLocalPV/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: upgrade-zfs-localpv
+  generateName: upgrade-zfs-localpv-
   namespace: litmus
 spec:
   template:

--- a/providers/upgrade-zfsLocalPV/run_litmus_test.yml
+++ b/providers/upgrade-zfsLocalPV/run_litmus_test.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: upgrade-zfs-localpv
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        name: zfs-localpv-upgrade
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+            ## Give the versioned branch name for zfs_localPV provisioner from openebs/zfs-localpv repo
+            ## for e.g. (v0.6.x , v0.5.x  OR  master)
+          - name: TO_VERSION_ZFS_BRANCH
+            value: ''
+
+            ## Provide ZFS_DRIVER image to which upgrade is to done. To use ci images use ci tag.
+            ## Give full image name (for e.g. quay.io/openebs/zfs-driver:<tag>)
+          - name: TO_VERSION_ZFS_DRIVER_IMAGE
+            value: ''
+
+          - name: OPERATOR_NAMESPACE
+            value: ''
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/upgrade-zfsLocalPV/test.yml -i /etc/ansible/hosts -v; exit 0"]
+    
+                  

--- a/providers/upgrade-zfsLocalPV/test.yml
+++ b/providers/upgrade-zfsLocalPV/test.yml
@@ -1,0 +1,209 @@
+- hosts: localhost
+  connection: local
+    
+  vars_files:
+  - test_vars.yml
+    
+  tasks:
+
+  - block:
+    
+    ## Generating the testname for deployment
+     - include_tasks: /utils/fcm/create_testname.yml
+    
+    ## RECORD START-OF-TEST IN LITMUS RESULT CR
+     - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+       vars:
+         status: 'SOT'
+
+     - name: Verify that the ZFS-controller pod and zfs-node daemonset all are in running state
+       shell: >
+         kubectl get pods -n kube-system -l role=openebs-zfs
+         --no-headers -o custom-columns=:status.phase | sort | uniq
+       args: 
+         executable: /bin/bash
+       register: ZFS_driver_components
+       failed_when: "'Running' not in ZFS_driver_components.stdout"
+
+     - name: Get the version tag for zfs-driver
+       shell: >
+         kubectl get sts openebs-zfs-controller -n kube-system 
+         -o jsonpath='{.spec.template.spec.containers[?(@.name=="openebs-zfs-plugin")].image}' | cut -d ":" -f2
+       args:
+         executable: /bin/bash
+       register: zfs_driver_tag
+
+     - name: Get the replica count for zfs-controller statefulset
+       shell: >
+         kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.status.replicas}'
+       args: 
+         executable: /bin/bash
+       register: no_of_zfs_ctrl_replicas
+
+     - name: Record the number of zfs-controller replicas
+       set_fact:
+         zfs_ctrl_replicas: "{{ no_of_zfs_ctrl_replicas.stdout }}"
+
+     - name: Get the list of node-agent pods in openebs-zfs-node daemonset
+       shell: >
+         kubectl get po -n kube-system -l app=openebs-zfs-node --no-headers -o custom-columns=:.metadata.name
+       args:
+         executable: /bin/bash
+       register: ds_pods
+         
+     - block:
+       ## This task creates new CRDs as zfs-LocalPV related CRs are now grouped 
+       ## under `zfs.openebs.io` from v0.6 release.
+       - name: Apply the new CRDs for zfs-LocalPV 
+         shell: >
+           kubectl apply -f https://raw.githubusercontent.com/openebs/zfs-localpv/master/upgrade/crd.yaml
+         args:
+           executable: /bin/bash
+         register: new_crds
+         failed_when: "new_crds.rc != 0"
+
+       ## This task create new CRs for zfs-volume and zfs-snapshot with updated
+       ## apiversion to `zfs.openebs.io`. Previously this was `openebs.io`.
+       - name: Download the Upgrade script for creating new CRs with apiversion as `zfs.openebs.io`
+         get_url:  
+           url: https://raw.githubusercontent.com/openebs/zfs-localpv/master/upgrade/upgrade.sh
+           dest: ./upgrade.sh
+           force: yes
+         register: result
+         until: "'OK' in result.msg"
+         delay: 5
+         retries: 3
+
+       - name: Apply the upgrade scriptopenebs-zfs-node
+         shell: sh ./upgrade.sh {{ operator_ns }}
+         args:
+           executable: /bin/bash
+
+       when: 
+       - zfs_driver_tag.stdout == "v0.4" or zfs_driver_tag.stdout == "0.4.1" or zfs_driver_tag.stdout == "v0.5"
+       - "'v0.4.x' not in to_version_zfs_branch" 
+       - "'v0.5.x' not in to_version_zfs_branch"
+
+     - name: Download the zfs-operator file
+       get_url:
+         url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ to_version_zfs_branch }}/deploy/zfs-operator.yaml
+         dest: ./new_zfs_operator.yml
+         force: yes
+       register: result
+       until: "'OK' in result.msg"
+       delay: 5
+       retries: 3
+            
+     - name: Update the openebs zfs-driver image 
+       replace:
+         path: ./new_zfs_operator.yml
+         regexp: quay.io/openebs/zfs-driver:ci
+         replace: "{{ lookup('env','ZFS_DRIVER_IMAGE') }}"
+       when: lookup('env','ZFS_DRIVER_IMAGE') | length > 0
+
+     - name: Update the number of zfs-controller statefulset replicas
+       replace:
+         path: ./new_zfs_operator.yml
+         regexp: "replicas: 1"
+         replace: "replicas: {{ zfs_ctrl_replicas }}"
+
+     - name: Apply the zfs_operator file to deploy zfs-driver components to the newer version
+       shell: 
+         kubectl apply -f ./new_zfs_operator.yml
+       args:
+          executable: /bin/bash
+
+     - name: Wait for some time to old zfs-driver components to go into Terminating state.
+       shell: >
+         sleep 30
+
+     - name: Verify zfs-node agent previous pods are not present in kube-system namespace
+       shell: >
+         kubectl get pods -n kube-system -l app=openebs-zfs-node --no-headers
+       args: 
+         executable: /bin/bash
+       register: new_ds_pods
+       until: "'{{ item }}' not in new_ds_pods.stdout"
+       delay: 5
+       retries: 40
+       with_items: "{{ ds_pods.stdout_lines }}"
+
+     - name: Verify zfs-node agent newer pods are in running status
+       shell: >
+         kubectl get pods -n kube-system -l app=openebs-zfs-node
+         --no-headers -o custom-columns=:status.phase | sort | uniq
+       args: 
+         executable: /bin/bash
+       register: new_ds_pods
+       until: "new_ds_pods.stdout == 'Running'"
+       delay: 5
+       retries: 30
+
+     - name: Verify that zfs-node agent daemonset image is upgraded
+       shell: >
+         kubectl get ds openebs-zfs-node -n kube-system 
+         -o jsonpath='{.spec.template.spec.containers[?(@.name=="openebs-zfs-plugin")].image}'
+       args: 
+         executable: /bin/bash
+       register: ds_image
+       failed_when: ds_image.stdout != to_version_zfs_driver_image
+
+     - name: Check for the count of zfs-controller ready replicas
+       shell: >
+         kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.status.readyReplicas}'
+       args:
+         executable: /bin/bash
+       register: ready_replicas
+       until: "ready_replicas.stdout|int == zfs_ctrl_replicas|int"
+       delay: 5
+       retries: 20
+
+     - name: Verify that zfs-driver version from the zfs-controller statefulset image is upgraded
+       shell: >
+         kubectl get sts openebs-zfs-controller -n kube-system
+         -o jsonpath='{.spec.template.spec.containers[?(@.name=="openebs-zfs-plugin")].image}'
+       args:
+         executable: /bin/bash
+       register: zfs_ctrl_image
+       failed_when: zfs_ctrl_image.stdout != to_version_zfs_driver_image
+
+     - block:
+
+       - name: Download the cleanup script for removing the resources with old CRs and delete old CRDs
+         get_url:  
+           url: https://raw.githubusercontent.com/openebs/zfs-localpv/master/upgrade/cleanup.sh
+           dest: ./cleanup.sh
+           force: yes
+         register: result
+         until: "'OK' in result.msg"
+         delay: 5
+         retries: 3
+
+       - name: Apply the cleanup script
+         shell: sh ./cleanup.sh {{ operator_ns }}
+         args:
+           executable: /bin/bash
+
+       when: 
+       - zfs_driver_tag.stdout == "v0.4" or zfs_driver_tag.stdout == "0.4.1" or zfs_driver_tag.stdout == "v0.5"
+       - "'v0.4.x' not in to_version_zfs_branch" 
+       - "'v0.5.x' not in to_version_zfs_branch"
+
+     - set_fact:
+         flag: "Pass"
+
+    rescue:
+      - set_fact:
+          flag: "Fail"
+
+    always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+      - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+        vars:
+          status: 'EOT'
+         
+
+
+       
+            
+            

--- a/providers/upgrade-zfsLocalPV/test.yml
+++ b/providers/upgrade-zfsLocalPV/test.yml
@@ -202,8 +202,3 @@
         vars:
           status: 'EOT'
          
-
-
-       
-            
-            

--- a/providers/upgrade-zfsLocalPV/test.yml
+++ b/providers/upgrade-zfsLocalPV/test.yml
@@ -16,14 +16,23 @@
        vars:
          status: 'SOT'
 
-     - name: Verify that the ZFS-controller pod and zfs-node daemonset all are in running state
+     - name: Get the list of pods of zfs-localpv components (zfs-controller and zfs-node agent deamonset)
        shell: >
-         kubectl get pods -n kube-system -l role=openebs-zfs
-         --no-headers -o custom-columns=:status.phase | sort | uniq
+         kubectl get pods -n kube-system -l role=openebs-zfs 
+         --no-headers -o custom-columns=:.metadata.name
+       args:
+         executable: /bin/bash
+       register: zfs_localpv_components
+
+     - name: Verify that the zfs-localpv components are in running state
+       shell: >
+         kubectl get pods {{ item }} -n kube-system --no-headers -o custom-columns=:status.phase
        args: 
          executable: /bin/bash
        register: ZFS_driver_components
-       failed_when: "'Running' not in ZFS_driver_components.stdout"
+       failed_when: "ZFS_driver_components.stdout != 'Running'"
+       with_items: "{{ zfs_localpv_components.stdout_lines }}"
+       ignore_errors: true
 
      - name: Get the version tag for zfs-driver
        shell: >
@@ -74,7 +83,7 @@
          delay: 5
          retries: 3
 
-       - name: Apply the upgrade scriptopenebs-zfs-node
+       - name: Apply the upgrade script
          shell: sh ./upgrade.sh {{ operator_ns }}
          args:
            executable: /bin/bash

--- a/providers/upgrade-zfsLocalPV/test_vars.yml
+++ b/providers/upgrade-zfsLocalPV/test_vars.yml
@@ -1,0 +1,7 @@
+test_name: zfs-localpv-upgrade
+
+to_version_zfs_branch: "{{ lookup('env','TO_VERSION_ZFS_BRANCH') }}"
+
+to_version_zfs_driver_image: "{{ lookup('env','TO_VERSION_ZFS_DRIVER_IMAGE') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR added a litmusbook for upgrading the zfs-localpv 
- If upgrade is required from any version after v0.6 to latest version ;  latest zfs-operator with desired image is needed only to apply.
- if upgrade is required from version before v0.6 then steps required are here:
https://github.com/openebs/zfs-localpv/blob/master/upgrade/README.md


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/openebs/e2e-tests/issues/274

Logs for the ansible-playbook of the same:
```
PLAY [localhost] ***************************************************************
2020-04-28T18:27:46.474186 (delta: 0.073476)         elapsed: 0.073476 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-04-28T18:27:46.505960 (delta: 0.031729)         elapsed: 0.10525 ********* 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-04-28T18:27:57.587472 (delta: 11.08147)         elapsed: 11.186762 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-04-28T18:27:57.721271 (delta: 0.133139)         elapsed: 11.320561 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-04-28T18:27:57.806595 (delta: 0.085247)         elapsed: 11.405885 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-04-28T18:27:57.914950 (delta: 0.10829)         elapsed: 11.51424 ********* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-28T18:27:58.089992 (delta: 0.174977)         elapsed: 11.689282 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "14cf64bf71a40f43f492f59f1a0fbda31d499c80", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3a86bc0c88a0ef266c3e3b93e0b0b177", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1588098478.16-28425417652174/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-28T18:27:59.002517 (delta: 0.912463)         elapsed: 12.601807 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.969538", "end": "2020-04-28 18:28:00.403471", "rc": 0, "start": "2020-04-28 18:27:59.433933", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: zfs-localpv-upgrade \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: zfs-localpv-upgrade ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-28T18:28:00.477995 (delta: 1.475413)         elapsed: 14.077285 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-28T17:54:36Z", "generation": 5, "name": "zfs-localpv-upgrade", "resourceVersion": "111449", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/zfs-localpv-upgrade", "uid": "d6abf7f8-3465-4e35-9aa9-92997b433a54"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-28T18:28:02.033688 (delta: 1.555625)         elapsed: 15.632978 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-28T18:28:02.130542 (delta: 0.09679)         elapsed: 15.729832 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-28T18:28:02.208910 (delta: 0.078297)         elapsed: 15.8082 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the ZFS-controller pod and zfs-node daemonset all are in running state] ***
2020-04-28T18:28:02.296529 (delta: 0.087542)         elapsed: 15.895819 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n kube-system -l role=openebs-zfs --no-headers -o custom-columns=:status.phase | sort | uniq", "delta": "0:00:01.224902", "end": "2020-04-28 18:28:03.796294", "failed_when_result": false, "rc": 0, "start": "2020-04-28 18:28:02.571392", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the version tag for zfs-driver] **************************************
2020-04-28T18:28:03.879684 (delta: 1.583084)         elapsed: 17.478974 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.spec.template.spec.containers[?(@.name==\"openebs-zfs-plugin\")].image}' | cut -d \":\" -f2", "delta": "0:00:01.272665", "end": "2020-04-28 18:28:05.378868", "rc": 0, "start": "2020-04-28 18:28:04.106203", "stderr": "", "stderr_lines": [], "stdout": "0.4.1", "stdout_lines": ["0.4.1"]}

TASK [Get the replica count for zfs-controller statefulset] ********************
2020-04-28T18:28:05.475954 (delta: 1.596205)         elapsed: 19.075244 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.status.replicas}'", "delta": "0:00:01.092635", "end": "2020-04-28 18:28:06.905157", "rc": 0, "start": "2020-04-28 18:28:05.812522", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Record the number of zfs-controller replicas] ****************************
2020-04-28T18:28:06.984295 (delta: 1.508272)         elapsed: 20.583585 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"zfs_ctrl_replicas": "2"}, "changed": false}

TASK [Get the list of node-agent pods in openebs-zfs-node daemonset] ***********
2020-04-28T18:28:07.103398 (delta: 0.119035)         elapsed: 20.702688 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n kube-system -l app=openebs-zfs-node --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.101481", "end": "2020-04-28 18:28:08.433242", "rc": 0, "start": "2020-04-28 18:28:07.331761", "stderr": "", "stderr_lines": [], "stdout": "openebs-zfs-node-5gqr6\nopenebs-zfs-node-gbfqx\nopenebs-zfs-node-pp5wp", "stdout_lines": ["openebs-zfs-node-5gqr6", "openebs-zfs-node-gbfqx", "openebs-zfs-node-pp5wp"]}

TASK [Apply the new CRDs for zfs-LocalPV] **************************************
2020-04-28T18:28:08.524446 (delta: 1.420981)         elapsed: 22.123736 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f https://raw.githubusercontent.com/openebs/zfs-localpv/master/upgrade/crd.yaml", "delta": "0:00:01.950214", "end": "2020-04-28 18:28:10.754466", "failed_when_result": false, "rc": 0, "start": "2020-04-28 18:28:08.804252", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/zfsvolumes.zfs.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/zfssnapshots.zfs.openebs.io created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/zfsvolumes.zfs.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/zfssnapshots.zfs.openebs.io created"]}

TASK [Download the Upgrade script for creating new CRs with apiversion as `zfs.openebs.io`] ***
2020-04-28T18:28:10.848493 (delta: 2.323991)         elapsed: 24.447783 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "d0a80b67a93c354d4b7e204c4dbdec7d49978869", "dest": "./upgrade.sh", "gid": 0, "group": "root", "md5sum": "ec5cdee28ef99a6e0d11663412469d72", "mode": "0644", "msg": "OK (1263 bytes)", "owner": "root", "size": 1263, "src": "/root/.ansible/tmp/ansible-tmp-1588098490.93-98899559076599/tmpzCEQDp", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/zfs-localpv/master/upgrade/upgrade.sh"}

TASK [Apply the upgrade scriptopenebs-zfs-node] ********************************
2020-04-28T18:28:12.168975 (delta: 1.320417)         elapsed: 25.768265 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sh ./upgrade.sh openebs", "delta": "0:00:03.555489", "end": "2020-04-28 18:28:15.999447", "rc": 0, "start": "2020-04-28 18:28:12.443958", "stderr": "", "stderr_lines": [], "stdout": "Fetching ZFS Volumes\nzfsvolume.zfs.openebs.io/pvc-74b67a4b-664f-4c29-ab18-e401cde90eae created\nFetching ZFS Snapshots\nzfssnapshot.zfs.openebs.io/snapshot-82be2ad2-ac61-456c-a78d-a51782a747ad created", "stdout_lines": ["Fetching ZFS Volumes", "zfsvolume.zfs.openebs.io/pvc-74b67a4b-664f-4c29-ab18-e401cde90eae created", "Fetching ZFS Snapshots", "zfssnapshot.zfs.openebs.io/snapshot-82be2ad2-ac61-456c-a78d-a51782a747ad created"]}

TASK [Download the zfs-operator file] ******************************************
2020-04-28T18:28:16.093186 (delta: 3.924146)         elapsed: 29.692476 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "dff22f6f78f2a48fc8f929dfc6c21ee5728fd9ce", "dest": "./new_zfs_operator.yml", "gid": 0, "group": "root", "md5sum": "0991102c0da9527e0ef878bbb71c8ba2", "mode": "0644", "msg": "OK (56028 bytes)", "owner": "root", "size": 56028, "src": "/root/.ansible/tmp/ansible-tmp-1588098496.17-146423434578872/tmpfGkSWG", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/zfs-localpv/master/deploy/zfs-operator.yaml"}

TASK [Update the openebs zfs-driver image] *************************************
2020-04-28T18:28:17.301510 (delta: 1.208252)         elapsed: 30.9008 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the number of zfs-controller statefulset replicas] ****************
2020-04-28T18:28:17.394976 (delta: 0.093404)         elapsed: 30.994266 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Apply the zfs_operator file to deploy zfs-driver components to the newer version] ***
2020-04-28T18:28:17.958041 (delta: 0.563002)         elapsed: 31.557331 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f ./new_zfs_operator.yml", "delta": "0:00:01.639181", "end": "2020-04-28 18:28:19.861028", "rc": 0, "start": "2020-04-28 18:28:18.221847", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs unchanged\ncustomresourcedefinition.apiextensions.k8s.io/zfsvolumes.zfs.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/zfssnapshots.zfs.openebs.io configured\ncsidriver.storage.k8s.io/zfs.csi.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured\nserviceaccount/openebs-zfs-controller-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-zfs-provisioner-role configured\nclusterrolebinding.rbac.authorization.k8s.io/openebs-zfs-provisioner-binding unchanged\nstatefulset.apps/openebs-zfs-controller configured\nclusterrole.rbac.authorization.k8s.io/openebs-zfs-snapshotter-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-zfs-snapshotter-binding unchanged\nserviceaccount/openebs-zfs-node-sa unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-zfs-driver-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-zfs-driver-registrar-binding unchanged\ndaemonset.apps/openebs-zfs-node configured", "stdout_lines": ["namespace/openebs unchanged", "customresourcedefinition.apiextensions.k8s.io/zfsvolumes.zfs.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/zfssnapshots.zfs.openebs.io configured", "csidriver.storage.k8s.io/zfs.csi.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured", "serviceaccount/openebs-zfs-controller-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-zfs-provisioner-role configured", "clusterrolebinding.rbac.authorization.k8s.io/openebs-zfs-provisioner-binding unchanged", "statefulset.apps/openebs-zfs-controller configured", "clusterrole.rbac.authorization.k8s.io/openebs-zfs-snapshotter-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-zfs-snapshotter-binding unchanged", "serviceaccount/openebs-zfs-node-sa unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-zfs-driver-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-zfs-driver-registrar-binding unchanged", "daemonset.apps/openebs-zfs-node configured"]}

TASK [Wait for some time to old zfs-driver components to go into Terminating state.] ***
2020-04-28T18:28:20.042904 (delta: 2.084799)         elapsed: 33.642194 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 30", "delta": "0:00:31.164074", "end": "2020-04-28 18:28:51.708477", "rc": 0, "start": "2020-04-28 18:28:20.544403", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify zfs-node agent previous pods are not present in kube-system namespace] ***
2020-04-28T18:28:51.802949 (delta: 31.759958)         elapsed: 65.402239 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ item }}' not in new_ds_pods.stdout
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (40 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (39 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (38 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (37 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (36 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (35 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (34 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (33 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (32 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (31 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (30 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (29 retries left).
FAILED - RETRYING: Verify zfs-node agent previous pods are not present in kube-system namespace (28 retries left).
changed: [127.0.0.1] => (item=openebs-zfs-node-5gqr6) => {"attempts": 14, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-zfs-node --no-headers", "delta": "0:00:01.152504", "end": "2020-04-28 18:30:16.054720", "item": "openebs-zfs-node-5gqr6", "rc": 0, "start": "2020-04-28 18:30:14.902216", "stderr": "", "stderr_lines": [], "stdout": "openebs-zfs-node-296z2   2/2   Running   0     37s\nopenebs-zfs-node-9ztzp   2/2   Running   0     76s\nopenebs-zfs-node-pswkd   2/2   Running   0     3s", "stdout_lines": ["openebs-zfs-node-296z2   2/2   Running   0     37s", "openebs-zfs-node-9ztzp   2/2   Running   0     76s", "openebs-zfs-node-pswkd   2/2   Running   0     3s"]}
changed: [127.0.0.1] => (item=openebs-zfs-node-gbfqx) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-zfs-node --no-headers", "delta": "0:00:01.079740", "end": "2020-04-28 18:30:17.346085", "item": "openebs-zfs-node-gbfqx", "rc": 0, "start": "2020-04-28 18:30:16.266345", "stderr": "", "stderr_lines": [], "stdout": "openebs-zfs-node-296z2   2/2   Running   0     38s\nopenebs-zfs-node-9ztzp   2/2   Running   0     77s\nopenebs-zfs-node-pswkd   2/2   Running   0     4s", "stdout_lines": ["openebs-zfs-node-296z2   2/2   Running   0     38s", "openebs-zfs-node-9ztzp   2/2   Running   0     77s", "openebs-zfs-node-pswkd   2/2   Running   0     4s"]}
changed: [127.0.0.1] => (item=openebs-zfs-node-pp5wp) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-zfs-node --no-headers", "delta": "0:00:01.210282", "end": "2020-04-28 18:30:18.762919", "item": "openebs-zfs-node-pp5wp", "rc": 0, "start": "2020-04-28 18:30:17.552637", "stderr": "", "stderr_lines": [], "stdout": "openebs-zfs-node-296z2   2/2   Running   0     39s\nopenebs-zfs-node-9ztzp   2/2   Running   0     78s\nopenebs-zfs-node-pswkd   2/2   Running   0     5s", "stdout_lines": ["openebs-zfs-node-296z2   2/2   Running   0     39s", "openebs-zfs-node-9ztzp   2/2   Running   0     78s", "openebs-zfs-node-pswkd   2/2   Running   0     5s"]}

TASK [Verify zfs-node agent newer pods are in running status] ******************
2020-04-28T18:30:18.850656 (delta: 87.047646)         elapsed: 152.449946 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-zfs-node --no-headers -o custom-columns=:status.phase | sort | uniq", "delta": "0:00:01.120625", "end": "2020-04-28 18:30:20.206789", "rc": 0, "start": "2020-04-28 18:30:19.086164", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify that zfs-node agent daemonset image is upgraded] ******************
2020-04-28T18:30:20.311768 (delta: 1.461012)         elapsed: 153.911058 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds openebs-zfs-node -n kube-system -o jsonpath='{.spec.template.spec.containers[?(@.name==\"openebs-zfs-plugin\")].image}'", "delta": "0:00:01.299847", "end": "2020-04-28 18:30:21.864192", "failed_when_result": false, "rc": 0, "start": "2020-04-28 18:30:20.564345", "stderr": "", "stderr_lines": [], "stdout": "quay.io/openebs/zfs-driver:ci", "stdout_lines": ["quay.io/openebs/zfs-driver:ci"]}

TASK [Check for the count of zfs-controller ready replicas] ********************
2020-04-28T18:30:21.967091 (delta: 1.65501)         elapsed: 155.566381 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.status.readyReplicas}'", "delta": "0:00:01.169840", "end": "2020-04-28 18:30:23.421240", "rc": 0, "start": "2020-04-28 18:30:22.251400", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Verify that zfs-driver version from the zfs-controller statefulset image is upgraded] ***
2020-04-28T18:30:23.517127 (delta: 1.54949)         elapsed: 157.116417 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sts openebs-zfs-controller -n kube-system -o jsonpath='{.spec.template.spec.containers[?(@.name==\"openebs-zfs-plugin\")].image}'", "delta": "0:00:01.095091", "end": "2020-04-28 18:30:24.851856", "failed_when_result": false, "rc": 0, "start": "2020-04-28 18:30:23.756765", "stderr": "", "stderr_lines": [], "stdout": "quay.io/openebs/zfs-driver:ci", "stdout_lines": ["quay.io/openebs/zfs-driver:ci"]}

TASK [Download the cleanup script for removing the resources with old CRs and delete old CRDs] ***
2020-04-28T18:30:24.951506 (delta: 1.434318)         elapsed: 158.550796 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "70c0199ce1cfeaef49e406b8910c15108f48325d", "dest": "./cleanup.sh", "gid": 0, "group": "root", "md5sum": "41620be28cfabab10edbcda35879a0e5", "mode": "0644", "msg": "OK (1483 bytes)", "owner": "root", "size": 1483, "src": "/root/.ansible/tmp/ansible-tmp-1588098625.05-8536198810852/tmpjU455q", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/zfs-localpv/master/upgrade/cleanup.sh"}

TASK [Apply the cleanup script] ************************************************
2020-04-28T18:30:26.109377 (delta: 1.157787)         elapsed: 159.708667 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sh ./cleanup.sh openebs", "delta": "0:00:04.513430", "end": "2020-04-28 18:30:30.932007", "rc": 0, "start": "2020-04-28 18:30:26.418577", "stderr": "Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply\nWarning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply", "stderr_lines": ["Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply", "Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply"], "stdout": "Fetching ZFS Volumes\nCleaning the ZFS Volumes(1)\nzfsvolume.openebs.io/pvc-74b67a4b-664f-4c29-ab18-e401cde90eae configured\nzfsvolume.openebs.io \"pvc-74b67a4b-664f-4c29-ab18-e401cde90eae\" deleted\ncustomresourcedefinition.apiextensions.k8s.io \"zfsvolumes.openebs.io\" deleted\nCleaning the volumeattachment(1)\nvolumeattachment.storage.k8s.io \"csi-f1e9d26d7bf34ff2f9060edaaf0101bddc67e4917028af30fe083da1a64af69d\" deleted\nFetching ZFS Snapshots\nCleaning the ZFS Snapshot(1)\nzfssnapshot.openebs.io/snapshot-82be2ad2-ac61-456c-a78d-a51782a747ad configured\nzfssnapshot.openebs.io \"snapshot-82be2ad2-ac61-456c-a78d-a51782a747ad\" deleted\ncustomresourcedefinition.apiextensions.k8s.io \"zfssnapshots.openebs.io\" deleted", "stdout_lines": ["Fetching ZFS Volumes", "Cleaning the ZFS Volumes(1)", "zfsvolume.openebs.io/pvc-74b67a4b-664f-4c29-ab18-e401cde90eae configured", "zfsvolume.openebs.io \"pvc-74b67a4b-664f-4c29-ab18-e401cde90eae\" deleted", "customresourcedefinition.apiextensions.k8s.io \"zfsvolumes.openebs.io\" deleted", "Cleaning the volumeattachment(1)", "volumeattachment.storage.k8s.io \"csi-f1e9d26d7bf34ff2f9060edaaf0101bddc67e4917028af30fe083da1a64af69d\" deleted", "Fetching ZFS Snapshots", "Cleaning the ZFS Snapshot(1)", "zfssnapshot.openebs.io/snapshot-82be2ad2-ac61-456c-a78d-a51782a747ad configured", "zfssnapshot.openebs.io \"snapshot-82be2ad2-ac61-456c-a78d-a51782a747ad\" deleted", "customresourcedefinition.apiextensions.k8s.io \"zfssnapshots.openebs.io\" deleted"]}

TASK [set_fact] ****************************************************************
2020-04-28T18:30:31.007620 (delta: 4.898183)         elapsed: 164.60691 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-04-28T18:30:31.114418 (delta: 0.106635)         elapsed: 164.713708 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-04-28T18:30:31.241317 (delta: 0.126837)         elapsed: 164.840607 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-04-28T18:30:31.356017 (delta: 0.114633)         elapsed: 164.955307 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-04-28T18:30:31.444606 (delta: 0.088511)         elapsed: 165.043896 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-04-28T18:30:31.526809 (delta: 0.082138)         elapsed: 165.126099 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "ec89d990e64b915f8224224f8e244aad106c19b2", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "fc35561783e6170f06e74cda0a0008c1", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1588098631.61-3487743633854/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-04-28T18:30:34.053038 (delta: 2.526161)         elapsed: 167.652328 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.753887", "end": "2020-04-28 18:30:35.041916", "rc": 0, "start": "2020-04-28 18:30:34.288029", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: zfs-localpv-upgrade \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: zfs-localpv-upgrade ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-04-28T18:30:35.135773 (delta: 1.082672)         elapsed: 168.735063 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-04-28T17:54:36Z", "generation": 6, "name": "zfs-localpv-upgrade", "resourceVersion": "112144", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/zfs-localpv-upgrade", "uid": "d6abf7f8-3465-4e35-9aa9-92997b433a54"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=30   changed=24   unreachable=0    failed=0   

2020-04-28T18:30:36.360849 (delta: 1.224945)         elapsed: 169.960139 ****** 
```
