### PR TITLE
feat[yaml]: Implemented litmusbook to validate preloading changes of jiva volume

### DIFF
--- a/experiments/chaos/jiva-preload/README.md
+++ b/experiments/chaos/jiva-preload/README.md
@@ -1,0 +1,39 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | Storage | Applications | K8s Platform |
+| ----- | ------------------------------------------------------------ | ------- | ------------ | ------------ |
+| Chaos | Ensure that preloading does not affect syncing of the data. | OpenEBS | Any          | Any          |
+
+## Entry-Criteria
+
+- Application should be created using jiva volume and should be up.
+- Jiva volume should be created with three replica.
+
+## Exit-Criteria
+
+- Application and all three jiva replica should be up.
+
+## Procedure
+
+- Check all the replicas are up and running.
+- Write data to even offset using dd.
+- Restart all three replicas.
+- Wait for two replicas to come into RW state.
+- Start I/O with full pace, this time to odd offsets.
+- Check whether all the three replicas are up and in running state.
+
+## Note
+
+- The reason behind dumping the data in even and odd offsets is to increase the number of extents in 'filefrag -e file_name'. As the number of extents will go high, preloading will take some time and our intention of experiment would get surved. 
+- Preloading will be done in the first replica only before serving any I/O and timeout for the I/Os are set to infinity, in the rest of the replicas preloading will takes place after syncing up the data.
+ 
+## Environment Variables
+
+| Parameters        | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| APP_LABEL         | Label of the Application.                        |
+| APP_NAMESPACE     | Namespace where application is deployed.         |
+| APP_PVC           | Persistent Volume Claim of the application.      |
+| OFFSET_COUNT      | Block Count to dump the data using dd.           |
+| OPERATOR_NS       | OpenEBS.                                         |
+| MOUNT_PATH        | Mount path where volume is mounted.              |

--- a/experiments/chaos/jiva-preload/run_litmus_test.yml
+++ b/experiments/chaos/jiva-preload/run_litmus_test.yml
@@ -35,7 +35,7 @@ spec:
           - name: APP_LABEL
             value: ''
 
-             # Application Label
+             # Application mount path
           - name: MOUNT_PATH
             value: ''
             

--- a/experiments/chaos/jiva-preload/run_litmus_test.yml
+++ b/experiments/chaos/jiva-preload/run_litmus_test.yml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-jiva-preloading-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-jiva-preloading
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: ''
+            
+            # Application pvc
+          - name: APP_PVC
+            value: ''
+ 
+            # Application Label
+          - name: APP_LABEL
+            value: ''
+            
+            # Number of count to be used in dd process 
+          - name: OFFSET_COUNT
+            value: '2000'
+          
+            #Target namespace
+          - name: OPERATOR_NS
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/jiva-preload/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/chaos/jiva-preload/run_litmus_test.yml
+++ b/experiments/chaos/jiva-preload/run_litmus_test.yml
@@ -34,6 +34,10 @@ spec:
             # Application Label
           - name: APP_LABEL
             value: ''
+
+             # Application Label
+          - name: MOUNT_PATH
+            value: ''
             
             # Number of count to be used in dd process 
           - name: OFFSET_COUNT

--- a/experiments/chaos/jiva-preload/test.yml
+++ b/experiments/chaos/jiva-preload/test.yml
@@ -1,0 +1,139 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+          ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        ## DISPLAY APP INFORMATION
+
+        - name: Display the app information passed via the test job
+          debug:
+            msg:
+              - "The application info is as follows:"
+              - "Namespace    : {{ app_ns }}"
+              - "Label        : {{ app_label }}"
+              - "PVC          : {{ app_pvc }}"
+
+        ## APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
+   
+        - name: Obtain the application pod name
+          shell: >
+            kubectl get pod -n "{{ app_ns }}" -l "{{ app_label }}" --no-headers 
+            -o custom-columns=:.metadata.name
+          args:
+            executable: /bin/bash
+          register: app_pod
+          failed_when: "app_pod.rc != 0"
+
+        - name: Obtain the pv name of the application.
+          shell: >
+            kubectl get pvc -n "{{ app_ns }}" -o custom-columns=:.spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: app_pv
+          failed_when: "app_pv.rc != 0"
+
+        - name: Checking for all replicas to be in Running state
+          shell: >
+            kubectl get pod -n {{ operator_ns }} -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ app_pv.stdout }}" 
+            --no-headers -o custom-columns=:status.phase
+          register: running_rep_status
+          until: "((running_rep_status.stdout_lines|unique)|length) == 1 and 'Running' in running_rep_status.stdout"
+          delay: 10
+          retries: 30
+        
+        ## Writing the data to even offsets to make more number of extents in preloading file.
+        - name: Dumping the data to even offset using dd
+          shell: >
+            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- sh -c "dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek={{ item }}"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+          loop: "{{ range(0, offset_count | int, 2)|list }}" 
+
+        - name: Restart all the replica pods of jiva volume
+          shell: >
+            kubectl delete pods -n "{{ operator_ns }}" -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume="{{ app_pv.stdout }}" --force --grace-period=0 
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+
+        - name: Get the maya-apiserver pod name
+          shell:  kubectl get pods -n {{ operator_ns }} -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: mayapod
+          changed_when: True
+
+        - name: Get the volume list
+          shell: kubectl exec -it {{ mayapod.stdout }} -n {{ operator_ns }} -- mayactl volume list
+          args:
+            executable: /bin/bash
+          register: volname
+          changed_when: True
+          until: 'app_pv.stdout in volname.stdout'
+          delay: 30
+          retries: 5
+
+        - name: Get the replicas access mode
+          shell: >
+              kubectl exec -it {{ mayapod.stdout }} -n {{ operator_ns }} -- mayactl volume describe --volname "{{ app_pv.stdout }}" -n {{ app_ns }} | grep 'RW' | wc -l
+          args:
+            executable: /bin/bash
+          register: result
+          until: result.stdout| int == 2
+          delay: 30
+          retries: 30
+          changed_when: True
+
+        ## Writing the data to odd offsets to make even more number of extents in preloading file.
+        - name: Dumping the data to odd offsets using dd
+          shell: >
+            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- sh -c "dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek={{ item }}"
+          args:
+            executable: /bin/bash
+          register: status
+          failed_when: "status.rc != 0"
+          loop: "{{ range(1, offset_count | int, 2)|list }}" 
+        
+        #### Check the replica access mode after completion of dumping process
+        - name: Check the replicas access mode
+          include_tasks: "/funclib/openebs/access-mode-check.yml"
+          vars:
+            ns: "{{ app_ns }}"
+            pvc_name: "{{ app_pvc }}"
+                       
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+                  
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/chaos/jiva-preload/test.yml
+++ b/experiments/chaos/jiva-preload/test.yml
@@ -64,7 +64,7 @@
         ## Writing the data to even offsets to make more number of extents in preloading file.
         - name: Dumping the data to even offset using dd
           shell: >
-            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- sh -c "dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek={{ item }}"
+            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- sh -c "dd if=/dev/urandom of={{ mount_path }}/abc.txt bs=4k count=1 seek={{ item }}"
           args:
             executable: /bin/bash
           register: status
@@ -110,7 +110,7 @@
         ## Writing the data to odd offsets to make even more number of extents in preloading file.
         - name: Dumping the data to odd offsets using dd
           shell: >
-            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- sh -c "dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek={{ item }}"
+            kubectl exec -ti "{{ app_pod.stdout }}" -n "{{ app_ns }}" -- sh -c "dd if=/dev/urandom of={{ mount_path }}/abc.txt bs=4k count=1 seek={{ item }}"
           args:
             executable: /bin/bash
           register: status

--- a/experiments/chaos/jiva-preload/test_vars.yml
+++ b/experiments/chaos/jiva-preload/test_vars.yml
@@ -7,6 +7,8 @@ app_label: "{{ lookup('env','APP_LABEL') }}"
 
 app_pvc: "{{ lookup('env','APP_PVC') }}"
 
+mount_path: "{{ lookup('env','MOUNT_PATH') }}"
+
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 
 offset_count: "{{ lookup('env','OFFSET_COUNT') }}"

--- a/experiments/chaos/jiva-preload/test_vars.yml
+++ b/experiments/chaos/jiva-preload/test_vars.yml
@@ -1,0 +1,12 @@
+---
+test_name: jiva-preloading
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+offset_count: "{{ lookup('env','OFFSET_COUNT') }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Implemented litmusbook to validate preloading changes of jiva volume that is, now preloading will be done only for the number of replicas decided by corum's formula (n+1)/2 before serving any I/O.
In rest of the replicas preloading will take place after sync up of the data.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #309 

**Special notes for your reviewer**:
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/jiva-preload/test.yml

