### PR TITLE
refactor[cstor-operator]: Modified and updated the cstor operator and cspc provision test cases

### DIFF
--- a/providers/cstor/cstor-cspc-pool/blockdevice.j2
+++ b/providers/cstor/cstor-cspc-pool/blockdevice.j2
@@ -1,13 +1,6 @@
     - nodeSelector:
         kubernetes.io/hostname: {{ item[0] }}
+      dataRaidGroups:
+      - blockDevices:
       poolConfig:
-        cacheFile: ""
-        defaultRaidGroupType: pool-type
-        overProvisioning: false
-        compression: "off"
-      raidGroups:
-      - type: pool-type
-        isWriteCache: false
-        isSpare: false
-        isReadCache: false
-        blockDevices:
+        dataRaidGroupType: pool-type

--- a/providers/cstor/cstor-cspc-pool/cspc.yml
+++ b/providers/cstor/cstor-cspc-pool/cspc.yml
@@ -1,4 +1,4 @@
-apiVersion: openebs.io/v1alpha1
+apiVersion: cstor.openebs.io/v1
 kind: CStorPoolCluster
 metadata:
   name: pool-name
@@ -6,17 +6,3 @@ metadata:
 spec:
   pools:
 
----
-
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: sc-name
-  annotations:
-    openebs.io/cas-type: cstor  
-provisioner: cstor.csi.openebs.io
-allowVolumeExpansion: true
-parameters:
-  cas-type: cstor
-  cstorPoolCluster: pool-name
-  replicaCount: "replica-count"

--- a/providers/cstor/cstor-cspc-pool/run_litmus_test.yml
+++ b/providers/cstor/cstor-cspc-pool/run_litmus_test.yml
@@ -31,10 +31,6 @@ spec:
            # stripe, mirror, raidz, raidz2
           - name: POOL_TYPE
             value: stripe
-            
-           # Provide the name of STORAGE_CLASS 
-          - name: STORAGE_CLASS
-            value: openebs-cstor-cspc-disk
 
            # Namespace where the OpenEBS components are deployed
           - name: OPERATOR_NS

--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -75,18 +75,6 @@
                 regexp: "pool-name"
                 replace: "{{ pool_name }}"
 
-            - name: Update replica count matching pool count in storage class spec
-              replace:
-                path: ./cspc.yml
-                regexp: "replica-count"
-                replace: "{{ pool_count }}"
-
-            - name: Replacing the storage class name in CSPC spec
-              replace:
-                path: ./cspc.yml
-                regexp: "sc-name"
-                replace: "{{ sc_name }}"
-
             - name: Replacing the namespace in CSPC spec
               replace:
                 path: ./cspc.yml
@@ -171,13 +159,6 @@
               until: "runningStatusCount.stdout == device_count"
               delay: 30
               retries: 10
-
-            - name: Check if the storage class is created
-              shell: kubectl get sc
-              args:
-                executable: /bin/bash
-              register: sc_list
-              failed_when: "sc_name not in sc_list.stdout"
 
           when: deploy_mode == "create"
 

--- a/providers/cstor/cstor-cspc-pool/test_vars.yml
+++ b/providers/cstor/cstor-cspc-pool/test_vars.yml
@@ -3,7 +3,6 @@ operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 test_name: cstor-pool-provision
 pool_name: "{{ lookup('env','POOL_NAME') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
-sc_name: "{{ lookup('env', 'STORAGE_CLASS') }}"
 node_label: "{{ lookup('env','NODE_LABEL') }}"
 deploy_mode: "{{ lookup('env','DEPLOY_MODE') }}"
 pool_count: "{{ lookup('env','POOL_COUNT') }}"

--- a/providers/openebs/installers/operator/master/litmusbook/test.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/test.yaml
@@ -63,34 +63,101 @@
               delay: 5
               retries: 3
 
