### PR TITLE
feat(experiment): add experiment to provision localpv on selected device

### DIFF
--- a/experiments/functional/localpv/localpv-provisioning-selected-device/README.md
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/README.md
@@ -1,0 +1,60 @@
+## Experiment Metadata
+
+| Type       | Description                                                  | Storage | Applications | K8s Platform |
+| ---------- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Functional | Ensure that local PV can be provisioned on selected block device | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- OpenEBS should be running.
+- Unclaimed block device should be available
+
+## Exit-Criteria
+
+- Volume should be created on the labelled block device
+
+## Procedure
+
+- This functional test checks if the local pv can be provisioned on the selected block device.
+
+- This litmusbook accepts the parameters in form of job environmental variables.
+
+- Certain block device will be labelled with `openebs.io/block-device-tag=< tag-value >`
+
+- The `< tag-value >` can be passed to Local PV storage class via cas annotations. If the value is present, then Local PV device provisioner will set the following additional selector on the BDC:
+  `openebs.io/block-device-tag=< tag-value >`
+
+- The storage class spec will be built as follows:
+
+  ```
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: openebs-device-mongo
+    annotations:
+      openebs.io/cas-type: local
+      cas.openebs.io/config: |
+        - name: StorageType
+          value: "device"
+        - name: BlockDeviceTag
+          value: "<tag_value>"
+  provisioner: openebs.io/local
+  volumeBindingMode: WaitForFirstConsumer
+  reclaimPolicy: Delete
+  ```
+
+  
+
+- Upon using the above storage class, the PV should be provisioned on the tagged block device
+
+- Finally, checking if the tagged BD alone is used by BDC being part of the volume.
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                                  |
+| ------------- | ------------------------------------------------------------ |
+| APP_NAMESPACE | Namespace where application and volume is deployed.          |
+| PVC           | Name of PVC to be created                                    |
+| OPERATOR_NS   | Namespace where OpenEBS is running                           |
+| BD_TAG        | The label value to be used by the key `openebs.io/block-device-tag=< tag-value >` |

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/percona.j2
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/percona.j2
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      securityContext:
+        fsGroup: 999
+      tolerations:
+      - key: "ak"
+        value: "av"
+        operator: "Equal"
+        effect: "NoSchedule"
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: {{ pvc_name }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ pvc_name }}
+spec:
+  storageClassName: {{ sc_name }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: localpv-selected-device-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: localpv-selected-device
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+           # Namespace where the OpenEBS components are deployed
+          - name: OPERATOR_NS
+            value: ''
+
+          - name: BD_TAG
+            value: 'e2e'
+
+          - name: APP_NAMESPACE
+            value: ''
+
+          - name: PVC
+            value: ''
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/localpv/localpv-provisioning-selected-device/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/storage_class.j2
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/storage_class.j2
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ sc_name }}
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      - name: StorageType
+        value: "device"
+      - name: BlockDeviceTag
+        value: "{{ device_tag }}"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
@@ -1,0 +1,130 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+         ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Obtain the list of nodes
+          shell: kubectl get nodes --no-headers | grep -v master | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: nodes
+
+        - name: Getting the Unclaimed block-device from each node
+          shell: >
+            kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ item }}
+            -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | head -n 1
+          register: blockDevice
+          with_items:
+            - "{{ nodes.stdout_lines }}"
+
+        - name: Label the selected block devices
+          shell: >
+            kubectl label bd -n "{{ operator_ns }}" "{{ item.stdout }}" openebs.io/block-device-tag="{{ device_tag }}"
+          args:
+            executable: /bin/bash
+          register: bd_result
+          with_items:
+            - "{{ blockDevice.results }}"
+
+        - name: Forming storage class manifest from template
+          template:
+            src: storage_class.j2
+            dest: storage_class.yml
+
+        - name: Creating storageClass
+          shell: kubectl apply -f storage_class.yml
+          args:
+            executable: /bin/bash
+          register: sc_status
+          failed_when: sc_status.rc != 0
+
+        - name: Forming application manifest from the template
+          template:
+            src: percona.j2
+            dest: percona.yml
+
+        - name: Creating namespace
+          shell: kubectl create ns "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          register: ns_status
+          failed_when: ns_status.rc != 0
+
+        - name: Deploying application
+          shell: kubectl apply -f percona.yml -n "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          register: app_status
+          failed_when: "app_status.rc != 0"
+
+        - name: Check if the PVC is bound
+          shell: >
+            kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: pvc_status
+          until: "'Bound' in pvc_status.stdout"
+          delay: 10
+          retries: 20
+
+        - name: Getting PV name from PVC
+          shell: >
+            kubectl get pvc {{ pvc_name }} -n {{ namespace }}
+            --no-headers -o custom-columns=:.spec.volumeName
+          args:
+            executable: /bin/bash
+          register: volume
+          failed_when: "volume.rc != 0"
+
+        - name: Obtain the labelled BDs list
+          shell: >
+            kubectl get bd -n "{{ operator_ns }}" -l ndm.io/managed=true,openebs.io/block-device-tag
+            --no-headers -o jsonpath='{.items[*].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: labelled_bd
+          failed_when: "labelled_bd.rc != 0"
+
+        - name: Obtain the BDC created for volume
+          shell: >
+            kubectl get pv "{{ volume.stdout }}"
+            -o jsonpath='{.metadata.annotations.local\.openebs\.io/blockdeviceclaim}'
+          args:
+            executable: /bin/bash
+          register: bdc_name
+
+        - name: Check if the labelled BD is used by local PV
+          shell: >
+            kubectl get bdc "{{ bdc_name.stdout }}" -n "{{ operator_ns }}"
+            --no-headers -o custom-columns=:spec.blockDeviceName
+          args:
+            executable: /bin/bash
+          register: used_bd
+          failed_when: "used_bd.stdout not in labelled_bd.stdout"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+          - set_fact:
+              flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
@@ -81,6 +81,17 @@
           delay: 10
           retries: 20
 