PLAY [localhost] ***************************************************************
2020-05-05T14:22:42.216549 (delta: 0.08479)         elapsed: 0.08479 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/jiva-preload/test.yml:3
2020-05-05T14:22:42.235993 (delta: 0.019392)         elapsed: 0.104234 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva-preload/test.yml:12
2020-05-05T14:22:53.750481 (delta: 11.514441)         elapsed: 11.618722 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-05-05T14:22:53.867372 (delta: 0.116797)         elapsed: 11.735613 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-05-05T14:22:53.952876 (delta: 0.085409)         elapsed: 11.821117 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva-preload/test.yml:15
2020-05-05T14:22:54.056769 (delta: 0.103775)         elapsed: 11.92501 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-05T14:22:54.187208 (delta: 0.130372)         elapsed: 12.055449 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b759a188ec48200d7b3b38c3f00d3737af6a9510", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "e88f1059d44113fa6f00183eb6dec45c", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1588688574.26-251762700440847/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-05T14:22:55.367786 (delta: 1.180512)         elapsed: 13.236027 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.145826", "end": "2020-05-05 14:22:57.028536", "rc": 0, "start": "2020-05-05 14:22:55.882710", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-preloading \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-preloading ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-05T14:22:57.117662 (delta: 1.749791)         elapsed: 14.985903 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-05T13:04:43Z", "generation": 7, "name": "jiva-preloading", "resourceVersion": "4360767", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-preloading", "uid": "a5c26b1b-7757-4333-aac6-69416aaa0c2e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-05T14:22:59.020203 (delta: 1.902474)         elapsed: 16.888444 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-05T14:22:59.137900 (delta: 0.11763)         elapsed: 17.006141 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-05T14:22:59.248761 (delta: 0.110741)         elapsed: 17.117002 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/jiva-preload/test.yml:21
2020-05-05T14:22:59.336442 (delta: 0.0876)         elapsed: 17.204683 ********* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : preload", 
        "Label        : app=busybox-sts", 
        "PVC          : openebs-busybox"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/jiva-preload/test.yml:30
2020-05-05T14:22:59.507837 (delta: 0.171327)         elapsed: 17.376078 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-05-05T14:22:59.685973 (delta: 0.178065)         elapsed: 17.554214 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n preload -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.307613", "end": "2020-05-05 14:23:01.295690", "rc": 0, "start": "2020-05-05 14:22:59.988077", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-05T14:21:06Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-05T14:21:06Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-05-05T14:23:01.401916 (delta: 1.715864)         elapsed: 19.270157 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n preload -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.606671", "end": "2020-05-05 14:23:03.356947", "rc": 0, "start": "2020-05-05 14:23:01.750276", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the application pod name] *****************************************
task path: /experiments/chaos/jiva-preload/test.yml:38
2020-05-05T14:23:03.492108 (delta: 2.090127)         elapsed: 21.360349 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n \"preload\" -l \"app=busybox-sts\" --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.324170", "end": "2020-05-05 14:23:05.131489", "failed_when_result": false, "rc": 0, "start": "2020-05-05 14:23:03.807319", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-k9f9t", "stdout_lines": ["app-busybox-85d45b855f-k9f9t"]}

TASK [Obtain the pv name of the application.] **********************************
task path: /experiments/chaos/jiva-preload/test.yml:47
2020-05-05T14:23:05.250476 (delta: 1.758231)         elapsed: 23.118717 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n \"preload\" -o custom-columns=:.spec.volumeName --no-headers", "delta": "0:00:01.283586", "end": "2020-05-05 14:23:06.838990", "failed_when_result": false, "rc": 0, "start": "2020-05-05 14:23:05.555404", "stderr": "", "stderr_lines": [], "stdout": "pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f", "stdout_lines": ["pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f"]}