+            - name: Downloading cspc operator yaml
+              get_url:
+                url: "{{ cspc_rbac_link }}"
+                dest: "{{ playbook_dir }}/{{ cspc_rbac }}"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3
+
+            - name: Downloading cspc crd yaml
+              get_url:
+                url: "{{ cspc_crd_link }}"
+                dest: "{{ playbook_dir }}/{{ cspc_crd }}"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3
+              
+            - name: Downloading cspi crd yaml
+              get_url:
+                url: "{{ cspi_crd_link }}"
+                dest: "{{ playbook_dir }}/{{ cspi_crd }}"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3
+
+            - name: Downloading csi volumes crd yaml
+              get_url:
+                url: "{{ csi_volume_crd_link }}"
+                dest: "{{ playbook_dir }}/{{ csi_volume_crd }}"
+                force: yes
+              register: result
+              until:  "'OK' in result.msg"
+              delay: 5
+              retries: 3              
+
             - name: Change CSPC operator image
               replace:
                 path: "{{ cspc_operator }}"
-                regexp: quay.io/openebs/cspc-operator:ci
-                replace: quay.io/openebs/cspc-operator:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+                regexp: openebs/cspc-operator-amd64:ci
+                replace: openebs/cspc-operator-amd64:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
               when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
 
-            - name: Change OPENEBS_IO_CSPI_MGMT image
+            - name: Change CSTOR POOL MANAGER image
               replace:
                 path: "{{ cspc_operator }}"
-                regexp: quay.io/openebs/cspi-mgmt:ci
-                replace: quay.io/openebs/cspi-mgmt:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+                regexp: openebs/cstor-pool-manager-amd64:ci
+                replace: openebs/cstor-pool-manager-amd64:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
               when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
 
             - name: Change OPENEBS_IO_CSTOR_POOL image
               replace:
                 path: "{{ cspc_operator }}"
-                regexp: quay.io/openebs/cstor-pool:ci
-                replace: quay.io/openebs/cstor-pool:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+                regexp: openebs/cstor-pool:ci
+                replace: openebs/cstor-pool:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
               when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
 
             - name: Change OPENEBS_IO_CSTOR_POOL_EXPORTER image
               replace:
                 path: "{{ cspc_operator }}"
-                regexp: quay.io/openebs/m-exporter:ci
-                replace: quay.io/openebs/m-exporter:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+                regexp: openebs/m-exporter:ci
+                replace: openebs/m-exporter:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
               when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
 
+            - name: Change openebs cvc operator image
+              replace:
+                path: "{{ cspc_operator }}"
+                regexp: openebs/cvc-operator-amd64:ci
+                replace: openebs/cvc-operator-amd64:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+              when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
+
+            - name: Change openebs CSTOR ISTGT image
+              replace:
+                path: "{{ cspc_operator }}"
+                regexp: openebs/cstor-istgt:ci
+                replace: openebs/cstor-istgt:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+              when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
+
+            - name: Change openebs CSTOR VOLUME MGMT image
+              replace:
+                path: "{{ cspc_operator }}"
+                regexp: openebs/cstor-volume-manager-amd64:ci
+                replace: openebs/cstor-volume-manager-amd64:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+              when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
+              
+            - name: Change openebs CSTOR WEBHOOK image
+              replace:
+                path: "{{ cspc_operator }}"
+                regexp: openebs/cstor-webhook-amd64:ci
+                replace: openebs/cstor-webhook-amd64:{{ lookup('env','CSPC_OPERATOR_IMAGE') }}
+              when: lookup('env','CSPC_OPERATOR_IMAGE') | length > 0
 
             - name: Change the openebs analytics value of openebs resources in operator YAML
               replace:
@@ -177,6 +244,26 @@
               shell: "{{ kubeapply }} apply -f {{ cspc_operator }}"
               args:
                 executable: /bin/bash
