### PR TITLE
Disable the gathering_facts in ansible-playbooks

### DIFF
--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: localhost
   connection: local
+  gather_facts: False
 
   vars_files:
     - test_vars.yml

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: localhost
   connection: local
+  gather_facts: False
 
   vars_files:
     - test_vars.yml

--- a/experiments/functional/csi-volume-resize/test.yml
+++ b/experiments/functional/csi-volume-resize/test.yml
@@ -11,6 +11,7 @@
 
 - hosts: localhost
   connection: local
+  gather_facts: False
 
   vars_files:
     - test_vars.yml

--- a/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfs-controller-HA/test.yml
@@ -1,5 +1,6 @@
 - hosts: localhost
   connection: local
+  gather_facts: False
 
   vars_files:
     - test_vars.yml


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- set the gather_fact as False to avoid the gathering fact task.
This PR sets it false in remaining task which was not covered in PR https://github.com/openebs/e2e-tests/pull/312 and used in native-k8s pipeline