TASK [Checking for all replicas to be in Running state] ************************
task path: /experiments/chaos/jiva-preload/test.yml:55
2020-05-05T14:23:06.968763 (delta: 1.718207)         elapsed: 24.837004 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n openebs -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f\" --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.214371", "end": "2020-05-05 14:23:08.466097", "rc": 0, "start": "2020-05-05 14:23:07.251726", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Dumping the data to even offset using dd] ********************************
task path: /experiments/chaos/jiva-preload/test.yml:65
2020-05-05T14:23:08.574194 (delta: 1.605342)         elapsed: 26.442435 ******* 
changed: [127.0.0.1] => (item=0) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=0\"", "delta": "0:00:01.408224", "end": "2020-05-05 14:23:10.290144", "failed_when_result": false, "item": 0, "rc": 0, "start": "2020-05-05 14:23:08.881920", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.006787 seconds, 589.4KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.006787 seconds, 589.4KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=2) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=2\"", "delta": "0:00:01.485814", "end": "2020-05-05 14:23:12.057698", "failed_when_result": false, "item": 2, "rc": 0, "start": "2020-05-05 14:23:10.571884", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=4) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=4\"", "delta": "0:00:01.744410", "end": "2020-05-05 14:23:14.096143", "failed_when_result": false, "item": 4, "rc": 0, "start": "2020-05-05 14:23:12.351733", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=6) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=6\"", "delta": "0:00:01.569711", "end": "2020-05-05 14:23:15.950650", "failed_when_result": false, "item": 6, "rc": 0, "start": "2020-05-05 14:23:14.380939", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000144 seconds, 27.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000144 seconds, 27.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=8) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=8\"", "delta": "0:00:01.355968", "end": "2020-05-05 14:23:17.582203", "failed_when_result": false, "item": 8, "rc": 0, "start": "2020-05-05 14:23:16.226235", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=10) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=10\"", "delta": "0:00:01.471563", "end": "2020-05-05 14:23:19.312121", "failed_when_result": false, "item": 10, "rc": 0, "start": "2020-05-05 14:23:17.840558", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000178 seconds, 21.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000178 seconds, 21.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=12) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=12\"", "delta": "0:00:01.446070", "end": "2020-05-05 14:23:20.996255", "failed_when_result": false, "item": 12, "rc": 0, "start": "2020-05-05 14:23:19.550185", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003442 seconds, 1.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003442 seconds, 1.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=14) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=14\"", "delta": "0:00:01.517933", "end": "2020-05-05 14:23:22.782241", "failed_when_result": false, "item": 14, "rc": 0, "start": "2020-05-05 14:23:21.264308", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000112 seconds, 34.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000112 seconds, 34.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=16) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=16\"", "delta": "0:00:01.485695", "end": "2020-05-05 14:23:24.701621", "failed_when_result": false, "item": 16, "rc": 0, "start": "2020-05-05 14:23:23.215926", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=18) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=18\"", "delta": "0:00:01.437480", "end": "2020-05-05 14:23:26.480273", "failed_when_result": false, "item": 18, "rc": 0, "start": "2020-05-05 14:23:25.042793", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=20) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=20\"", "delta": "0:00:01.634794", "end": "2020-05-05 14:23:28.426779", "failed_when_result": false, "item": 20, "rc": 0, "start": "2020-05-05 14:23:26.791985", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=22) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=22\"", "delta": "0:00:01.390741", "end": "2020-05-05 14:23:30.147572", "failed_when_result": false, "item": 22, "rc": 0, "start": "2020-05-05 14:23:28.756831", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=24) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=24\"", "delta": "0:00:01.433720", "end": "2020-05-05 14:23:31.825096", "failed_when_result": false, "item": 24, "rc": 0, "start": "2020-05-05 14:23:30.391376", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.009017 seconds, 443.6KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.009017 seconds, 443.6KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=26) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=26\"", "delta": "0:00:01.697887", "end": "2020-05-05 14:23:33.797274", "failed_when_result": false, "item": 26, "rc": 0, "start": "2020-05-05 14:23:32.099387", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=28) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=28\"", "delta": "0:00:01.561404", "end": "2020-05-05 14:23:35.585093", "failed_when_result": false, "item": 28, "rc": 0, "start": "2020-05-05 14:23:34.023689", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000137 seconds, 28.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000137 seconds, 28.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=30) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=30\"", "delta": "0:00:01.468004", "end": "2020-05-05 14:23:37.305491", "failed_when_result": false, "item": 30, "rc": 0, "start": "2020-05-05 14:23:35.837487", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000131 seconds, 29.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000131 seconds, 29.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=32) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=32\"", "delta": "0:00:01.500882", "end": "2020-05-05 14:23:39.084661", "failed_when_result": false, "item": 32, "rc": 0, "start": "2020-05-05 14:23:37.583779", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000223 seconds, 17.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000223 seconds, 17.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=34) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=34\"", "delta": "0:00:01.453468", "end": "2020-05-05 14:23:40.783440", "failed_when_result": false, "item": 34, "rc": 0, "start": "2020-05-05 14:23:39.329972", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=36) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=36\"", "delta": "0:00:01.504015", "end": "2020-05-05 14:23:42.561045", "failed_when_result": false, "item": 36, "rc": 0, "start": "2020-05-05 14:23:41.057030", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000132 seconds, 29.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000132 seconds, 29.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=38) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=38\"", "delta": "0:00:01.602400", "end": "2020-05-05 14:23:44.418739", "failed_when_result": false, "item": 38, "rc": 0, "start": "2020-05-05 14:23:42.816339", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000164 seconds, 23.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000164 seconds, 23.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=40) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=40\"", "delta": "0:00:01.538036", "end": "2020-05-05 14:23:46.242869", "failed_when_result": false, "item": 40, "rc": 0, "start": "2020-05-05 14:23:44.704833", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=42) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=42\"", "delta": "0:00:01.346719", "end": "2020-05-05 14:23:47.901195", "failed_when_result": false, "item": 42, "rc": 0, "start": "2020-05-05 14:23:46.554476", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=44) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=44\"", "delta": "0:00:01.383781", "end": "2020-05-05 14:23:49.525007", "failed_when_result": false, "item": 44, "rc": 0, "start": "2020-05-05 14:23:48.141226", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=46) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=46\"", "delta": "0:00:01.443977", "end": "2020-05-05 14:23:51.243474", "failed_when_result": false, "item": 46, "rc": 0, "start": "2020-05-05 14:23:49.799497", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000161 seconds, 24.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000161 seconds, 24.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=48) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=48\"", "delta": "0:00:01.692104", "end": "2020-05-05 14:23:53.290191", "failed_when_result": false, "item": 48, "rc": 0, "start": "2020-05-05 14:23:51.598087", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000191 seconds, 20.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000191 seconds, 20.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=50) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=50\"", "delta": "0:00:01.512837", "end": "2020-05-05 14:23:55.032434", "failed_when_result": false, "item": 50, "rc": 0, "start": "2020-05-05 14:23:53.519597", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000161 seconds, 24.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000161 seconds, 24.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=52) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=52\"", "delta": "0:00:01.775293", "end": "2020-05-05 14:23:57.052951", "failed_when_result": false, "item": 52, "rc": 0, "start": "2020-05-05 14:23:55.277658", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000146 seconds, 26.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000146 seconds, 26.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=54) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=54\"", "delta": "0:00:01.440776", "end": "2020-05-05 14:23:58.748566", "failed_when_result": false, "item": 54, "rc": 0, "start": "2020-05-05 14:23:57.307790", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=56) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=56\"", "delta": "0:00:01.624179", "end": "2020-05-05 14:24:00.618157", "failed_when_result": false, "item": 56, "rc": 0, "start": "2020-05-05 14:23:58.993978", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=58) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=58\"", "delta": "0:00:01.444725", "end": "2020-05-05 14:24:02.295435", "failed_when_result": false, "item": 58, "rc": 0, "start": "2020-05-05 14:24:00.850710", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000139 seconds, 28.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000139 seconds, 28.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=60) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=60\"", "delta": "0:00:01.612035", "end": "2020-05-05 14:24:04.378679", "failed_when_result": false, "item": 60, "rc": 0, "start": "2020-05-05 14:24:02.766644", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000168 seconds, 23.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000168 seconds, 23.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=62) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=62\"", "delta": "0:00:01.651979", "end": "2020-05-05 14:24:06.268338", "failed_when_result": false, "item": 62, "rc": 0, "start": "2020-05-05 14:24:04.616359", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=64) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=64\"", "delta": "0:00:01.381986", "end": "2020-05-05 14:24:07.969269", "failed_when_result": false, "item": 64, "rc": 0, "start": "2020-05-05 14:24:06.587283", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=66) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=66\"", "delta": "0:00:01.640996", "end": "2020-05-05 14:24:09.934268", "failed_when_result": false, "item": 66, "rc": 0, "start": "2020-05-05 14:24:08.293272", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=68) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=68\"", "delta": "0:00:01.496542", "end": "2020-05-05 14:24:11.730504", "failed_when_result": false, "item": 68, "rc": 0, "start": "2020-05-05 14:24:10.233962", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000168 seconds, 23.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000168 seconds, 23.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=70) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=70\"", "delta": "0:00:01.695711", "end": "2020-05-05 14:24:13.697354", "failed_when_result": false, "item": 70, "rc": 0, "start": "2020-05-05 14:24:12.001643", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000163 seconds, 24.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000163 seconds, 24.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=72) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=72\"", "delta": "0:00:01.598486", "end": "2020-05-05 14:24:15.524081", "failed_when_result": false, "item": 72, "rc": 0, "start": "2020-05-05 14:24:13.925595", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.005063 seconds, 790.0KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.005063 seconds, 790.0KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=74) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=74\"", "delta": "0:00:01.440123", "end": "2020-05-05 14:24:17.213942", "failed_when_result": false, "item": 74, "rc": 0, "start": "2020-05-05 14:24:15.773819", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.001202 seconds, 3.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.001202 seconds, 3.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=76) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=76\"", "delta": "0:00:01.431764", "end": "2020-05-05 14:24:18.881097", "failed_when_result": false, "item": 76, "rc": 0, "start": "2020-05-05 14:24:17.449333", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=78) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=78\"", "delta": "0:00:01.482686", "end": "2020-05-05 14:24:20.602024", "failed_when_result": false, "item": 78, "rc": 0, "start": "2020-05-05 14:24:19.119338", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000160 seconds, 24.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000160 seconds, 24.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=80) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=80\"", "delta": "0:00:01.345957", "end": "2020-05-05 14:24:22.163272", "failed_when_result": false, "item": 80, "rc": 0, "start": "2020-05-05 14:24:20.817315", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000133 seconds, 29.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000133 seconds, 29.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=82) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=82\"", "delta": "0:00:01.686412", "end": "2020-05-05 14:24:24.208745", "failed_when_result": false, "item": 82, "rc": 0, "start": "2020-05-05 14:24:22.522333", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000169 seconds, 23.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000169 seconds, 23.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=84) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=84\"", "delta": "0:00:01.599985", "end": "2020-05-05 14:24:26.050885", "failed_when_result": false, "item": 84, "rc": 0, "start": "2020-05-05 14:24:24.450900", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000123 seconds, 31.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000123 seconds, 31.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=86) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=86\"", "delta": "0:00:01.450631", "end": "2020-05-05 14:24:27.738844", "failed_when_result": false, "item": 86, "rc": 0, "start": "2020-05-05 14:24:26.288213", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000162 seconds, 24.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000162 seconds, 24.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=88) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=88\"", "delta": "0:00:01.502235", "end": "2020-05-05 14:24:29.477086", "failed_when_result": false, "item": 88, "rc": 0, "start": "2020-05-05 14:24:27.974851", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=90) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=90\"", "delta": "0:00:01.378611", "end": "2020-05-05 14:24:31.096191", "failed_when_result": false, "item": 90, "rc": 0, "start": "2020-05-05 14:24:29.717580", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000135 seconds, 28.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000135 seconds, 28.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=92) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=92\"", "delta": "0:00:01.623518", "end": "2020-05-05 14:24:33.005044", "failed_when_result": false, "item": 92, "rc": 0, "start": "2020-05-05 14:24:31.381526", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.002234 seconds, 1.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.002234 seconds, 1.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=94) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=94\"", "delta": "0:00:01.474981", "end": "2020-05-05 14:24:34.755780", "failed_when_result": false, "item": 94, "rc": 0, "start": "2020-05-05 14:24:33.280799", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000163 seconds, 24.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000163 seconds, 24.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=96) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=96\"", "delta": "0:00:01.436062", "end": "2020-05-05 14:24:36.496421", "failed_when_result": false, "item": 96, "rc": 0, "start": "2020-05-05 14:24:35.060359", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=98) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=98\"", "delta": "0:00:01.573207", "end": "2020-05-05 14:24:38.297631", "failed_when_result": false, "item": 98, "rc": 0, "start": "2020-05-05 14:24:36.724424", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000136 seconds, 28.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000136 seconds, 28.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=100) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=100\"", "delta": "0:00:01.594550", "end": "2020-05-05 14:24:40.134635", "failed_when_result": false, "item": 100, "rc": 0, "start": "2020-05-05 14:24:38.540085", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000112 seconds, 34.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000112 seconds, 34.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=102) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=102\"", "delta": "0:00:01.398242", "end": "2020-05-05 14:24:41.753675", "failed_when_result": false, "item": 102, "rc": 0, "start": "2020-05-05 14:24:40.355433", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000121 seconds, 32.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000121 seconds, 32.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=104) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=104\"", "delta": "0:00:01.773453", "end": "2020-05-05 14:24:43.771178", "failed_when_result": false, "item": 104, "rc": 0, "start": "2020-05-05 14:24:41.997725", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000301 seconds, 13.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000301 seconds, 13.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=106) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=106\"", "delta": "0:00:01.603844", "end": "2020-05-05 14:24:45.649364", "failed_when_result": false, "item": 106, "rc": 0, "start": "2020-05-05 14:24:44.045520", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=108) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=108\"", "delta": "0:00:01.514908", "end": "2020-05-05 14:24:47.425759", "failed_when_result": false, "item": 108, "rc": 0, "start": "2020-05-05 14:24:45.910851", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000159 seconds, 24.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000159 seconds, 24.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=110) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=110\"", "delta": "0:00:01.403362", "end": "2020-05-05 14:24:49.080269", "failed_when_result": false, "item": 110, "rc": 0, "start": "2020-05-05 14:24:47.676907", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000112 seconds, 34.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000112 seconds, 34.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=112) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=112\"", "delta": "0:00:01.428866", "end": "2020-05-05 14:24:50.749284", "failed_when_result": false, "item": 112, "rc": 0, "start": "2020-05-05 14:24:49.320418", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=114) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=114\"", "delta": "0:00:01.572707", "end": "2020-05-05 14:24:52.569071", "failed_when_result": false, "item": 114, "rc": 0, "start": "2020-05-05 14:24:50.996364", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000169 seconds, 23.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000169 seconds, 23.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=116) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=116\"", "delta": "0:00:01.488312", "end": "2020-05-05 14:24:54.448406", "failed_when_result": false, "item": 116, "rc": 0, "start": "2020-05-05 14:24:52.960094", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=118) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=118\"", "delta": "0:00:01.489225", "end": "2020-05-05 14:24:56.177161", "failed_when_result": false, "item": 118, "rc": 0, "start": "2020-05-05 14:24:54.687936", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=120) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=120\"", "delta": "0:00:01.735295", "end": "2020-05-05 14:24:58.411959", "failed_when_result": false, "item": 120, "rc": 0, "start": "2020-05-05 14:24:56.676664", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000379 seconds, 10.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000379 seconds, 10.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=122) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=122\"", "delta": "0:00:01.581062", "end": "2020-05-05 14:25:00.290703", "failed_when_result": false, "item": 122, "rc": 0, "start": "2020-05-05 14:24:58.709641", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000179 seconds, 21.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000179 seconds, 21.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=124) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=124\"", "delta": "0:00:01.464511", "end": "2020-05-05 14:25:02.003942", "failed_when_result": false, "item": 124, "rc": 0, "start": "2020-05-05 14:25:00.539431", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000116 seconds, 33.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000116 seconds, 33.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=126) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=126\"", "delta": "0:00:01.642490", "end": "2020-05-05 14:25:03.944939", "failed_when_result": false, "item": 126, "rc": 0, "start": "2020-05-05 14:25:02.302449", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=128) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=128\"", "delta": "0:00:01.525270", "end": "2020-05-05 14:25:05.734454", "failed_when_result": false, "item": 128, "rc": 0, "start": "2020-05-05 14:25:04.209184", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000146 seconds, 26.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000146 seconds, 26.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=130) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=130\"", "delta": "0:00:01.457412", "end": "2020-05-05 14:25:07.606922", "failed_when_result": false, "item": 130, "rc": 0, "start": "2020-05-05 14:25:06.149510", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=132) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=132\"", "delta": "0:00:01.552010", "end": "2020-05-05 14:25:09.419409", "failed_when_result": false, "item": 132, "rc": 0, "start": "2020-05-05 14:25:07.867399", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.010687 seconds, 374.3KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.010687 seconds, 374.3KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=134) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=134\"", "delta": "0:00:01.400643", "end": "2020-05-05 14:25:11.077152", "failed_when_result": false, "item": 134, "rc": 0, "start": "2020-05-05 14:25:09.676509", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000116 seconds, 33.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000116 seconds, 33.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=136) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=136\"", "delta": "0:00:01.456075", "end": "2020-05-05 14:25:12.821770", "failed_when_result": false, "item": 136, "rc": 0, "start": "2020-05-05 14:25:11.365695", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000184 seconds, 21.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000184 seconds, 21.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=138) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=138\"", "delta": "0:00:01.548498", "end": "2020-05-05 14:25:14.697825", "failed_when_result": false, "item": 138, "rc": 0, "start": "2020-05-05 14:25:13.149327", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.024495 seconds, 163.3KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.024495 seconds, 163.3KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=140) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=140\"", "delta": "0:00:01.427700", "end": "2020-05-05 14:25:16.465381", "failed_when_result": false, "item": 140, "rc": 0, "start": "2020-05-05 14:25:15.037681", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000141 seconds, 27.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000141 seconds, 27.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=142) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=142\"", "delta": "0:00:01.502704", "end": "2020-05-05 14:25:18.233503", "failed_when_result": false, "item": 142, "rc": 0, "start": "2020-05-05 14:25:16.730799", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000153 seconds, 25.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000153 seconds, 25.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=144) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=144\"", "delta": "0:00:01.598174", "end": "2020-05-05 14:25:20.100303", "failed_when_result": false, "item": 144, "rc": 0, "start": "2020-05-05 14:25:18.502129", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003706 seconds, 1.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003706 seconds, 1.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=146) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=146\"", "delta": "0:00:01.439995", "end": "2020-05-05 14:25:21.799866", "failed_when_result": false, "item": 146, "rc": 0, "start": "2020-05-05 14:25:20.359871", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000144 seconds, 27.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000144 seconds, 27.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=148) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=148\"", "delta": "0:00:01.732804", "end": "2020-05-05 14:25:23.760484", "failed_when_result": false, "item": 148, "rc": 0, "start": "2020-05-05 14:25:22.027680", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=150) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=150\"", "delta": "0:00:01.588323", "end": "2020-05-05 14:25:25.591054", "failed_when_result": false, "item": 150, "rc": 0, "start": "2020-05-05 14:25:24.002731", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000128 seconds, 30.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000128 seconds, 30.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=152) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=152\"", "delta": "0:00:01.442744", "end": "2020-05-05 14:25:27.281636", "failed_when_result": false, "item": 152, "rc": 0, "start": "2020-05-05 14:25:25.838892", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000136 seconds, 28.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000136 seconds, 28.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=154) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=154\"", "delta": "0:00:01.476277", "end": "2020-05-05 14:25:28.985842", "failed_when_result": false, "item": 154, "rc": 0, "start": "2020-05-05 14:25:27.509565", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=156) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=156\"", "delta": "0:00:01.412052", "end": "2020-05-05 14:25:30.635163", "failed_when_result": false, "item": 156, "rc": 0, "start": "2020-05-05 14:25:29.223111", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.010777 seconds, 371.2KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.010777 seconds, 371.2KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=158) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=158\"", "delta": "0:00:01.332161", "end": "2020-05-05 14:25:32.202520", "failed_when_result": false, "item": 158, "rc": 0, "start": "2020-05-05 14:25:30.870359", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000116 seconds, 33.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000116 seconds, 33.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=160) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=160\"", "delta": "0:00:01.485293", "end": "2020-05-05 14:25:34.104464", "failed_when_result": false, "item": 160, "rc": 0, "start": "2020-05-05 14:25:32.619171", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000113 seconds, 34.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000113 seconds, 34.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=162) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=162\"", "delta": "0:00:01.455883", "end": "2020-05-05 14:25:35.794705", "failed_when_result": false, "item": 162, "rc": 0, "start": "2020-05-05 14:25:34.338822", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.008636 seconds, 463.2KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.008636 seconds, 463.2KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=164) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=164\"", "delta": "0:00:01.436191", "end": "2020-05-05 14:25:37.476241", "failed_when_result": false, "item": 164, "rc": 0, "start": "2020-05-05 14:25:36.040050", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000142 seconds, 27.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000142 seconds, 27.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=166) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=166\"", "delta": "0:00:01.392145", "end": "2020-05-05 14:25:39.134878", "failed_when_result": false, "item": 166, "rc": 0, "start": "2020-05-05 14:25:37.742733", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000113 seconds, 34.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000113 seconds, 34.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=168) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=168\"", "delta": "0:00:01.365298", "end": "2020-05-05 14:25:40.739817", "failed_when_result": false, "item": 168, "rc": 0, "start": "2020-05-05 14:25:39.374519", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=170) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=170\"", "delta": "0:00:01.432282", "end": "2020-05-05 14:25:42.417753", "failed_when_result": false, "item": 170, "rc": 0, "start": "2020-05-05 14:25:40.985471", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000141 seconds, 27.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000141 seconds, 27.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=172) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=172\"", "delta": "0:00:01.464328", "end": "2020-05-05 14:25:44.413513", "failed_when_result": false, "item": 172, "rc": 0, "start": "2020-05-05 14:25:42.949185", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=174) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=174\"", "delta": "0:00:01.430533", "end": "2020-05-05 14:25:46.109254", "failed_when_result": false, "item": 174, "rc": 0, "start": "2020-05-05 14:25:44.678721", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000188 seconds, 20.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000188 seconds, 20.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=176) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=176\"", "delta": "0:00:01.438868", "end": "2020-05-05 14:25:47.818163", "failed_when_result": false, "item": 176, "rc": 0, "start": "2020-05-05 14:25:46.379295", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.008305 seconds, 481.6KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.008305 seconds, 481.6KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=178) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=178\"", "delta": "0:00:01.398221", "end": "2020-05-05 14:25:49.484162", "failed_when_result": false, "item": 178, "rc": 0, "start": "2020-05-05 14:25:48.085941", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000126 seconds, 31.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=180) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=180\"", "delta": "0:00:01.520102", "end": "2020-05-05 14:25:51.322686", "failed_when_result": false, "item": 180, "rc": 0, "start": "2020-05-05 14:25:49.802584", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=182) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=182\"", "delta": "0:00:01.642767", "end": "2020-05-05 14:25:53.274237", "failed_when_result": false, "item": 182, "rc": 0, "start": "2020-05-05 14:25:51.631470", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003565 seconds, 1.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003565 seconds, 1.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=184) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=184\"", "delta": "0:00:01.448345", "end": "2020-05-05 14:25:55.009970", "failed_when_result": false, "item": 184, "rc": 0, "start": "2020-05-05 14:25:53.561625", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000133 seconds, 29.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000133 seconds, 29.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=186) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=186\"", "delta": "0:00:01.707535", "end": "2020-05-05 14:25:56.951668", "failed_when_result": false, "item": 186, "rc": 0, "start": "2020-05-05 14:25:55.244133", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000138 seconds, 28.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000138 seconds, 28.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=188) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=188\"", "delta": "0:00:01.519696", "end": "2020-05-05 14:25:58.748529", "failed_when_result": false, "item": 188, "rc": 0, "start": "2020-05-05 14:25:57.228833", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.005169 seconds, 773.8KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.005169 seconds, 773.8KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=190) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=190\"", "delta": "0:00:01.564434", "end": "2020-05-05 14:26:00.614369", "failed_when_result": false, "item": 190, "rc": 0, "start": "2020-05-05 14:25:59.049935", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000158 seconds, 24.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000158 seconds, 24.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=192) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=192\"", "delta": "0:00:01.365266", "end": "2020-05-05 14:26:02.221288", "failed_when_result": false, "item": 192, "rc": 0, "start": "2020-05-05 14:26:00.856022", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=194) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=194\"", "delta": "0:00:01.456814", "end": "2020-05-05 14:26:04.078279", "failed_when_result": false, "item": 194, "rc": 0, "start": "2020-05-05 14:26:02.621465", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.005996 seconds, 667.1KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.005996 seconds, 667.1KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=196) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=196\"", "delta": "0:00:01.656846", "end": "2020-05-05 14:26:05.993253", "failed_when_result": false, "item": 196, "rc": 0, "start": "2020-05-05 14:26:04.336407", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000172 seconds, 22.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000172 seconds, 22.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=198) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=198\"", "delta": "0:00:01.374740", "end": "2020-05-05 14:26:07.620734", "failed_when_result": false, "item": 198, "rc": 0, "start": "2020-05-05 14:26:06.245994", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s"], "stdout": "", "stdout_lines": []}