+
+            - name: Applying cspc rbac
+              shell: "{{ kubeapply }} apply -f {{ cspc_rbac }}"
+              args:
+                executable: /bin/bash
+
+            - name: Applying cspc crd
+              shell: "{{ kubeapply }} apply -f {{ cspc_crd }}"
+              args:
+                executable: /bin/bash
+
+            - name: Applying cspi crd
+              shell: "{{ kubeapply }} apply -f {{ cspi_crd }}"
+              args:
+                executable: /bin/bash
+
+            - name: Applying csi volume crd
+              shell: "{{ kubeapply }} apply -f {{ csi_volume_crd }}"
+              args:
+                executable: /bin/bash                
 
             - name: Updating maya api server image
               shell: "{{ kubeapply }} set image deployment maya-apiserver maya-apiserver={{ lookup('env','MAYA_APISERVER_IMAGE') }} -n {{ namespace }}"

--- a/providers/openebs/installers/operator/master/litmusbook/test_vars.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/test_vars.yaml
@@ -4,10 +4,18 @@ namespace: openebs
 #storageclass_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
 openebs_operator_link: "https://raw.githubusercontent.com/openebs/openebs/{{ lookup('env','OPENEBS_VERSION') }}/k8s/openebs-operator.yaml"
 storageclass_link: "https://raw.githubusercontent.com/openebs/openebs/{{ lookup('env','OPENEBS_VERSION') }}/k8s/openebs-storageclasses.yaml"
-cspc_operator_link: "https://raw.githubusercontent.com/openebs/openebs/{{ lookup('env','OPENEBS_VERSION') }}/k8s/cstor-operator.yaml"
+cspc_operator_link: https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/cstor-operator.yaml
+cspc_rbac_link: https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/rbac.yaml
+cspc_crd_link: https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/cspc-crd.yaml
+cspi_crd_link: https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/cspi-crd.yaml
+csi_volume_crd_link: https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/volumes-crd.yaml
 openebs_operator: openebs-operator.yaml
 storageclass: storageclass.yaml
 cspc_operator: cstor-operator.yaml
+cspc_rbac: rbac.yaml
+cspc_crd: cspc-crd.yaml
+cspi_crd: cspi-crd.yaml
+csi_volume_crd: volumes-crd.yaml
 selector_name: openebs-ndm
 sparse_pool_label: 'app=cstor-pool'
 test_name: "openebs-{{ lookup('env','Action') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>