+        - name: Check if the application is running
+          shell: >
+            kubectl get pods -n {{ namespace }} -l name=percona 
+            --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_state
+          until: "'Running' in app_state.stdout"
+          delay: 5
+          retries: 50
+
         - name: Getting PV name from PVC
           shell: >
             kubectl get pvc {{ pvc_name }} -n {{ namespace }}

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/test_vars.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/test_vars.yml
@@ -1,0 +1,13 @@
+# Test-specific parameters
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+test_name: localpv-selected-device
+
+device_tag: "{{ lookup('env','BD_TAG') }}"
+
+pvc_name: "{{ lookup('env','PVC') }}"
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+sc_name: openebs-device-test


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- This experiment verifies if the local pv can be provisioned on selected/tagged block device
- Labelling the block devices with `openebs.io/block-device-tag=<tag-value>`
- Creating storage class with cas annotation `openebs.io/block-device-tag=<tag value>`
- Using this storage class to provision local and ensuring if it gets created on tagged device only.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #300  #273 

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [x] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [x] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [x] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'

PLAY [localhost] ***************************************************************
2020-05-03T23:53:20.788367 (delta: 0.066994)         elapsed: 0.066994 ******** 
=============================================================================== 
Read vars_file 'test_vars.yml'

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:2
2020-05-03T23:53:20.800968 (delta: 0.012564)         elapsed: 0.079595 ******** 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802 `" && echo ansible-tmp-1588550000.84-124454943786802="` echo /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/system/setup.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpXioC0t TO /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802/AnsiballZ_setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802/ /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550000.84-124454943786802/ > /dev/null 2>&1 && sleep 0'
ok: [127.0.0.1]
META: ran handlers
Read vars_file 'test_vars.yml'

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:12
2020-05-03T23:53:30.010857 (delta: 9.209863)         elapsed: 9.289484 ******** 
Read vars_file 'test_vars.yml'
included: /utils/fcm/create_testname.yml for 127.0.0.1
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-05-03T23:53:30.102268 (delta: 0.091335)         elapsed: 9.380895 ******** 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-05-03T23:53:30.163774 (delta: 0.061434)         elapsed: 9.442401 ******** 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:15
2020-05-03T23:53:30.227528 (delta: 0.063713)         elapsed: 9.506155 ******** 
Read vars_file 'test_vars.yml'
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-03T23:53:30.352651 (delta: 0.12508)         elapsed: 9.631278 ********* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567 `" && echo ansible-tmp-1588550010.42-267441246961567="` echo /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/stat.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpL997k7 TO /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/AnsiballZ_stat.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/ /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpJoIML2/litmus-result.j2 TO /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/source
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/ /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/source && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/copy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpVAu6aP TO /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/AnsiballZ_copy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/ /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "checksum": "6733f8d5033b372785de0765d0178a1e07d4d313", 
    "dest": "./litmus-result.yaml", 
    "diff": [], 
    "gid": 0, 
    "group": "root", 
    "invocation": {
        "module_args": {
            "_original_basename": "litmus-result.j2", 
            "attributes": null, 
            "backup": false, 
            "checksum": "6733f8d5033b372785de0765d0178a1e07d4d313", 
            "content": null, 
            "delimiter": null, 
            "dest": "./litmus-result.yaml", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "local_follow": null, 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "md5sum": "9ffe6e2f8083b501ca9d3fb59460ba55", 
    "mode": "0644", 
    "owner": "root", 
    "size": 424, 
    "src": "/root/.ansible/tmp/ansible-tmp-1588550010.42-267441246961567/source", 
    "state": "file", 
    "uid": 0
}
Read vars_file 'test_vars.yml'

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-03T23:53:31.080826 (delta: 0.728125)         elapsed: 10.359453 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750 `" && echo ansible-tmp-1588550011.14-50817834164750="` echo /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmp2rcrqQ TO /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750/ /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550011.14-50817834164750/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "cat litmus-result.yaml", 
    "delta": "0:00:00.705389", 
    "end": "2020-05-03 23:53:32.102186", 
    "invocation": {
        "module_args": {
            "_raw_params": "cat litmus-result.yaml", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:31.396797", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: localpv-selected-device \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", 
    "stdout_lines": [
        "---", 
        "apiVersion: litmus.io/v1alpha1", 
        "kind: LitmusResult", 
        "metadata:", 
        "", 
        "  # name of the litmus testcase", 
        "  name: localpv-selected-device ", 
        "spec:", 
        "", 
        "  # holds information on the testcase", 
        "  testMetadata:", 
        "    app:  ", 
        "    chaostype:  ", 
        "", 
        "  # holds the state of testcase,  manually updated by json merge patch", 
        "  # result is the useful value today, but anticipate phase use in future ", 
        "  testStatus: ", 
        "    phase: in-progress  ", 
        "    result: none "
    ]
}
Read vars_file 'test_vars.yml'

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-03T23:53:32.161846 (delta: 1.080919)         elapsed: 11.440473 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585 `" && echo ansible-tmp-1588550012.21-241113959432585="` echo /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/clustering/k8s/k8s.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpLlAGTS TO /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585/AnsiballZ_k8s.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585/ /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585/AnsiballZ_k8s.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585/AnsiballZ_k8s.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550012.21-241113959432585/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "diff": [
        [
            "change", 
            "spec.testStatus.phase", 
            [
                "in-progress", 
                "completed"
            ]
        ], 
        [
            "change", 
            "spec.testStatus.result", 
            [
                "none", 
                "Fail"
            ]
        ], 
        [
            "change", 
            "metadata.generation", 
            [
                35, 
                34
            ]
        ], 
        [
            "change", 
            "metadata.resourceVersion", 
            [
                "133276", 
                "127771"
            ]
        ]
    ], 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "api_key": null, 
            "cert_file": null, 
            "context": null, 
            "force": false, 
            "host": null, 
            "key_file": null, 
            "kubeconfig": null, 
            "merge_type": null, 
            "password": null, 
            "ssl_ca_cert": null, 
            "state": "present", 
            "username": null, 
            "verify_ssl": null
        }
    }, 
    "method": "patch", 
    "result": {
        "apiVersion": "litmus.io/v1alpha1", 
        "kind": "LitmusResult", 
        "metadata": {
            "creationTimestamp": "2020-05-03T18:17:51Z", 
            "generation": 35, 
            "name": "localpv-selected-device", 
            "resourceVersion": "133276", 
            "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/localpv-selected-device", 
            "uid": "cdb78a11-3927-4d6b-a7b2-0072f850fd40"
        }, 
        "spec": {
            "testMetadata": {}, 
            "testStatus": {
                "phase": "in-progress", 
                "result": "none"
            }
        }
    }
}
Read vars_file 'test_vars.yml'

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-03T23:53:33.167865 (delta: 1.005976)         elapsed: 12.446492 ******* 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-03T23:53:33.226535 (delta: 0.058628)         elapsed: 12.505162 ******* 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-03T23:53:33.286673 (delta: 0.060096)         elapsed: 12.5653 ********* 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Obtain the list of nodes] ************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:19
2020-05-03T23:53:33.345925 (delta: 0.059191)         elapsed: 12.624552 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598 `" && echo ansible-tmp-1588550013.4-231884453452598="` echo /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmps0INrm TO /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598/ /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550013.4-231884453452598/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl get nodes --no-headers | grep -v master | awk '{print $1}'", 
    "delta": "0:00:01.087445", 
    "end": "2020-05-03 23:53:34.620587", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get nodes --no-headers | grep -v master | awk '{print $1}'", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:33.533142", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "giri-node1\ngiri-node2\ngiri-node3", 
    "stdout_lines": [
        "giri-node1", 
        "giri-node2", 
        "giri-node3"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Getting the Unclaimed block-device from each node] ***********************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:25