TASK [Restart all the replica pods of jiva volume] *****************************
task path: /experiments/chaos/jiva-preload/test.yml:74
2020-05-05T14:26:07.765176 (delta: 179.19086)         elapsed: 205.633417 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n \"openebs\" -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume=\"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f\" --force --grace-period=0", "delta": "0:00:01.454781", "end": "2020-05-05 14:26:09.511980", "failed_when_result": false, "rc": 0, "start": "2020-05-05 14:26:08.057199", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f-rep-1-6d4f8d9f49-5z2wx\" force deleted\npod \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f-rep-2-9fb8544d4-cvk9n\" force deleted\npod \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f-rep-3-6f97bc9598-8dndx\" force deleted", "stdout_lines": ["pod \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f-rep-1-6d4f8d9f49-5z2wx\" force deleted", "pod \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f-rep-2-9fb8544d4-cvk9n\" force deleted", "pod \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f-rep-3-6f97bc9598-8dndx\" force deleted"]}

TASK [Get the maya-apiserver pod name] *****************************************
task path: /experiments/chaos/jiva-preload/test.yml:82
2020-05-05T14:26:09.666612 (delta: 1.901358)         elapsed: 207.534853 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.675184", "end": "2020-05-05 14:26:11.746705", "rc": 0, "start": "2020-05-05 14:26:10.071521", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-7d458584b7-4wpvg", "stdout_lines": ["maya-apiserver-7d458584b7-4wpvg"]}