- Modified openebs installation task related to cstor operator with respect to api version v1
- Modified cspc pool provision, changed the yam spec for cspc

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
d2iq@rack2:~/sathya/test/e2e-tests/providers/cstor/cstor-cspc-pool$ kubectl logs -f cstor-cspc-pool-provision-dbhkk-7hvw7 -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-05-07T10:41:05.621732 (delta: 0.075211)         elapsed: 0.075211 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-05-07T10:41:05.636277 (delta: 0.014466)         elapsed: 0.089756 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-05-07T10:41:17.947662 (delta: 12.311365)         elapsed: 12.401141 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-05-07T10:41:18.089258 (delta: 0.141544)         elapsed: 12.542737 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-05-07T10:41:18.180676 (delta: 0.09134)         elapsed: 12.634155 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-05-07T10:41:18.263403 (delta: 0.082638)         elapsed: 12.716882 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-05-07T10:41:18.427359 (delta: 0.163899)         elapsed: 12.880838 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "035bacdb4b1fd8992a7683879a3fea2b885ee8ef", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "723a8fdf57f6efa3378c103e9eb54b09", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1588848078.54-123999751689640/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-05-07T10:41:19.414720 (delta: 0.987258)         elapsed: 13.868199 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.082395", "end": "2020-05-07 10:41:21.102879", "rc": 0, "start": "2020-05-07 10:41:20.020484", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-05-07T10:41:21.165847 (delta: 1.751069)         elapsed: 15.619326 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T10:21:07Z", "generation": 7, "name": "cstor-pool-provision", "resourceVersion": "672217", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "6ef22dab-156d-4bc3-891d-4b30a85a20c9"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-05-07T10:41:22.772728 (delta: 1.606825)         elapsed: 17.226207 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-05-07T10:41:22.892151 (delta: 0.119307)         elapsed: 17.34563 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-05-07T10:41:23.025840 (delta: 0.133551)         elapsed: 17.479319 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-05-07T10:41:23.160285 (delta: 0.13434)         elapsed: 17.613764 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -3", "delta": "0:00:01.509932", "end": "2020-05-07 10:41:24.991876", "failed_when_result": false, "rc": 0, "start": "2020-05-07 10:41:23.481944", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node1.mayalabs.io\nd2iq-node2.mayalabs.io\nd2iq-node3.mayalabs.io", "stdout_lines": ["d2iq-node1.mayalabs.io", "d2iq-node2.mayalabs.io", "d2iq-node3.mayalabs.io"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2020-05-07T10:41:25.153873 (delta: 1.99347)         elapsed: 19.607352 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:01.392156", "end": "2020-05-07 10:41:26.800317", "failed_when_result": false, "rc": 0, "start": "2020-05-07 10:41:25.408161", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-05-07T10:41:26.946717 (delta: 1.792506)         elapsed: 21.400196 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}}) => {"ansible_facts": {"disk_count": "1"}, "changed": false, "item": {"key": "stripe", "value": {"count": 1}}}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Add node labels for each nodes and create blockdevice template] **********
2020-05-07T10:41:27.251635 (delta: 0.304783)         elapsed: 21.705114 ******* 
changed: [127.0.0.1] => (item=[u'd2iq-node1.mayalabs.io']) => {"changed": true, "checksum": "6204ff37f1437b51bd368e5164fd3708dd03764e", "dest": "./blockdevice-d2iq-node1.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["d2iq-node1.mayalabs.io"], "md5sum": "61c53dc4570d67f61df27d84f40dd410", "mode": "0644", "owner": "root", "size": 174, "src": "/root/.ansible/tmp/ansible-tmp-1588848087.33-271214410126411/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item=[u'd2iq-node2.mayalabs.io']) => {"changed": true, "checksum": "29b83b1854dcf2f86b4efdb3aa120ac350676a53", "dest": "./blockdevice-d2iq-node2.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["d2iq-node2.mayalabs.io"], "md5sum": "39d140ffa3c4a91b1121203c928f9c3b", "mode": "0644", "owner": "root", "size": 174, "src": "/root/.ansible/tmp/ansible-tmp-1588848087.79-204663002868449/source", "state": "file", "uid": 0}
changed: [127.0.0.1] => (item=[u'd2iq-node3.mayalabs.io']) => {"changed": true, "checksum": "186acc9a0d0ef179751c5e67712218a44ef721a6", "dest": "./blockdevice-d2iq-node3.mayalabs.io.yml", "gid": 0, "group": "root", "item": ["d2iq-node3.mayalabs.io"], "md5sum": "6b53c97e686e0b938c631ad953a95e44", "mode": "0644", "owner": "root", "size": 174, "src": "/root/.ansible/tmp/ansible-tmp-1588848088.24-242192002317447/source", "state": "file", "uid": 0}

TASK [Getting the Unclaimed block-device count] ********************************
2020-05-07T10:41:28.693915 (delta: 1.442221)         elapsed: 23.147394 ******* 
changed: [127.0.0.1] => (item=d2iq-node1.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.567545", "end": "2020-05-07 10:41:30.564070", "item": "d2iq-node1.mayalabs.io", "rc": 0, "start": "2020-05-07 10:41:28.996525", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0d523d92406ce19801b840738bf83497", "stdout_lines": ["blockdevice-0d523d92406ce19801b840738bf83497"]}
changed: [127.0.0.1] => (item=d2iq-node2.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.481599", "end": "2020-05-07 10:41:32.423906", "item": "d2iq-node2.mayalabs.io", "rc": 0, "start": "2020-05-07 10:41:30.942307", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0980f7d094a8b4feb069c7745b9b891f", "stdout_lines": ["blockdevice-0980f7d094a8b4feb069c7745b9b891f"]}
changed: [127.0.0.1] => (item=d2iq-node3.mayalabs.io) => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.458072", "end": "2020-05-07 10:41:34.271133", "item": "d2iq-node3.mayalabs.io", "rc": 0, "start": "2020-05-07 10:41:32.813061", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-0deb852da7a97b23017975b37d133cc7", "stdout_lines": ["blockdevice-0deb852da7a97b23017975b37d133cc7"]}

TASK [set_fact] ****************************************************************
2020-05-07T10:41:34.373099 (delta: 5.679118)         elapsed: 28.826578 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"device_count": "3"}, "changed": false}