2020-05-03T23:53:34.688062 (delta: 1.342094)         elapsed: 13.966689 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267 `" && echo ansible-tmp-1588550014.75-62380021227267="` echo /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpLmmCpz TO /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267/ /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550014.75-62380021227267/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => (item=giri-node1) => {
    "changed": true, 
    "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
    "delta": "0:00:00.821832", 
    "end": "2020-05-03 23:53:35.694696", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "item": "giri-node1", 
    "rc": 0, 
    "start": "2020-05-03 23:53:34.872864", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice-111cc41d48cd83408e1b45347a2c9d83", 
    "stdout_lines": [
        "blockdevice-111cc41d48cd83408e1b45347a2c9d83"
    ]
}
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752 `" && echo ansible-tmp-1588550015.73-6930980094752="` echo /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpJG1N7m TO /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752/ /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550015.73-6930980094752/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => (item=giri-node2) => {
    "changed": true, 
    "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node2 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
    "delta": "0:00:00.821968", 
    "end": "2020-05-03 23:53:36.688327", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node2 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "item": "giri-node2", 
    "rc": 0, 
    "start": "2020-05-03 23:53:35.866359", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5", 
    "stdout_lines": [
        "blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5"
    ]
}
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999 `" && echo ansible-tmp-1588550016.73-265011965000999="` echo /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpnUOZrr TO /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999/ /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550016.73-265011965000999/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => (item=giri-node3) => {
    "changed": true, 
    "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node3 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
    "delta": "0:00:00.985070", 
    "end": "2020-05-03 23:53:37.847357", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node3 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "item": "giri-node3", 
    "rc": 0, 
    "start": "2020-05-03 23:53:36.862287", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice-13113626d35a434a33f02ef4f943a7bd", 
    "stdout_lines": [
        "blockdevice-13113626d35a434a33f02ef4f943a7bd"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Label the selected block devices] ****************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:33
2020-05-03T23:53:37.916506 (delta: 3.2284)         elapsed: 17.195133 ********* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258 `" && echo ansible-tmp-1588550017.98-145558096812258="` echo /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpHrOdt3 TO /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258/ /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550017.98-145558096812258/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-111cc41d48cd83408e1b45347a2c9d83', '_ansible_item_result': True, u'delta': u'0:00:00.821832', 'stdout_lines': [u'blockdevice-111cc41d48cd83408e1b45347a2c9d83'], '_ansible_item_label': u'giri-node1', u'end': u'2020-05-03 23:53:35.694696', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | head -n 1', 'item': u'giri-node1', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-05-03 23:53:34.872864', '_ansible_ignore_errors': None}) => {
    "changed": true, 
    "cmd": "kubectl label bd -n \"openebs\" \"blockdevice-111cc41d48cd83408e1b45347a2c9d83\" openebs.io/block-device-tag=\"e2e\"", 
    "delta": "0:00:00.813751", 
    "end": "2020-05-03 23:53:38.916794", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl label bd -n \"openebs\" \"blockdevice-111cc41d48cd83408e1b45347a2c9d83\" openebs.io/block-device-tag=\"e2e\"", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "item": {
        "changed": true, 
        "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
        "delta": "0:00:00.821832", 
        "end": "2020-05-03 23:53:35.694696", 
        "failed": false, 
        "invocation": {
            "module_args": {
                "_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node1 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
                "_uses_shell": true, 
                "argv": null, 
                "chdir": null, 
                "creates": null, 
                "executable": null, 
                "removes": null, 
                "stdin": null, 
                "warn": true
            }
        }, 
        "item": "giri-node1", 
        "rc": 0, 
        "start": "2020-05-03 23:53:34.872864", 
        "stderr": "", 
        "stderr_lines": [], 
        "stdout": "blockdevice-111cc41d48cd83408e1b45347a2c9d83", 
        "stdout_lines": [
            "blockdevice-111cc41d48cd83408e1b45347a2c9d83"
        ]
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:38.103043", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice.openebs.io/blockdevice-111cc41d48cd83408e1b45347a2c9d83 labeled", 
    "stdout_lines": [
        "blockdevice.openebs.io/blockdevice-111cc41d48cd83408e1b45347a2c9d83 labeled"
    ]
}
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701 `" && echo ansible-tmp-1588550018.96-108954676366701="` echo /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpMwi5TF TO /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701/ /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550018.96-108954676366701/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5', '_ansible_item_result': True, u'delta': u'0:00:00.821968', 'stdout_lines': [u'blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5'], '_ansible_item_label': u'giri-node2', u'end': u'2020-05-03 23:53:36.688327', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node2 -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | head -n 1', 'item': u'giri-node2', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node2 -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-05-03 23:53:35.866359', '_ansible_ignore_errors': None}) => {
    "changed": true, 
    "cmd": "kubectl label bd -n \"openebs\" \"blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5\" openebs.io/block-device-tag=\"e2e\"", 
    "delta": "0:00:00.832978", 
    "end": "2020-05-03 23:53:39.950515", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl label bd -n \"openebs\" \"blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5\" openebs.io/block-device-tag=\"e2e\"", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "item": {
        "changed": true, 
        "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node2 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
        "delta": "0:00:00.821968", 
        "end": "2020-05-03 23:53:36.688327", 
        "failed": false, 
        "invocation": {
            "module_args": {
                "_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node2 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
                "_uses_shell": true, 
                "argv": null, 
                "chdir": null, 
                "creates": null, 
                "executable": null, 
                "removes": null, 
                "stdin": null, 
                "warn": true
            }
        }, 
        "item": "giri-node2", 
        "rc": 0, 
        "start": "2020-05-03 23:53:35.866359", 
        "stderr": "", 
        "stderr_lines": [], 
        "stdout": "blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5", 
        "stdout_lines": [
            "blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5"
        ]
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:39.117537", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice.openebs.io/blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5 labeled", 
    "stdout_lines": [
        "blockdevice.openebs.io/blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5 labeled"
    ]
}
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848 `" && echo ansible-tmp-1588550020.0-135021172636848="` echo /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmp50Dhpy TO /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848/ /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550020.0-135021172636848/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'blockdevice-13113626d35a434a33f02ef4f943a7bd', '_ansible_item_result': True, u'delta': u'0:00:00.985070', 'stdout_lines': [u'blockdevice-13113626d35a434a33f02ef4f943a7bd'], '_ansible_item_label': u'giri-node3', u'end': u'2020-05-03 23:53:37.847357', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node3 -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | head -n 1', 'item': u'giri-node3', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node3 -o jsonpath=\'{.items[?(@.status.claimState=="Unclaimed")].metadata.name}\' | tr " " "\\n" | head -n 1', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-05-03 23:53:36.862287', '_ansible_ignore_errors': None}) => {
    "changed": true, 
    "cmd": "kubectl label bd -n \"openebs\" \"blockdevice-13113626d35a434a33f02ef4f943a7bd\" openebs.io/block-device-tag=\"e2e\"", 
    "delta": "0:00:00.784504", 
    "end": "2020-05-03 23:53:40.926751", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl label bd -n \"openebs\" \"blockdevice-13113626d35a434a33f02ef4f943a7bd\" openebs.io/block-device-tag=\"e2e\"", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "item": {
        "changed": true, 
        "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node3 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
        "delta": "0:00:00.985070", 
        "end": "2020-05-03 23:53:37.847357", 
        "failed": false, 
        "invocation": {
            "module_args": {
                "_raw_params": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=giri-node3 -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | head -n 1", 
                "_uses_shell": true, 
                "argv": null, 
                "chdir": null, 
                "creates": null, 
                "executable": null, 
                "removes": null, 
                "stdin": null, 
                "warn": true
            }
        }, 
        "item": "giri-node3", 
        "rc": 0, 
        "start": "2020-05-03 23:53:36.862287", 
        "stderr": "", 
        "stderr_lines": [], 
        "stdout": "blockdevice-13113626d35a434a33f02ef4f943a7bd", 
        "stdout_lines": [
            "blockdevice-13113626d35a434a33f02ef4f943a7bd"
        ]
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:40.142247", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice.openebs.io/blockdevice-13113626d35a434a33f02ef4f943a7bd labeled", 
    "stdout_lines": [
        "blockdevice.openebs.io/blockdevice-13113626d35a434a33f02ef4f943a7bd labeled"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Forming storage class manifest from template] ****************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:42
2020-05-03T23:53:40.989894 (delta: 3.073346)         elapsed: 20.268521 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137 `" && echo ansible-tmp-1588550021.03-242509052343137="` echo /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/stat.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpqa1him TO /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/AnsiballZ_stat.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/ /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpWevN7U/storage_class.j2 TO /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/source
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/ /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/source && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/copy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpFmHAfI TO /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/AnsiballZ_copy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/ /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "checksum": "20f78ac93b693851fc4a799a4cfa07afbd356d13", 
    "dest": "./storage_class.yml", 
    "diff": [], 
    "gid": 0, 
    "group": "root", 
    "invocation": {
        "module_args": {
            "_original_basename": "storage_class.j2", 
            "attributes": null, 
            "backup": false, 
            "checksum": "20f78ac93b693851fc4a799a4cfa07afbd356d13", 
            "content": null, 
            "delimiter": null, 
            "dest": "./storage_class.yml", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "local_follow": null, 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "md5sum": "d7f2738536444c32269af41e1f6858ac", 
    "mode": "0644", 
    "owner": "root", 
    "size": 358, 
    "src": "/root/.ansible/tmp/ansible-tmp-1588550021.03-242509052343137/source", 
    "state": "file", 
    "uid": 0
}
Read vars_file 'test_vars.yml'

TASK [Creating storageClass] ***************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:47
2020-05-03T23:53:41.362903 (delta: 0.372966)         elapsed: 20.64153 ******** 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881 `" && echo ansible-tmp-1588550021.4-16641898921881="` echo /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpCzL0co TO /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881/ /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550021.4-16641898921881/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl apply -f storage_class.yml", 
    "delta": "0:00:01.066857", 
    "end": "2020-05-03 23:53:42.590598", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl apply -f storage_class.yml", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:41.523741", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "storageclass.storage.k8s.io/openebs-device-test unchanged", 
    "stdout_lines": [
        "storageclass.storage.k8s.io/openebs-device-test unchanged"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Forming application manifest from the template] **************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:54
2020-05-03T23:53:42.660519 (delta: 1.297567)         elapsed: 21.939146 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935 `" && echo ansible-tmp-1588550022.71-127483201659935="` echo /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/stat.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpNhEz1a TO /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/AnsiballZ_stat.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/ /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpvEutm3/percona.j2 TO /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/source
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/ /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/source && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/copy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpMr0ApI TO /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/AnsiballZ_copy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/ /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "checksum": "a0205db6ec971e49cd2ff472b8c7fa763bb2844d", 
    "dest": "./percona.yml", 
    "diff": [], 
    "gid": 0, 
    "group": "root", 
    "invocation": {
        "module_args": {
            "_original_basename": "percona.j2", 
            "attributes": null, 
            "backup": false, 
            "checksum": "a0205db6ec971e49cd2ff472b8c7fa763bb2844d", 
            "content": null, 
            "delimiter": null, 
            "dest": "./percona.yml", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "local_follow": null, 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "md5sum": "a2f8df8cb24d4996f68cb30d12b53a47", 
    "mode": "0644", 
    "owner": "root", 
    "size": 1345, 
    "src": "/root/.ansible/tmp/ansible-tmp-1588550022.71-127483201659935/source", 
    "state": "file", 
    "uid": 0
}
Read vars_file 'test_vars.yml'

TASK [Creating namespace] ******************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:59
2020-05-03T23:53:43.066805 (delta: 0.406238)         elapsed: 22.345432 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118 `" && echo ansible-tmp-1588550023.12-151292446233118="` echo /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpYZj39L TO /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118/ /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550023.12-151292446233118/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl create ns \"ns\"", 
    "delta": "0:00:01.012531", 
    "end": "2020-05-03 23:53:44.272769", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl create ns \"ns\"", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:43.260238", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "namespace/ns created", 
    "stdout_lines": [
        "namespace/ns created"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Deploying application] ***************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:66
2020-05-03T23:53:44.339743 (delta: 1.272858)         elapsed: 23.61837 ******** 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979 `" && echo ansible-tmp-1588550024.39-161532720625979="` echo /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpHbKIGO TO /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979/ /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550024.39-161532720625979/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl apply -f percona.yml -n \"ns\"", 
    "delta": "0:00:00.999957", 
    "end": "2020-05-03 23:53:45.523081", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl apply -f percona.yml -n \"ns\"", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:44.523124", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "deployment.apps/percona created\npersistentvolumeclaim/test created\nservice/percona-mysql created", 
    "stdout_lines": [
        "deployment.apps/percona created", 
        "persistentvolumeclaim/test created", 
        "service/percona-mysql created"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Check if the PVC is bound] ***********************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:73
2020-05-03T23:53:45.615628 (delta: 1.275809)         elapsed: 24.894255 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601 `" && echo ansible-tmp-1588550025.67-170740807857601="` echo /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmptCCO_x TO /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601/ /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550025.67-170740807857601/ > /dev/null 2>&1 && sleep 0'
FAILED - RETRYING: Check if the PVC is bound (20 retries left).Result was: {
    "attempts": 1, 
    "changed": true, 
    "cmd": "kubectl get pvc -n ns test --no-headers -o custom-columns=:status.phase", 
    "delta": "0:00:01.079395", 
    "end": "2020-05-03 23:53:46.876297", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get pvc -n ns test --no-headers -o custom-columns=:status.phase", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "retries": 21, 
    "start": "2020-05-03 23:53:45.796902", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "Pending", 
    "stdout_lines": [
        "Pending"
    ]
}
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369 `" && echo ansible-tmp-1588550036.91-5720792359369="` echo /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpJHSLdO TO /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369/ /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550036.91-5720792359369/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "attempts": 2, 
    "changed": true, 
    "cmd": "kubectl get pvc -n ns test --no-headers -o custom-columns=:status.phase", 
    "delta": "0:00:00.957106", 
    "end": "2020-05-03 23:53:58.007717", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get pvc -n ns test --no-headers -o custom-columns=:status.phase", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:57.050611", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "Bound", 
    "stdout_lines": [
        "Bound"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Getting PV name from PVC] ************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:84
2020-05-03T23:53:58.080292 (delta: 12.464564)         elapsed: 37.358919 ****** 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736 `" && echo ansible-tmp-1588550038.14-204964850005736="` echo /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmptciE2T TO /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736/ /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550038.14-204964850005736/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl get pvc test -n ns --no-headers -o custom-columns=:.spec.volumeName", 
    "delta": "0:00:00.991881", 
    "end": "2020-05-03 23:53:59.267953", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get pvc test -n ns --no-headers -o custom-columns=:.spec.volumeName", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:58.276072", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91", 
    "stdout_lines": [
        "pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Obtain the labelled BDs list] ********************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:93
2020-05-03T23:53:59.335526 (delta: 1.255141)         elapsed: 38.614153 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153 `" && echo ansible-tmp-1588550039.39-80904265515153="` echo /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpkEnHh3 TO /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153/ /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550039.39-80904265515153/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl get bd -n \"openebs\" -l ndm.io/managed=true,openebs.io/block-device-tag --no-headers -o jsonpath='{.items[*].metadata.name}'", 
    "delta": "0:00:00.993761", 
    "end": "2020-05-03 23:54:00.504237", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get bd -n \"openebs\" -l ndm.io/managed=true,openebs.io/block-device-tag --no-headers -o jsonpath='{.items[*].metadata.name}'", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:53:59.510476", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice-0ee17cf390682c34a3d42e8149c5c776 blockdevice-111cc41d48cd83408e1b45347a2c9d83 blockdevice-13113626d35a434a33f02ef4f943a7bd blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5", 
    "stdout_lines": [
        "blockdevice-0ee17cf390682c34a3d42e8149c5c776 blockdevice-111cc41d48cd83408e1b45347a2c9d83 blockdevice-13113626d35a434a33f02ef4f943a7bd blockdevice-ab636ddeba8f8cd45f7e91a6b55c15e5"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Obtain the BDC created for volume] ***************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:102
2020-05-03T23:54:00.576814 (delta: 1.241247)         elapsed: 39.855441 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454 `" && echo ansible-tmp-1588550040.63-19529801010454="` echo /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmptXAMTv TO /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454/ /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550040.63-19529801010454/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl get pv \"pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91\" -o jsonpath='{.metadata.annotations.local\\.openebs\\.io/blockdeviceclaim}'", 
    "delta": "0:00:01.021553", 
    "end": "2020-05-03 23:54:01.788477", 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get pv \"pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91\" -o jsonpath='{.metadata.annotations.local\\.openebs\\.io/blockdeviceclaim}'", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:54:00.766924", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "bdc-pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91", 
    "stdout_lines": [
        "bdc-pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91"
    ]
}
Read vars_file 'test_vars.yml'

TASK [Check if the labelled BD is used by local PV] ****************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:110
2020-05-03T23:54:01.854133 (delta: 1.277275)         elapsed: 41.13276 ******** 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609 `" && echo ansible-tmp-1588550041.9-228052679369609="` echo /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpz8ixMx TO /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609/ /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550041.9-228052679369609/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "kubectl get bdc \"bdc-pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91\" -n \"openebs\" --no-headers -o custom-columns=:spec.blockDeviceName", 
    "delta": "0:00:00.936400", 
    "end": "2020-05-03 23:54:02.969932", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "kubectl get bdc \"bdc-pvc-f51dedcf-4f94-495b-98f9-f2b00e075d91\" -n \"openebs\" --no-headers -o custom-columns=:spec.blockDeviceName", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": "/bin/bash", 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:54:02.033532", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "blockdevice-111cc41d48cd83408e1b45347a2c9d83", 
    "stdout_lines": [
        "blockdevice-111cc41d48cd83408e1b45347a2c9d83"
    ]
}
Read vars_file 'test_vars.yml'

TASK [set_fact] ****************************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:119
2020-05-03T23:54:03.074549 (delta: 1.220371)         elapsed: 42.353176 ******* 
ok: [127.0.0.1] => {
    "ansible_facts": {
        "flag": "Pass"
    }, 
    "changed": false
}
Read vars_file 'test_vars.yml'

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/localpv/localpv-provisioning-selected-device/test.yml:128
2020-05-03T23:54:03.164252 (delta: 0.089658)         elapsed: 42.442879 ******* 
Read vars_file 'test_vars.yml'
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'
Read vars_file 'test_vars.yml'

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-03T23:54:03.323974 (delta: 0.15967)         elapsed: 42.602601 ******** 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-03T23:54:03.398300 (delta: 0.074267)         elapsed: 42.676927 ******* 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-03T23:54:03.465035 (delta: 0.066631)         elapsed: 42.743662 ******* 
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
Read vars_file 'test_vars.yml'

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-03T23:54:03.532539 (delta: 0.067461)         elapsed: 42.811166 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771 `" && echo ansible-tmp-1588550043.58-180491611234771="` echo /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/stat.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpoKwyhw TO /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/AnsiballZ_stat.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/ /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/AnsiballZ_stat.py && sleep 0'
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmpDXAPFW/litmus-result.j2 TO /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/source
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/ /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/source && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/files/copy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmp6WvtCI TO /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/AnsiballZ_copy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/ /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/AnsiballZ_copy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "checksum": "56430adf3c4010539bf5917e3376402c4fcdeb32", 
    "dest": "./litmus-result.yaml", 
    "diff": [], 
    "gid": 0, 
    "group": "root", 
    "invocation": {
        "module_args": {
            "_original_basename": "litmus-result.j2", 
            "attributes": null, 
            "backup": false, 
            "checksum": "56430adf3c4010539bf5917e3376402c4fcdeb32", 
            "content": null, 
            "delimiter": null, 
            "dest": "./litmus-result.yaml", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "local_follow": null, 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "md5sum": "c0ca4ac1a19eccb6c865b2aa990bb022", 
    "mode": "0644", 
    "owner": "root", 
    "size": 422, 
    "src": "/root/.ansible/tmp/ansible-tmp-1588550043.58-180491611234771/source", 
    "state": "file", 
    "uid": 0
}
Read vars_file 'test_vars.yml'

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-03T23:54:05.378892 (delta: 1.846292)         elapsed: 44.657519 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206 `" && echo ansible-tmp-1588550045.44-56850122207206="` echo /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmp5IGc82 TO /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206/ /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206/AnsiballZ_command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550045.44-56850122207206/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "cat litmus-result.yaml", 
    "delta": "0:00:00.724512", 
    "end": "2020-05-03 23:54:06.291115", 
    "invocation": {
        "module_args": {
            "_raw_params": "cat litmus-result.yaml", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-05-03 23:54:05.566603", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: localpv-selected-device \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", 
    "stdout_lines": [
        "---", 
        "apiVersion: litmus.io/v1alpha1", 
        "kind: LitmusResult", 
        "metadata:", 
        "", 
        "  # name of the litmus testcase", 
        "  name: localpv-selected-device ", 
        "spec:", 
        "", 
        "  # holds information on the testcase", 
        "  testMetadata:", 
        "    app:  ", 
        "    chaostype:  ", 
        "", 
        "  # holds the state of testcase,  manually updated by json merge patch", 
        "  # result is the useful value today, but anticipate phase use in future ", 
        "  testStatus: ", 
        "    phase: completed  ", 
        "    result: Pass "
    ]
}
Read vars_file 'test_vars.yml'

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-03T23:54:06.361018 (delta: 0.982084)         elapsed: 45.639645 ******* 
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226 `" && echo ansible-tmp-1588550046.41-203574233993226="` echo /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226 `" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/clustering/k8s/k8s.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6vNCeJy/tmp2TmTke TO /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226/AnsiballZ_k8s.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226/ /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226/AnsiballZ_k8s.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226/AnsiballZ_k8s.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1588550046.41-203574233993226/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "diff": [
        [
            "change", 
            "spec.testStatus.phase", 
            [
                "completed", 
                "in-progress"
            ]
        ], 
        [
            "change", 
            "spec.testStatus.result", 
            [
                "Pass", 
                "none"
            ]
        ], 
        [
            "change", 
            "metadata.generation", 
            [
                36, 
                35
            ]
        ], 
        [
            "change", 
            "metadata.resourceVersion", 
            [
                "133467", 
                "133276"
            ]
        ]
    ], 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "api_key": null, 
            "cert_file": null, 
            "context": null, 
            "force": false, 
            "host": null, 
            "key_file": null, 
            "kubeconfig": null, 
            "merge_type": [
                "merge"
            ], 
            "password": null, 
            "ssl_ca_cert": null, 
            "state": "present", 
            "username": null, 
            "verify_ssl": null
        }
    }, 
    "method": "patch", 
    "result": {
        "apiVersion": "litmus.io/v1alpha1", 
        "kind": "LitmusResult", 
        "metadata": {
            "creationTimestamp": "2020-05-03T18:17:51Z", 
            "generation": 36, 
            "name": "localpv-selected-device", 
            "resourceVersion": "133467", 
            "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/localpv-selected-device", 
            "uid": "cdb78a11-3927-4d6b-a7b2-0072f850fd40"
        }, 
        "spec": {
            "testMetadata": {}, 
            "testStatus": {
                "phase": "completed", 
                "result": "Pass"
            }
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=19   unreachable=0    failed=0   

2020-05-03T23:54:07.228389 (delta: 0.866769)         elapsed: 46.507016 ******* 
===============================================================================
```