TASK [Get the volume list] *****************************************************
task path: /experiments/chaos/jiva-preload/test.yml:89
2020-05-05T14:26:11.859104 (delta: 2.19242)         elapsed: 209.727345 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-7d458584b7-4wpvg -n openebs -- mayactl volume list", "delta": "0:00:02.843945", "end": "2020-05-05 14:26:15.291430", "rc": 0, "start": "2020-05-05 14:26:12.447485", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Namespace  Name                                      Status   Type  Capacity  StorageClass            Access Mode\n---------  ----                                      ------   ----  --------  -------------           -----------\nopenebs    pvc-496e906c-1d10-4aa5-814d-3caa36b86744  Running  jiva  5G        jiva-snapshot-sc-9lk9n  ReadWriteOnce\nopenebs    pvc-68b0e596-f11b-41f0-ad19-5315f187efc9  Running  jiva  5Gi       jiva                    ReadWriteOnce\nopenebs    pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce\nopenebs    pvc-8aa24ccb-42a0-4717-bf16-ad0278cce2fe  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce", "stdout_lines": ["Namespace  Name                                      Status   Type  Capacity  StorageClass            Access Mode", "---------  ----                                      ------   ----  --------  -------------           -----------", "openebs    pvc-496e906c-1d10-4aa5-814d-3caa36b86744  Running  jiva  5G        jiva-snapshot-sc-9lk9n  ReadWriteOnce", "openebs    pvc-68b0e596-f11b-41f0-ad19-5315f187efc9  Running  jiva  5Gi       jiva                    ReadWriteOnce", "openebs    pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce", "openebs    pvc-8aa24ccb-42a0-4717-bf16-ad0278cce2fe  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce"]}

TASK [Get the replicas access mode] ********************************************
task path: /experiments/chaos/jiva-preload/test.yml:99
2020-05-05T14:26:15.397309 (delta: 3.538121)         elapsed: 213.26555 ******* 
FAILED - RETRYING: Get the replicas access mode (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl exec -it maya-apiserver-7d458584b7-4wpvg -n openebs -- mayactl volume describe --volname \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f\" -n preload | grep 'RW' | wc -l", "delta": "0:00:02.041906", "end": "2020-05-05 14:26:51.987323", "rc": 0, "start": "2020-05-05 14:26:49.945417", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "2", "stdout_lines": ["2"]}