TASK [Add the block devices for each node's block device template] *************
2020-05-07T10:41:34.591063 (delta: 0.217882)         elapsed: 29.044542 ******* 
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1
included: /providers/cstor/cstor-cspc-pool/add_blockdevice.yml for 127.0.0.1

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-05-07T10:41:34.949646 (delta: 0.358486)         elapsed: 29.403125 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.353359", "end": "2020-05-07 10:41:36.563929", "rc": 0, "start": "2020-05-07 10:41:35.210570", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-0d523d92406ce19801b840738bf83497 ", "stdout_lines": [" blockdevice-0d523d92406ce19801b840738bf83497 "]}

TASK [Add the block devices] ***************************************************
2020-05-07T10:41:36.715746 (delta: 1.766002)         elapsed: 31.169225 ******* 
changed: [127.0.0.1] => (item= blockdevice-0d523d92406ce19801b840738bf83497 ) => {"backup": "", "changed": true, "item": " blockdevice-0d523d92406ce19801b840738bf83497 ", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-05-07T10:41:37.423246 (delta: 0.707316)         elapsed: 31.876725 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.464709", "end": "2020-05-07 10:41:39.193180", "rc": 0, "start": "2020-05-07 10:41:37.728471", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-0980f7d094a8b4feb069c7745b9b891f ", "stdout_lines": [" blockdevice-0980f7d094a8b4feb069c7745b9b891f "]}

TASK [Add the block devices] ***************************************************
2020-05-07T10:41:39.342842 (delta: 1.919517)         elapsed: 33.796321 ******* 
changed: [127.0.0.1] => (item= blockdevice-0980f7d094a8b4feb069c7745b9b891f ) => {"backup": "", "changed": true, "item": " blockdevice-0980f7d094a8b4feb069c7745b9b891f ", "msg": "line added"}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-05-07T10:41:39.729021 (delta: 0.386032)         elapsed: 34.1825 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"1\"", "delta": "0:00:01.386424", "end": "2020-05-07 10:41:41.474080", "rc": 0, "start": "2020-05-07 10:41:40.087656", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-0deb852da7a97b23017975b37d133cc7 ", "stdout_lines": [" blockdevice-0deb852da7a97b23017975b37d133cc7 "]}

TASK [Add the block devices] ***************************************************
2020-05-07T10:41:41.617071 (delta: 1.887971)         elapsed: 36.07055 ******** 
changed: [127.0.0.1] => (item= blockdevice-0deb852da7a97b23017975b37d133cc7 ) => {"backup": "", "changed": true, "item": " blockdevice-0deb852da7a97b23017975b37d133cc7 ", "msg": "line added"}

TASK [Include the blockdevice template in the CSPC spec] ***********************
2020-05-07T10:41:42.167290 (delta: 0.550113)         elapsed: 36.620769 ******* 
changed: [127.0.0.1] => (item=d2iq-node1.mayalabs.io) => {"changed": true, "item": "d2iq-node1.mayalabs.io", "msg": "Block inserted"}
changed: [127.0.0.1] => (item=d2iq-node2.mayalabs.io) => {"changed": true, "item": "d2iq-node2.mayalabs.io", "msg": "Block inserted"}
changed: [127.0.0.1] => (item=d2iq-node3.mayalabs.io) => {"changed": true, "item": "d2iq-node3.mayalabs.io", "msg": "Block inserted"}