TASK [Dumping the data to odd offsets using dd] ********************************
task path: /experiments/chaos/jiva-preload/test.yml:111
2020-05-05T14:26:52.148557 (delta: 36.751179)         elapsed: 250.016798 ***** 
changed: [127.0.0.1] => (item=1) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=1\"", "delta": "0:00:01.683549", "end": "2020-05-05 14:26:54.375575", "failed_when_result": false, "item": 1, "rc": 0, "start": "2020-05-05 14:26:52.692026", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000866 seconds, 4.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000866 seconds, 4.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=3) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=3\"", "delta": "0:00:01.563429", "end": "2020-05-05 14:26:56.211659", "failed_when_result": false, "item": 3, "rc": 0, "start": "2020-05-05 14:26:54.648230", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=5) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=5\"", "delta": "0:00:01.551584", "end": "2020-05-05 14:26:58.142478", "failed_when_result": false, "item": 5, "rc": 0, "start": "2020-05-05 14:26:56.590894", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000160 seconds, 24.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000160 seconds, 24.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=7) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=7\"", "delta": "0:00:01.716760", "end": "2020-05-05 14:27:00.131725", "failed_when_result": false, "item": 7, "rc": 0, "start": "2020-05-05 14:26:58.414965", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000147 seconds, 26.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000147 seconds, 26.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=9) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=9\"", "delta": "0:00:01.398810", "end": "2020-05-05 14:27:01.749352", "failed_when_result": false, "item": 9, "rc": 0, "start": "2020-05-05 14:27:00.350542", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=11) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=11\"", "delta": "0:00:01.659105", "end": "2020-05-05 14:27:03.696361", "failed_when_result": false, "item": 11, "rc": 0, "start": "2020-05-05 14:27:02.037256", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=13) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=13\"", "delta": "0:00:01.622624", "end": "2020-05-05 14:27:05.557866", "failed_when_result": false, "item": 13, "rc": 0, "start": "2020-05-05 14:27:03.935242", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000138 seconds, 28.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000138 seconds, 28.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=15) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=15\"", "delta": "0:00:01.432757", "end": "2020-05-05 14:27:07.411589", "failed_when_result": false, "item": 15, "rc": 0, "start": "2020-05-05 14:27:05.978832", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=17) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=17\"", "delta": "0:00:01.555095", "end": "2020-05-05 14:27:09.226046", "failed_when_result": false, "item": 17, "rc": 0, "start": "2020-05-05 14:27:07.670951", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=19) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=19\"", "delta": "0:00:01.417474", "end": "2020-05-05 14:27:10.894680", "failed_when_result": false, "item": 19, "rc": 0, "start": "2020-05-05 14:27:09.477206", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000151 seconds, 25.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000151 seconds, 25.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=21) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=21\"", "delta": "0:00:01.474733", "end": "2020-05-05 14:27:12.610746", "failed_when_result": false, "item": 21, "rc": 0, "start": "2020-05-05 14:27:11.136013", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000151 seconds, 25.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000151 seconds, 25.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=23) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=23\"", "delta": "0:00:01.547501", "end": "2020-05-05 14:27:14.449029", "failed_when_result": false, "item": 23, "rc": 0, "start": "2020-05-05 14:27:12.901528", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000165 seconds, 23.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000165 seconds, 23.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=25) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=25\"", "delta": "0:00:01.451131", "end": "2020-05-05 14:27:16.209126", "failed_when_result": false, "item": 25, "rc": 0, "start": "2020-05-05 14:27:14.757995", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003232 seconds, 1.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003232 seconds, 1.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=27) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=27\"", "delta": "0:00:01.477664", "end": "2020-05-05 14:27:17.963156", "failed_when_result": false, "item": 27, "rc": 0, "start": "2020-05-05 14:27:16.485492", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000140 seconds, 27.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000140 seconds, 27.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=29) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=29\"", "delta": "0:00:01.581066", "end": "2020-05-05 14:27:19.791449", "failed_when_result": false, "item": 29, "rc": 0, "start": "2020-05-05 14:27:18.210383", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000148 seconds, 26.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000148 seconds, 26.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=31) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=31\"", "delta": "0:00:01.393447", "end": "2020-05-05 14:27:21.482253", "failed_when_result": false, "item": 31, "rc": 0, "start": "2020-05-05 14:27:20.088806", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.009273 seconds, 431.4KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.009273 seconds, 431.4KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=33) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=33\"", "delta": "0:00:01.611611", "end": "2020-05-05 14:27:23.354574", "failed_when_result": false, "item": 33, "rc": 0, "start": "2020-05-05 14:27:21.742963", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000141 seconds, 27.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000141 seconds, 27.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=35) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=35\"", "delta": "0:00:01.634225", "end": "2020-05-05 14:27:25.227685", "failed_when_result": false, "item": 35, "rc": 0, "start": "2020-05-05 14:27:23.593460", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000150 seconds, 26.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000150 seconds, 26.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=37) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=37\"", "delta": "0:00:01.417965", "end": "2020-05-05 14:27:26.938446", "failed_when_result": false, "item": 37, "rc": 0, "start": "2020-05-05 14:27:25.520481", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000171 seconds, 22.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000171 seconds, 22.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=39) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=39\"", "delta": "0:00:01.615433", "end": "2020-05-05 14:27:28.781579", "failed_when_result": false, "item": 39, "rc": 0, "start": "2020-05-05 14:27:27.166146", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000153 seconds, 25.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000153 seconds, 25.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=41) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=41\"", "delta": "0:00:01.383626", "end": "2020-05-05 14:27:30.426232", "failed_when_result": false, "item": 41, "rc": 0, "start": "2020-05-05 14:27:29.042606", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=43) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=43\"", "delta": "0:00:01.487748", "end": "2020-05-05 14:27:32.147232", "failed_when_result": false, "item": 43, "rc": 0, "start": "2020-05-05 14:27:30.659484", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.012369 seconds, 323.4KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.012369 seconds, 323.4KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=45) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=45\"", "delta": "0:00:01.483196", "end": "2020-05-05 14:27:34.016465", "failed_when_result": false, "item": 45, "rc": 0, "start": "2020-05-05 14:27:32.533269", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=47) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=47\"", "delta": "0:00:01.507861", "end": "2020-05-05 14:27:35.768286", "failed_when_result": false, "item": 47, "rc": 0, "start": "2020-05-05 14:27:34.260425", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000135 seconds, 28.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000135 seconds, 28.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=49) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=49\"", "delta": "0:00:01.454222", "end": "2020-05-05 14:27:37.445288", "failed_when_result": false, "item": 49, "rc": 0, "start": "2020-05-05 14:27:35.991066", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000143 seconds, 27.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000143 seconds, 27.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=51) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=51\"", "delta": "0:00:01.435568", "end": "2020-05-05 14:27:39.173775", "failed_when_result": false, "item": 51, "rc": 0, "start": "2020-05-05 14:27:37.738207", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000139 seconds, 28.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000139 seconds, 28.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=53) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=53\"", "delta": "0:00:01.421199", "end": "2020-05-05 14:27:40.850747", "failed_when_result": false, "item": 53, "rc": 0, "start": "2020-05-05 14:27:39.429548", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000123 seconds, 31.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000123 seconds, 31.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=55) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=55\"", "delta": "0:00:01.417183", "end": "2020-05-05 14:27:42.515242", "failed_when_result": false, "item": 55, "rc": 0, "start": "2020-05-05 14:27:41.098059", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000142 seconds, 27.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000142 seconds, 27.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=57) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=57\"", "delta": "0:00:01.545932", "end": "2020-05-05 14:27:44.447236", "failed_when_result": false, "item": 57, "rc": 0, "start": "2020-05-05 14:27:42.901304", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.006971 seconds, 573.8KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.006971 seconds, 573.8KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=59) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=59\"", "delta": "0:00:01.390935", "end": "2020-05-05 14:27:46.074483", "failed_when_result": false, "item": 59, "rc": 0, "start": "2020-05-05 14:27:44.683548", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=61) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=61\"", "delta": "0:00:01.383425", "end": "2020-05-05 14:27:47.688227", "failed_when_result": false, "item": 61, "rc": 0, "start": "2020-05-05 14:27:46.304802", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.004077 seconds, 981.1KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.004077 seconds, 981.1KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=63) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=63\"", "delta": "0:00:01.471821", "end": "2020-05-05 14:27:49.391831", "failed_when_result": false, "item": 63, "rc": 0, "start": "2020-05-05 14:27:47.920010", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=65) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=65\"", "delta": "0:00:01.400039", "end": "2020-05-05 14:27:51.089845", "failed_when_result": false, "item": 65, "rc": 0, "start": "2020-05-05 14:27:49.689806", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000130 seconds, 30.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000130 seconds, 30.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=67) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=67\"", "delta": "0:00:01.532139", "end": "2020-05-05 14:27:52.995593", "failed_when_result": false, "item": 67, "rc": 0, "start": "2020-05-05 14:27:51.463454", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=69) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=69\"", "delta": "0:00:01.342198", "end": "2020-05-05 14:27:54.630459", "failed_when_result": false, "item": 69, "rc": 0, "start": "2020-05-05 14:27:53.288261", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000192 seconds, 20.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000192 seconds, 20.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=71) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=71\"", "delta": "0:00:01.761797", "end": "2020-05-05 14:27:56.834536", "failed_when_result": false, "item": 71, "rc": 0, "start": "2020-05-05 14:27:55.072739", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.007081 seconds, 564.9KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.007081 seconds, 564.9KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=73) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=73\"", "delta": "0:00:01.525139", "end": "2020-05-05 14:27:58.600221", "failed_when_result": false, "item": 73, "rc": 0, "start": "2020-05-05 14:27:57.075082", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=75) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=75\"", "delta": "0:00:01.528483", "end": "2020-05-05 14:28:00.414848", "failed_when_result": false, "item": 75, "rc": 0, "start": "2020-05-05 14:27:58.886365", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=77) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=77\"", "delta": "0:00:01.471782", "end": "2020-05-05 14:28:02.141392", "failed_when_result": false, "item": 77, "rc": 0, "start": "2020-05-05 14:28:00.669610", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.006185 seconds, 646.7KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.006185 seconds, 646.7KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=79) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=79\"", "delta": "0:00:01.678309", "end": "2020-05-05 14:28:04.219564", "failed_when_result": false, "item": 79, "rc": 0, "start": "2020-05-05 14:28:02.541255", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000125 seconds, 31.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=81) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=81\"", "delta": "0:00:01.750524", "end": "2020-05-05 14:28:06.244042", "failed_when_result": false, "item": 81, "rc": 0, "start": "2020-05-05 14:28:04.493518", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=83) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=83\"", "delta": "0:00:01.550311", "end": "2020-05-05 14:28:08.082553", "failed_when_result": false, "item": 83, "rc": 0, "start": "2020-05-05 14:28:06.532242", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000266 seconds, 14.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000266 seconds, 14.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=85) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=85\"", "delta": "0:00:01.586816", "end": "2020-05-05 14:28:09.991126", "failed_when_result": false, "item": 85, "rc": 0, "start": "2020-05-05 14:28:08.404310", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=87) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=87\"", "delta": "0:00:01.434436", "end": "2020-05-05 14:28:11.685085", "failed_when_result": false, "item": 87, "rc": 0, "start": "2020-05-05 14:28:10.250649", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=89) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=89\"", "delta": "0:00:01.771776", "end": "2020-05-05 14:28:13.691708", "failed_when_result": false, "item": 89, "rc": 0, "start": "2020-05-05 14:28:11.919932", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.016969 seconds, 235.7KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.016969 seconds, 235.7KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=91) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=91\"", "delta": "0:00:01.476234", "end": "2020-05-05 14:28:15.408440", "failed_when_result": false, "item": 91, "rc": 0, "start": "2020-05-05 14:28:13.932206", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000111 seconds, 35.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000111 seconds, 35.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=93) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=93\"", "delta": "0:00:01.424878", "end": "2020-05-05 14:28:17.071959", "failed_when_result": false, "item": 93, "rc": 0, "start": "2020-05-05 14:28:15.647081", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=95) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=95\"", "delta": "0:00:01.376525", "end": "2020-05-05 14:28:18.675104", "failed_when_result": false, "item": 95, "rc": 0, "start": "2020-05-05 14:28:17.298579", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000156 seconds, 25.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000156 seconds, 25.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=97) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=97\"", "delta": "0:00:01.460061", "end": "2020-05-05 14:28:20.406356", "failed_when_result": false, "item": 97, "rc": 0, "start": "2020-05-05 14:28:18.946295", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000149 seconds, 26.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=99) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=99\"", "delta": "0:00:01.293155", "end": "2020-05-05 14:28:21.949391", "failed_when_result": false, "item": 99, "rc": 0, "start": "2020-05-05 14:28:20.656236", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000107 seconds, 36.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000107 seconds, 36.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=101) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=101\"", "delta": "0:00:01.772519", "end": "2020-05-05 14:28:23.942742", "failed_when_result": false, "item": 101, "rc": 0, "start": "2020-05-05 14:28:22.170223", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003257 seconds, 1.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003257 seconds, 1.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=103) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=103\"", "delta": "0:00:01.533025", "end": "2020-05-05 14:28:25.707070", "failed_when_result": false, "item": 103, "rc": 0, "start": "2020-05-05 14:28:24.174045", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=105) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=105\"", "delta": "0:00:01.393075", "end": "2020-05-05 14:28:27.368060", "failed_when_result": false, "item": 105, "rc": 0, "start": "2020-05-05 14:28:25.974985", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000144 seconds, 27.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000144 seconds, 27.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=107) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=107\"", "delta": "0:00:01.601502", "end": "2020-05-05 14:28:29.197915", "failed_when_result": false, "item": 107, "rc": 0, "start": "2020-05-05 14:28:27.596413", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003770 seconds, 1.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003770 seconds, 1.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=109) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=109\"", "delta": "0:00:01.362675", "end": "2020-05-05 14:28:30.811191", "failed_when_result": false, "item": 109, "rc": 0, "start": "2020-05-05 14:28:29.448516", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000142 seconds, 27.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000142 seconds, 27.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=111) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=111\"", "delta": "0:00:01.397434", "end": "2020-05-05 14:28:32.450753", "failed_when_result": false, "item": 111, "rc": 0, "start": "2020-05-05 14:28:31.053319", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=113) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=113\"", "delta": "0:00:01.469088", "end": "2020-05-05 14:28:34.270301", "failed_when_result": false, "item": 113, "rc": 0, "start": "2020-05-05 14:28:32.801213", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.007498 seconds, 533.5KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.007498 seconds, 533.5KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=115) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=115\"", "delta": "0:00:01.502525", "end": "2020-05-05 14:28:36.042651", "failed_when_result": false, "item": 115, "rc": 0, "start": "2020-05-05 14:28:34.540126", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=117) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=117\"", "delta": "0:00:01.495929", "end": "2020-05-05 14:28:37.774060", "failed_when_result": false, "item": 117, "rc": 0, "start": "2020-05-05 14:28:36.278131", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000115 seconds, 34.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=119) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=119\"", "delta": "0:00:01.535422", "end": "2020-05-05 14:28:39.622803", "failed_when_result": false, "item": 119, "rc": 0, "start": "2020-05-05 14:28:38.087381", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.004198 seconds, 952.8KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.004198 seconds, 952.8KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=121) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=121\"", "delta": "0:00:01.412918", "end": "2020-05-05 14:28:41.310785", "failed_when_result": false, "item": 121, "rc": 0, "start": "2020-05-05 14:28:39.897867", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000111 seconds, 35.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000111 seconds, 35.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=123) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=123\"", "delta": "0:00:01.571099", "end": "2020-05-05 14:28:43.118775", "failed_when_result": false, "item": 123, "rc": 0, "start": "2020-05-05 14:28:41.547676", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000172 seconds, 22.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000172 seconds, 22.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=125) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=125\"", "delta": "0:00:01.423649", "end": "2020-05-05 14:28:44.864610", "failed_when_result": false, "item": 125, "rc": 0, "start": "2020-05-05 14:28:43.440961", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000129 seconds, 30.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000129 seconds, 30.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=127) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=127\"", "delta": "0:00:01.307879", "end": "2020-05-05 14:28:46.426289", "failed_when_result": false, "item": 127, "rc": 0, "start": "2020-05-05 14:28:45.118410", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.002234 seconds, 1.7MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.002234 seconds, 1.7MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=129) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=129\"", "delta": "0:00:01.363166", "end": "2020-05-05 14:28:48.077768", "failed_when_result": false, "item": 129, "rc": 0, "start": "2020-05-05 14:28:46.714602", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000140 seconds, 27.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000140 seconds, 27.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=131) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=131\"", "delta": "0:00:01.601057", "end": "2020-05-05 14:28:49.977535", "failed_when_result": false, "item": 131, "rc": 0, "start": "2020-05-05 14:28:48.376478", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=133) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=133\"", "delta": "0:00:01.667219", "end": "2020-05-05 14:28:51.907263", "failed_when_result": false, "item": 133, "rc": 0, "start": "2020-05-05 14:28:50.240044", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=135) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=135\"", "delta": "0:00:01.653188", "end": "2020-05-05 14:28:53.800134", "failed_when_result": false, "item": 135, "rc": 0, "start": "2020-05-05 14:28:52.146946", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000121 seconds, 32.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000121 seconds, 32.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=137) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=137\"", "delta": "0:00:01.471755", "end": "2020-05-05 14:28:55.512788", "failed_when_result": false, "item": 137, "rc": 0, "start": "2020-05-05 14:28:54.041033", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000118 seconds, 33.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=139) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=139\"", "delta": "0:00:01.666709", "end": "2020-05-05 14:28:57.434224", "failed_when_result": false, "item": 139, "rc": 0, "start": "2020-05-05 14:28:55.767515", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.008777 seconds, 455.7KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.008777 seconds, 455.7KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=141) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=141\"", "delta": "0:00:01.529596", "end": "2020-05-05 14:28:59.255293", "failed_when_result": false, "item": 141, "rc": 0, "start": "2020-05-05 14:28:57.725697", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000210 seconds, 18.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000210 seconds, 18.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=143) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=143\"", "delta": "0:00:01.531188", "end": "2020-05-05 14:29:01.200586", "failed_when_result": false, "item": 143, "rc": 0, "start": "2020-05-05 14:28:59.669398", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000121 seconds, 32.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000121 seconds, 32.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=145) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=145\"", "delta": "0:00:01.522117", "end": "2020-05-05 14:29:02.980308", "failed_when_result": false, "item": 145, "rc": 0, "start": "2020-05-05 14:29:01.458191", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000178 seconds, 21.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000178 seconds, 21.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=147) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=147\"", "delta": "0:00:01.384768", "end": "2020-05-05 14:29:04.757889", "failed_when_result": false, "item": 147, "rc": 0, "start": "2020-05-05 14:29:03.373121", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000173 seconds, 22.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000173 seconds, 22.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=149) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=149\"", "delta": "0:00:01.687694", "end": "2020-05-05 14:29:06.957248", "failed_when_result": false, "item": 149, "rc": 0, "start": "2020-05-05 14:29:05.269554", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000120 seconds, 32.6MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=151) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=151\"", "delta": "0:00:01.444387", "end": "2020-05-05 14:29:08.681926", "failed_when_result": false, "item": 151, "rc": 0, "start": "2020-05-05 14:29:07.237539", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003308 seconds, 1.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003308 seconds, 1.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=153) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=153\"", "delta": "0:00:01.428545", "end": "2020-05-05 14:29:10.357510", "failed_when_result": false, "item": 153, "rc": 0, "start": "2020-05-05 14:29:08.928965", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000117 seconds, 33.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=155) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=155\"", "delta": "0:00:01.330512", "end": "2020-05-05 14:29:11.973881", "failed_when_result": false, "item": 155, "rc": 0, "start": "2020-05-05 14:29:10.643369", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000131 seconds, 29.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000131 seconds, 29.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=157) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=157\"", "delta": "0:00:01.723424", "end": "2020-05-05 14:29:13.968645", "failed_when_result": false, "item": 157, "rc": 0, "start": "2020-05-05 14:29:12.245221", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.016913 seconds, 236.5KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.016913 seconds, 236.5KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=159) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=159\"", "delta": "0:00:01.510209", "end": "2020-05-05 14:29:15.757655", "failed_when_result": false, "item": 159, "rc": 0, "start": "2020-05-05 14:29:14.247446", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=161) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=161\"", "delta": "0:00:01.538656", "end": "2020-05-05 14:29:17.522821", "failed_when_result": false, "item": 161, "rc": 0, "start": "2020-05-05 14:29:15.984165", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000150 seconds, 26.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000150 seconds, 26.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=163) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=163\"", "delta": "0:00:01.510698", "end": "2020-05-05 14:29:19.274339", "failed_when_result": false, "item": 163, "rc": 0, "start": "2020-05-05 14:29:17.763641", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.005834 seconds, 685.6KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.005834 seconds, 685.6KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=165) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=165\"", "delta": "0:00:01.454232", "end": "2020-05-05 14:29:21.013986", "failed_when_result": false, "item": 165, "rc": 0, "start": "2020-05-05 14:29:19.559754", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000153 seconds, 25.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000153 seconds, 25.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=167) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=167\"", "delta": "0:00:01.381232", "end": "2020-05-05 14:29:22.632988", "failed_when_result": false, "item": 167, "rc": 0, "start": "2020-05-05 14:29:21.251756", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000207 seconds, 18.9MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000207 seconds, 18.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=169) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=169\"", "delta": "0:00:01.495757", "end": "2020-05-05 14:29:24.415552", "failed_when_result": false, "item": 169, "rc": 0, "start": "2020-05-05 14:29:22.919795", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003902 seconds, 1.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003902 seconds, 1.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=171) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=171\"", "delta": "0:00:01.466055", "end": "2020-05-05 14:29:26.135816", "failed_when_result": false, "item": 171, "rc": 0, "start": "2020-05-05 14:29:24.669761", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000154 seconds, 25.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000154 seconds, 25.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=173) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=173\"", "delta": "0:00:01.352994", "end": "2020-05-05 14:29:27.724564", "failed_when_result": false, "item": 173, "rc": 0, "start": "2020-05-05 14:29:26.371570", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000114 seconds, 34.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=175) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=175\"", "delta": "0:00:01.367281", "end": "2020-05-05 14:29:29.340033", "failed_when_result": false, "item": 175, "rc": 0, "start": "2020-05-05 14:29:27.972752", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000133 seconds, 29.4MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000133 seconds, 29.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=177) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=177\"", "delta": "0:00:01.393802", "end": "2020-05-05 14:29:30.972991", "failed_when_result": false, "item": 177, "rc": 0, "start": "2020-05-05 14:29:29.579189", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000119 seconds, 32.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=179) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=179\"", "delta": "0:00:01.495893", "end": "2020-05-05 14:29:32.743073", "failed_when_result": false, "item": 179, "rc": 0, "start": "2020-05-05 14:29:31.247180", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000124 seconds, 31.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=181) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=181\"", "delta": "0:00:01.413880", "end": "2020-05-05 14:29:34.529241", "failed_when_result": false, "item": 181, "rc": 0, "start": "2020-05-05 14:29:33.115361", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000168 seconds, 23.3MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000168 seconds, 23.3MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=183) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=183\"", "delta": "0:00:01.503603", "end": "2020-05-05 14:29:36.442610", "failed_when_result": false, "item": 183, "rc": 0, "start": "2020-05-05 14:29:34.939007", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.003660 seconds, 1.1MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.003660 seconds, 1.1MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=185) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=185\"", "delta": "0:00:01.551400", "end": "2020-05-05 14:29:38.261630", "failed_when_result": false, "item": 185, "rc": 0, "start": "2020-05-05 14:29:36.710230", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000191 seconds, 20.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000191 seconds, 20.5MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=187) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=187\"", "delta": "0:00:01.655001", "end": "2020-05-05 14:29:40.172893", "failed_when_result": false, "item": 187, "rc": 0, "start": "2020-05-05 14:29:38.517892", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000111 seconds, 35.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000111 seconds, 35.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=189) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=189\"", "delta": "0:00:01.345428", "end": "2020-05-05 14:29:41.819187", "failed_when_result": false, "item": 189, "rc": 0, "start": "2020-05-05 14:29:40.473759", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.007119 seconds, 561.9KB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.007119 seconds, 561.9KB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=191) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=191\"", "delta": "0:00:01.625705", "end": "2020-05-05 14:29:43.677710", "failed_when_result": false, "item": 191, "rc": 0, "start": "2020-05-05 14:29:42.052005", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000150 seconds, 26.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000150 seconds, 26.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=193) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=193\"", "delta": "0:00:01.533981", "end": "2020-05-05 14:29:45.497178", "failed_when_result": false, "item": 193, "rc": 0, "start": "2020-05-05 14:29:43.963197", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000134 seconds, 29.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000134 seconds, 29.2MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=195) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=195\"", "delta": "0:00:01.295739", "end": "2020-05-05 14:29:47.019379", "failed_when_result": false, "item": 195, "rc": 0, "start": "2020-05-05 14:29:45.723640", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000127 seconds, 30.8MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=197) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=197\"", "delta": "0:00:01.403017", "end": "2020-05-05 14:29:48.657514", "failed_when_result": false, "item": 197, "rc": 0, "start": "2020-05-05 14:29:47.254497", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000122 seconds, 32.0MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=199) => {"changed": true, "cmd": "kubectl exec -ti \"app-busybox-85d45b855f-k9f9t\" -n \"preload\" -- sh -c \"dd if=/dev/urandom of=/busybox/abc.txt bs=4k count=1 seek=199\"", "delta": "0:00:01.354818", "end": "2020-05-05 14:29:50.260089", "failed_when_result": false, "item": 199, "rc": 0, "start": "2020-05-05 14:29:48.905271", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n1+0 records in\n1+0 records out\n4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "1+0 records in", "1+0 records out", "4096 bytes (4.0KB) copied, 0.000155 seconds, 25.2MB/s"], "stdout": "", "stdout_lines": []}