TASK [Replacing the pool name in CSPC spec] ************************************
2020-05-07T10:41:43.367516 (delta: 1.200167)         elapsed: 37.820995 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the namespace in CSPC spec] ************************************
2020-05-07T10:41:43.947103 (delta: 0.579518)         elapsed: 38.400582 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the pool type in CSPC spec] ************************************
2020-05-07T10:41:44.395692 (delta: 0.448508)         elapsed: 38.849171 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2020-05-07T10:41:44.801307 (delta: 0.405549)         elapsed: 39.254786 ******* 
ok: [127.0.0.1] => (item=apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: cstor-cspc-disk-pool
  namespace: openebs
spec:
  pools:
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: d2iq-node3.mayalabs.io
      dataRaidGroups:
      - blockDevices:
        - blockDeviceName:  blockdevice-0deb852da7a97b23017975b37d133cc7 
      poolConfig:
        dataRaidGroupType: stripe
# ## d2iq-node3.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: d2iq-node2.mayalabs.io
      dataRaidGroups:
      - blockDevices:
        - blockDeviceName:  blockdevice-0980f7d094a8b4feb069c7745b9b891f 
      poolConfig:
        dataRaidGroupType: stripe
# ## d2iq-node2.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK
# BEGIN ANSIBLE MANAGED BLOCK
    - nodeSelector:
        kubernetes.io/hostname: d2iq-node1.mayalabs.io
      dataRaidGroups:
      - blockDevices:
        - blockDeviceName:  blockdevice-0d523d92406ce19801b840738bf83497 
      poolConfig:
        dataRaidGroupType: stripe
# ## d2iq-node1.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK) => {
    "item": "apiVersion: cstor.openebs.io/v1\nkind: CStorPoolCluster\nmetadata:\n  name: cstor-cspc-disk-pool\n  namespace: openebs\nspec:\n  pools:\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: d2iq-node3.mayalabs.io\n      dataRaidGroups:\n      - blockDevices:\n        - blockDeviceName:  blockdevice-0deb852da7a97b23017975b37d133cc7 \n      poolConfig:\n        dataRaidGroupType: stripe\n# ## d2iq-node3.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: d2iq-node2.mayalabs.io\n      dataRaidGroups:\n      - blockDevices:\n        - blockDeviceName:  blockdevice-0980f7d094a8b4feb069c7745b9b891f \n      poolConfig:\n        dataRaidGroupType: stripe\n# ## d2iq-node2.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK\n# BEGIN ANSIBLE MANAGED BLOCK\n    - nodeSelector:\n        kubernetes.io/hostname: d2iq-node1.mayalabs.io\n      dataRaidGroups:\n      - blockDevices:\n        - blockDeviceName:  blockdevice-0d523d92406ce19801b840738bf83497 \n      poolConfig:\n        dataRaidGroupType: stripe\n# ## d2iq-node1.mayalabs.io Ansible Config ## ANSIBLE MANAGED BLOCK"
}

TASK [Create cstor disk pool] **************************************************
2020-05-07T10:41:44.966536 (delta: 0.165164)         elapsed: 39.420015 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc.yml", "delta": "0:00:01.880529", "end": "2020-05-07 10:41:47.211896", "rc": 0, "start": "2020-05-07 10:41:45.331367", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.cstor.openebs.io/cstor-cspc-disk-pool created", "stdout_lines": ["cstorpoolcluster.cstor.openebs.io/cstor-cspc-disk-pool created"]}