TASK [Check the replicas access mode] ******************************************
task path: /experiments/chaos/jiva-preload/test.yml:121
2020-05-05T14:29:50.414996 (delta: 178.266327)         elapsed: 428.283237 **** 
included: /funclib/openebs/access-mode-check.yml for 127.0.0.1

TASK [Get the pv name] *********************************************************
task path: /funclib/openebs/access-mode-check.yml:2
2020-05-05T14:29:50.572266 (delta: 0.157198)         elapsed: 428.440507 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n preload -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.252875", "end": "2020-05-05 14:29:52.078087", "rc": 0, "start": "2020-05-05 14:29:50.825212", "stderr": "", "stderr_lines": [], "stdout": "pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f", "stdout_lines": ["pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f"]}

TASK [Get the nodes count] *****************************************************
task path: /funclib/openebs/access-mode-check.yml:9
2020-05-05T14:29:52.166585 (delta: 1.594224)         elapsed: 430.034826 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | wc -l", "delta": "0:00:01.334932", "end": "2020-05-05 14:29:53.842101", "rc": 0, "start": "2020-05-05 14:29:52.507169", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the maya-apiserver pod name] *****************************************
task path: /funclib/openebs/access-mode-check.yml:15
2020-05-05T14:29:53.923643 (delta: 1.756962)         elapsed: 431.791884 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.208413", "end": "2020-05-05 14:29:55.414542", "rc": 0, "start": "2020-05-05 14:29:54.206129", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-7d458584b7-4wpvg", "stdout_lines": ["maya-apiserver-7d458584b7-4wpvg"]}