TASK [Check whether cspc is created] *******************************************
2020-05-07T10:41:47.289201 (delta: 2.32258)         elapsed: 41.74268 ********* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspc -n openebs -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.237182", "end": "2020-05-07 10:41:48.852247", "rc": 0, "start": "2020-05-07 10:41:47.615065", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool", "stdout_lines": ["cstor-cspc-disk-pool"]}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-05-07T10:41:49.017145 (delta: 1.727857)         elapsed: 43.470624 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.378370", "end": "2020-05-07 10:41:50.851092", "rc": 0, "start": "2020-05-07 10:41:49.472722", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-h9sx\ncstor-cspc-disk-pool-tkrv\ncstor-cspc-disk-pool-zpkb", "stdout_lines": ["cstor-cspc-disk-pool-h9sx", "cstor-cspc-disk-pool-tkrv", "cstor-cspc-disk-pool-zpkb"]}

TASK [Verify the status of CSPI] ***********************************************
2020-05-07T10:41:51.011278 (delta: 1.994009)         elapsed: 45.464757 ******* 
FAILED - RETRYING: Verify the status of CSPI (30 retries left).
FAILED - RETRYING: Verify the status of CSPI (29 retries left).
FAILED - RETRYING: Verify the status of CSPI (28 retries left).
FAILED - RETRYING: Verify the status of CSPI (27 retries left).
FAILED - RETRYING: Verify the status of CSPI (26 retries left).
FAILED - RETRYING: Verify the status of CSPI (25 retries left).
FAILED - RETRYING: Verify the status of CSPI (24 retries left).
FAILED - RETRYING: Verify the status of CSPI (23 retries left).
FAILED - RETRYING: Verify the status of CSPI (22 retries left).
FAILED - RETRYING: Verify the status of CSPI (21 retries left).
FAILED - RETRYING: Verify the status of CSPI (20 retries left).
FAILED - RETRYING: Verify the status of CSPI (19 retries left).
FAILED - RETRYING: Verify the status of CSPI (18 retries left).
FAILED - RETRYING: Verify the status of CSPI (17 retries left).
FAILED - RETRYING: Verify the status of CSPI (16 retries left).
FAILED - RETRYING: Verify the status of CSPI (15 retries left).
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-h9sx) => {"attempts": 17, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-h9sx\")].status.phase}'", "delta": "0:00:01.498871", "end": "2020-05-07 10:43:40.345375", "item": "cstor-cspc-disk-pool-h9sx", "rc": 0, "start": "2020-05-07 10:43:38.846504", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-tkrv) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-tkrv\")].status.phase}'", "delta": "0:00:01.398774", "end": "2020-05-07 10:43:41.987023", "item": "cstor-cspc-disk-pool-tkrv", "rc": 0, "start": "2020-05-07 10:43:40.588249", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-zpkb) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-disk-pool-zpkb\")].status.phase}'", "delta": "0:00:01.367032", "end": "2020-05-07 10:43:43.734722", "item": "cstor-cspc-disk-pool-zpkb", "rc": 0, "start": "2020-05-07 10:43:42.367690", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify if the cStor Pool pods are Running] *******************************
2020-05-07T10:43:43.906613 (delta: 112.895217)         elapsed: 158.360092 **** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-h9sx) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-h9sx --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.501891", "end": "2020-05-07 10:43:45.735098", "item": "cstor-cspc-disk-pool-h9sx", "rc": 0, "start": "2020-05-07 10:43:44.233207", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-tkrv) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-tkrv --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.469737", "end": "2020-05-07 10:43:47.581917", "item": "cstor-cspc-disk-pool-tkrv", "rc": 0, "start": "2020-05-07 10:43:46.112180", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-zpkb) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-disk-pool-zpkb --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.423903", "end": "2020-05-07 10:43:49.339327", "item": "cstor-cspc-disk-pool-zpkb", "rc": 0, "start": "2020-05-07 10:43:47.915424", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get cStor Pool pod names to verify the container statuses and check the required number of pools created.] ***
2020-05-07T10:43:49.467469 (delta: 5.560753)         elapsed: 163.920948 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.270668", "end": "2020-05-07 10:43:51.120862", "failed_when_result": false, "rc": 0, "start": "2020-05-07 10:43:49.850194", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-h9sx-764778d6db-kxts6\ncstor-cspc-disk-pool-tkrv-c45f55778-fbpbt\ncstor-cspc-disk-pool-zpkb-b7985d5d9-g67xs", "stdout_lines": ["cstor-cspc-disk-pool-h9sx-764778d6db-kxts6", "cstor-cspc-disk-pool-tkrv-c45f55778-fbpbt", "cstor-cspc-disk-pool-zpkb-b7985d5d9-g67xs"]}