TASK [Get the volume list] *****************************************************
task path: /funclib/openebs/access-mode-check.yml:22
2020-05-05T14:29:55.529690 (delta: 1.605956)         elapsed: 433.397931 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-7d458584b7-4wpvg -n openebs -- mayactl volume list", "delta": "0:00:02.116786", "end": "2020-05-05 14:29:57.926396", "rc": 0, "start": "2020-05-05 14:29:55.809610", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Namespace  Name                                      Status   Type  Capacity  StorageClass            Access Mode\n---------  ----                                      ------   ----  --------  -------------           -----------\nopenebs    pvc-496e906c-1d10-4aa5-814d-3caa36b86744  Running  jiva  5G        jiva-snapshot-sc-9lk9n  ReadWriteOnce\nopenebs    pvc-68b0e596-f11b-41f0-ad19-5315f187efc9  Running  jiva  5Gi       jiva                    ReadWriteOnce\nopenebs    pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce\nopenebs    pvc-8aa24ccb-42a0-4717-bf16-ad0278cce2fe  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce", "stdout_lines": ["Namespace  Name                                      Status   Type  Capacity  StorageClass            Access Mode", "---------  ----                                      ------   ----  --------  -------------           -----------", "openebs    pvc-496e906c-1d10-4aa5-814d-3caa36b86744  Running  jiva  5G        jiva-snapshot-sc-9lk9n  ReadWriteOnce", "openebs    pvc-68b0e596-f11b-41f0-ad19-5315f187efc9  Running  jiva  5Gi       jiva                    ReadWriteOnce", "openebs    pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce", "openebs    pvc-8aa24ccb-42a0-4717-bf16-ad0278cce2fe  Running  jiva  5Gi       openebs-jiva-default    ReadWriteOnce"]}

TASK [Get the replicas access mode] ********************************************
task path: /funclib/openebs/access-mode-check.yml:32
2020-05-05T14:29:58.060490 (delta: 2.53073)         elapsed: 435.928731 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-7d458584b7-4wpvg -n openebs -- mayactl volume describe --volname \"pvc-7ebc3377-7e17-4d63-af3d-abbda9fb312f\" -n preload | grep 'RW' | wc -l", "delta": "0:00:02.012964", "end": "2020-05-05 14:30:00.398252", "rc": 0, "start": "2020-05-05 14:29:58.385288", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [debug] *******************************************************************
task path: /funclib/openebs/access-mode-check.yml:43
2020-05-05T14:30:00.575377 (delta: 2.514771)         elapsed: 438.443618 ****** 
ok: [127.0.0.1] => {
    "msg": "All the replicas are in sync"
}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/jiva-preload/test.yml:127
2020-05-05T14:30:00.711840 (delta: 0.13638)         elapsed: 438.580081 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva-preload/test.yml:137
2020-05-05T14:30:00.848792 (delta: 0.136873)         elapsed: 438.717033 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-05T14:30:01.026686 (delta: 0.177826)         elapsed: 438.894927 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-05T14:30:01.131601 (delta: 0.10482)         elapsed: 438.999842 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-05T14:30:01.220102 (delta: 0.087349)         elapsed: 439.088343 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-05T14:30:01.306054 (delta: 0.085866)         elapsed: 439.174295 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2a06a920ac80b640dd6079d54db3234ba458beeb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "19190427ef3a38c93aabca0ca81dbd4c", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1588689001.41-160357569546253/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-05T14:30:04.311396 (delta: 3.00522)         elapsed: 442.179637 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.173582", "end": "2020-05-05 14:30:05.765174", "rc": 0, "start": "2020-05-05 14:30:04.591592", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jiva-preloading \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jiva-preloading ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-05T14:30:05.905677 (delta: 1.594162)         elapsed: 443.773918 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-05T13:04:43Z", "generation": 8, "name": "jiva-preloading", "resourceVersion": "4362562", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/jiva-preloading", "uid": "a5c26b1b-7757-4333-aac6-69416aaa0c2e"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=31   changed=22   unreachable=0    failed=0   

2020-05-05T14:30:07.292884 (delta: 1.386689)         elapsed: 445.161125 ****** 
=============================================================================== 
```