TASK [Get the runningStatus of pool pod] ***************************************
2020-05-07T10:43:51.275030 (delta: 1.807483)         elapsed: 165.728509 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-h9sx-764778d6db-kxts6) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-h9sx-764778d6db-kxts6 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.453124", "end": "2020-05-07 10:43:53.061481", "item": "cstor-cspc-disk-pool-h9sx-764778d6db-kxts6", "rc": 0, "start": "2020-05-07 10:43:51.608357", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-tkrv-c45f55778-fbpbt) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-tkrv-c45f55778-fbpbt -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.313157", "end": "2020-05-07 10:43:54.732972", "item": "cstor-cspc-disk-pool-tkrv-c45f55778-fbpbt", "rc": 0, "start": "2020-05-07 10:43:53.419815", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-zpkb-b7985d5d9-g67xs) => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-cspc-disk-pool-zpkb-b7985d5d9-g67xs -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:01.357958", "end": "2020-05-07 10:43:56.480905", "item": "cstor-cspc-disk-pool-zpkb-b7985d5d9-g67xs", "rc": 0, "start": "2020-05-07 10:43:55.122947", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Remove the CStor Pool Cluster] *******************************************
2020-05-07T10:43:56.639898 (delta: 5.364746)         elapsed: 171.093377 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CStor Pool Cluster is deleted] *****************************
2020-05-07T10:43:56.801447 (delta: 0.161452)         elapsed: 171.254926 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the CSPI is getting removed] ***********************************
2020-05-07T10:43:56.964692 (delta: 0.163147)         elapsed: 171.418171 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor pool pods are deleted] *******************************
2020-05-07T10:43:57.120363 (delta: 0.155531)         elapsed: 171.573842 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-05-07T10:43:57.279706 (delta: 0.159238)         elapsed: 171.733185 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-05-07T10:43:57.503696 (delta: 0.22381)         elapsed: 171.957175 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-05-07T10:43:57.663733 (delta: 0.159859)         elapsed: 172.117212 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-05-07T10:43:57.738492 (delta: 0.074673)         elapsed: 172.191971 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-05-07T10:43:57.804865 (delta: 0.066308)         elapsed: 172.258344 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-05-07T10:43:57.909112 (delta: 0.10418)         elapsed: 172.362591 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "501786648ab66e7fc2a021e95e8fcc53f8ff4f77", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "23c79b43245ac077305a179ea8f3e971", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1588848238.02-132353268743673/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-05-07T10:44:00.651382 (delta: 2.742172)         elapsed: 175.104861 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.128799", "end": "2020-05-07 10:44:02.131409", "rc": 0, "start": "2020-05-07 10:44:01.002610", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-05-07T10:44:02.196324 (delta: 1.544866)         elapsed: 176.649803 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T10:21:07Z", "generation": 8, "name": "cstor-pool-provision", "resourceVersion": "673155", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "6ef22dab-156d-4bc3-891d-4b30a85a20c9"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=38   changed=27   unreachable=0    failed=0   

2020-05-07T10:44:03.409244 (delta: 1.212865)         elapsed: 177.862723 ****** 
=============================================================================== 
```
