### PR TITLE
refactor[yaml]: Modified the jiva replica network delay test

### DIFF
--- a/chaoslib/openebs/jiva_replica_network_delay.yaml
+++ b/chaoslib/openebs/jiva_replica_network_delay.yaml
@@ -29,9 +29,8 @@
 
 - name: Identify the jiva controller pod belonging to the PV
   shell: > 
-    kubectl get pods -l openebs.io/controller=jiva-controller
-    -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
-    | awk '{print $1}'
+    kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv.stdout }}" 
+    -n {{ operator_ns }} --no-headers -o custom-columns=:.metadata.name
   args:
     executable: /bin/bash
   register: jiva_controller_pod
@@ -44,7 +43,7 @@
 - name: Identify the jiva replica pod belonging to the PV
   shell: > 
     kubectl get pods -l openebs.io/replica=jiva-replica
-    -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
+    -n {{ operator_ns }} --no-headers | grep {{ pv.stdout }} 
     | awk 'FNR == 1 {print}'| awk {'print $1'}
   args:
     executable: /bin/bash
@@ -57,7 +56,7 @@
 
 - name: Get the node on which the jiva replica is scheduled
   shell: >
-    kubectl get pod {{ jiva_replica_pod.stdout }} -n {{ app_ns }}
+    kubectl get pod {{ jiva_replica_pod.stdout }} -n {{ operator_ns }}
     --no-headers -o custom-columns=:spec.nodeName
   args:
     executable: /bin/bash
@@ -65,8 +64,8 @@
 
 - name: Get controller svc
   shell: >
-    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
-    -n {{ app_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume="{{ pv.stdout }}" 
+    -n {{ operator_ns }} -o=jsonpath='{.items[0].spec.clusterIP}'
   args:
     executable: /bin/bash
   register: controller_svc
@@ -74,21 +73,21 @@
 
 - name: Install jq package inside a controller container
   shell: >
-    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} -c {{ jiva_controller_name }} 
+    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} -c {{ jiva_controller_name }} 
     -- bash -c "apt-get update && apt-get install -y jq && apt-get install -y iproute2"
   args:
     executable: /bin/bash
 
 - name: Install jq package inside a replica container
   shell: >
-    kubectl exec -it {{ jiva_replica_pod.stdout }} -n {{ app_ns }} -c {{ jiva_replica_name }}
+    kubectl exec -it {{ jiva_replica_pod.stdout }} -n {{ operator_ns }} -c {{ jiva_replica_name }}
     -- bash -c "apt-get update && apt-get install -y jq && apt-get install -y iproute2"
   args:
     executable: /bin/bash
 
 - name: Getting the ReplicaCount before injecting delay
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
@@ -102,17 +101,17 @@
     executable: /bin/bash
   register: pumba_pod
 
-- name: Inject egress delay of {{network_delay}}ms on jiva controller for {{ chaos_duration }}s
+- name: Inject egress delay of {{network_delay}}ms on jiva controller for {{ chaos_duration }}ms
   shell: >
     kubectl exec {{ pumba_pod.stdout }} -n {{ app_ns }} 
-    -- pumba netem --interface eth0 --duration {{ chaos_duration }}s delay
+    -- pumba netem --interface eth0 --duration {{ chaos_duration }}ms delay
     --time {{ network_delay }} re2:k8s_{{ jiva_replica_name }} 
   args:
     executable: /bin/bash
 
 - name: Verifying the Replica getting disconnected
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
@@ -139,7 +138,7 @@
 
 - name: Verifying the replicas post network recovery
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
    -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified the jiva replica network delay to incorporate the change, "jiva controller and replica pod would be in openebs (operator) namespace.
**Special notes for your reviewer**:
Logs for the test :-
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_replica_network_delay/test.yml

PLAY [localhost] ***************************************************************
2020-05-07T11:25:25.291679 (delta: 0.083242)         elapsed: 0.083242 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:2
2020-05-07T11:25:25.310852 (delta: 0.019119)         elapsed: 0.102415 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:11
2020-05-07T11:25:35.890250 (delta: 10.579351)         elapsed: 10.681813 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:2
2020-05-07T11:25:35.989030 (delta: 0.098689)         elapsed: 10.780593 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n sam --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.221303", "end": "2020-05-07 11:25:37.647894", "rc": 0, "start": "2020-05-07 11:25:36.426591", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:10
2020-05-07T11:25:37.738685 (delta: 1.749576)         elapsed: 12.530248 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.097985", "end": "2020-05-07 11:25:39.100618", "rc": 0, "start": "2020-05-07 11:25:38.002633", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:18
2020-05-07T11:25:39.199277 (delta: 1.460515)         elapsed: 13.99084 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:22
2020-05-07T11:25:39.320768 (delta: 0.121375)         elapsed: 14.112331 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:27
2020-05-07T11:25:39.450012 (delta: 0.129131)         elapsed: 14.241575 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n sam --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.170238", "end": "2020-05-07 11:25:40.873733", "rc": 0, "start": "2020-05-07 11:25:39.703495", "stderr": "", "stderr_lines": [], "stdout": "pvc-457dc60b-1eb7-467a-b32e-499a322b6dca", "stdout_lines": ["pvc-457dc60b-1eb7-467a-b32e-499a322b6dca"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:35
2020-05-07T11:25:40.985957 (delta: 1.535842)         elapsed: 15.77752 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-457dc60b-1eb7-467a-b32e-499a322b6dca --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.072012", "end": "2020-05-07 11:25:42.341014", "rc": 0, "start": "2020-05-07 11:25:41.269002", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:43
2020-05-07T11:25:42.471050 (delta: 1.485009)         elapsed: 17.262613 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:48
2020-05-07T11:25:42.724315 (delta: 0.25319)         elapsed: 17.515878 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "cc41594b9e756bd386a5f8aefa6f4406bb8500fb", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "c4e8e343052a60e26ff990195e2675d5", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1588850742.8-134943927703144/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:18
2020-05-07T11:25:44.158799 (delta: 1.433963)         elapsed: 18.950362 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_replica_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_replica_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:21
2020-05-07T11:25:44.320228 (delta: 0.161347)         elapsed: 19.111791 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_replica_network_delay.yaml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:27
2020-05-07T11:25:44.457264 (delta: 0.136942)         elapsed: 19.248827 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-05-07T11:25:44.629703 (delta: 0.172358)         elapsed: 19.421266 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-05-07T11:25:44.824871 (delta: 0.193846)         elapsed: 19.616434 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:29
2020-05-07T11:25:44.935050 (delta: 0.110071)         elapsed: 19.726613 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-07T11:25:45.096011 (delta: 0.16088)         elapsed: 19.887574 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "443a1dcd12c02b289a1b7a96be0b3ba148072b96", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4a2eb222bfccd1a2105b7468f0c61247", "mode": "0644", "owner": "root", "size": 464, "src": "/root/.ansible/tmp/ansible-tmp-1588850745.17-180066689943938/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-07T11:25:45.745699 (delta: 0.649614)         elapsed: 20.537262 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.918280", "end": "2020-05-07 11:25:46.927301", "rc": 0, "start": "2020-05-07 11:25:46.009021", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-replica-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-replica-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-07T11:25:47.001018 (delta: 1.25524)         elapsed: 21.792581 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T10:25:28Z", "generation": 8, "name": "openebs-replica-network-delay", "resourceVersion": "5006401", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-replica-network-delay", "uid": "d7e69c8f-8e93-4d43-8e26-f9a19b723ebe"}, "spec": {"testMetadata": {"chaostype": "openebs/jiva_replica_network_delay"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-07T11:25:48.884230 (delta: 1.883132)         elapsed: 23.675793 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-07T11:25:48.990008 (delta: 0.105685)         elapsed: 23.781571 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-07T11:25:49.069769 (delta: 0.079684)         elapsed: 23.861332 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:36
2020-05-07T11:25:49.171799 (delta: 0.101949)         elapsed: 23.963362 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : sam", 
        "Label        : app=busybox-sts", 
        "PVC          : openebs-busybox", 
        "StorageClass : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:47
2020-05-07T11:25:49.325374 (delta: 0.153486)         elapsed: 24.116937 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-05-07T11:25:49.473667 (delta: 0.148212)         elapsed: 24.26523 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n sam -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.257526", "end": "2020-05-07 11:25:51.117352", "rc": 0, "start": "2020-05-07 11:25:49.859826", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-07T11:06:18Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-07T11:06:18Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-05-07T11:25:51.301052 (delta: 1.82731)         elapsed: 26.092615 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.410368", "end": "2020-05-07 11:25:53.111632", "rc": 0, "start": "2020-05-07 11:25:51.701264", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:56
2020-05-07T11:25:53.287165 (delta: 1.986027)         elapsed: 28.078728 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n sam -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.338704", "end": "2020-05-07 11:25:55.022455", "rc": 0, "start": "2020-05-07 11:25:53.683751", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-bl6nf", "stdout_lines": ["app-busybox-85d45b855f-bl6nf"]}

TASK [Create some test data in the mysql database] *****************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:64
2020-05-07T11:25:55.124517 (delta: 1.83726)         elapsed: 29.91608 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:78
2020-05-07T11:25:55.249368 (delta: 0.12478)         elapsed: 30.040931 ******** 
included: /chaoslib/openebs/jiva_replica_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:1
2020-05-07T11:25:55.480161 (delta: 0.230697)         elapsed: 30.271724 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n sam", "delta": "0:00:01.541688", "end": "2020-05-07 11:25:57.332066", "rc": 0, "start": "2020-05-07 11:25:55.790378", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/pumba created", "stdout_lines": ["daemonset.apps/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:9
2020-05-07T11:25:57.476665 (delta: 1.996419)         elapsed: 32.268228 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n sam | sort | uniq", "delta": "0:00:01.124597", "end": "2020-05-07 11:26:20.941852", "rc": 0, "start": "2020-05-07 11:26:19.817255", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:21
2020-05-07T11:26:21.030066 (delta: 23.55326)         elapsed: 55.821629 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n sam --no-headers", "delta": "0:00:01.313512", "end": "2020-05-07 11:26:22.698394", "rc": 0, "start": "2020-05-07 11:26:21.384882", "stderr": "", "stderr_lines": [], "stdout": "pvc-457dc60b-1eb7-467a-b32e-499a322b6dca", "stdout_lines": ["pvc-457dc60b-1eb7-467a-b32e-499a322b6dca"]}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:30
2020-05-07T11:26:22.883951 (delta: 1.853541)         elapsed: 57.675514 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=\"pvc-457dc60b-1eb7-467a-b32e-499a322b6dca\" -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.134357", "end": "2020-05-07 11:26:24.478664", "rc": 0, "start": "2020-05-07 11:26:23.344307", "stderr": "", "stderr_lines": [], "stdout": "pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-5b599bccd6-bxwb9", "stdout_lines": ["pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-5b599bccd6-bxwb9"]}

TASK [Record the jiva controller container name] *******************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:38
2020-05-07T11:26:24.597178 (delta: 1.713119)         elapsed: 59.388741 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_name": "pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-con"}, "changed": false}

TASK [Identify the jiva replica pod belonging to the PV] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:43
2020-05-07T11:26:24.765012 (delta: 0.167738)         elapsed: 59.556575 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n openebs --no-headers | grep pvc-457dc60b-1eb7-467a-b32e-499a322b6dca | awk 'FNR == 1 {print}'| awk {'print $1'}", "delta": "0:00:01.164197", "end": "2020-05-07 11:26:26.324992", "rc": 0, "start": "2020-05-07 11:26:25.160795", "stderr": "", "stderr_lines": [], "stdout": "pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-1-564bcc99cf-jxcmx", "stdout_lines": ["pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-1-564bcc99cf-jxcmx"]}

TASK [Record the jiva replica container name] **********************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:52
2020-05-07T11:26:26.411563 (delta: 1.64647)         elapsed: 61.203126 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_name": "pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-con"}, "changed": false}

TASK [Get the node on which the jiva replica is scheduled] *********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:57
2020-05-07T11:26:26.559923 (delta: 0.148281)         elapsed: 61.351486 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-1-564bcc99cf-jxcmx -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.067415", "end": "2020-05-07 11:26:27.914924", "rc": 0, "start": "2020-05-07 11:26:26.847509", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node3", "stdout_lines": ["e2e1-node3"]}

TASK [Get controller svc] ******************************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:65
2020-05-07T11:26:28.000231 (delta: 1.440195)         elapsed: 62.791794 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume=\"pvc-457dc60b-1eb7-467a-b32e-499a322b6dca\" -n openebs -o=jsonpath='{.items[0].spec.clusterIP}'", "delta": "0:00:01.148297", "end": "2020-05-07 11:26:29.498135", "failed_when_result": false, "rc": 0, "start": "2020-05-07 11:26:28.349838", "stderr": "", "stderr_lines": [], "stdout": "10.98.207.108", "stdout_lines": ["10.98.207.108"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:74
2020-05-07T11:26:29.614238 (delta: 1.613859)         elapsed: 64.405801 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-5b599bccd6-bxwb9 -n openebs -c pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:16.539405", "end": "2020-05-07 11:26:46.451010", "rc": 0, "start": "2020-05-07 11:26:29.911605", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:8 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1101 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1470 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1029 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.7 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]\nGet:16 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:17 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [624 kB]\nGet:18 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6680 B]\nFetched 16.4 MB in 4s (3715 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 1s (229 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5294 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libatm1 libmnl0 libxtables11\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2 libatm1 libmnl0 libxtables11\n0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 586 kB of archives.\nAfter this operation, 1809 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]\nFetched 586 kB in 1s (468 kB/s)\nSelecting previously unselected package libatm1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5306 files and directories currently installed.)\r\nPreparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...\r\nUnpacking libatm1:amd64 (1:2.5.1-1.5) ...\r\nSelecting previously unselected package libmnl0:amd64.\r\nPreparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...\r\nUnpacking libmnl0:amd64 (1.0.3-5) ...\r\nSelecting previously unselected package iproute2.\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSelecting previously unselected package libxtables11:amd64.\r\nPreparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...\r\nUnpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libatm1:amd64 (1:2.5.1-1.5) ...\r\nSetting up libmnl0:amd64 (1.0.3-5) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSetting up libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...", "stdout_lines": ["Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:8 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1101 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1470 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1029 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.7 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]", "Get:16 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:17 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [624 kB]", "Get:18 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6680 B]", "Fetched 16.4 MB in 4s (3715 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 1s (229 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5294 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libatm1 libmnl0 libxtables11", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2 libatm1 libmnl0 libxtables11", "0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.", "Need to get 586 kB of archives.", "After this operation, 1809 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]", "Fetched 586 kB in 1s (468 kB/s)", "Selecting previously unselected package libatm1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5306 files and directories currently installed.)", "Preparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...", "Unpacking libatm1:amd64 (1:2.5.1-1.5) ...", "Selecting previously unselected package libmnl0:amd64.", "Preparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...", "Unpacking libmnl0:amd64 (1.0.3-5) ...", "Selecting previously unselected package iproute2.", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Selecting previously unselected package libxtables11:amd64.", "Preparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...", "Unpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libatm1:amd64 (1:2.5.1-1.5) ...", "Setting up libmnl0:amd64 (1.0.3-5) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Setting up libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ..."]}

TASK [Install jq package inside a replica container] ***************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:81
2020-05-07T11:26:46.567857 (delta: 16.953432)         elapsed: 81.35942 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-1-564bcc99cf-jxcmx -n openebs -c pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:16.418376", "end": "2020-05-07 11:27:03.317734", "rc": 0, "start": "2020-05-07 11:26:46.899358", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1101 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [624 kB]\nGet:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6680 B]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1470 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1029 kB]\nGet:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.7 kB]\nGet:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]\nFetched 16.4 MB in 4s (3560 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 1s (218 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5294 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libatm1 libmnl0 libxtables11\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2 libatm1 libmnl0 libxtables11\n0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 586 kB of archives.\nAfter this operation, 1809 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]\nFetched 586 kB in 1s (487 kB/s)\nSelecting previously unselected package libatm1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5306 files and directories currently installed.)\r\nPreparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...\r\nUnpacking libatm1:amd64 (1:2.5.1-1.5) ...\r\nSelecting previously unselected package libmnl0:amd64.\r\nPreparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...\r\nUnpacking libmnl0:amd64 (1.0.3-5) ...\r\nSelecting previously unselected package iproute2.\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSelecting previously unselected package libxtables11:amd64.\r\nPreparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...\r\nUnpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libatm1:amd64 (1:2.5.1-1.5) ...\r\nSetting up libmnl0:amd64 (1.0.3-5) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSetting up libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...", "stdout_lines": ["Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1101 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [624 kB]", "Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6680 B]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1470 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1029 kB]", "Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.7 kB]", "Get:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]", "Fetched 16.4 MB in 4s (3560 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 1s (218 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5294 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libatm1 libmnl0 libxtables11", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2 libatm1 libmnl0 libxtables11", "0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.", "Need to get 586 kB of archives.", "After this operation, 1809 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]", "Fetched 586 kB in 1s (487 kB/s)", "Selecting previously unselected package libatm1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5306 files and directories currently installed.)", "Preparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...", "Unpacking libatm1:amd64 (1:2.5.1-1.5) ...", "Selecting previously unselected package libmnl0:amd64.", "Preparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...", "Unpacking libmnl0:amd64 (1.0.3-5) ...", "Selecting previously unselected package iproute2.", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Selecting previously unselected package libxtables11:amd64.", "Preparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...", "Unpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libatm1:amd64 (1:2.5.1-1.5) ...", "Setting up libmnl0:amd64 (1.0.3-5) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Setting up libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ..."]}

TASK [Getting the ReplicaCount before injecting delay] *************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:88
2020-05-07T11:27:03.399827 (delta: 16.831868)         elapsed: 98.19139 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-5b599bccd6-bxwb9 -n openebs -c pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-con curl http://\"10.98.207.108\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.686191", "end": "2020-05-07 11:27:05.362664", "rc": 0, "start": "2020-05-07 11:27:03.676473", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1150  100  1150    0     0   325k      0 --:--:-- --:--:-- --:--:--  561k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1150  100  1150    0     0   325k      0 --:--:-- --:--:-- --:--:--  561k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Identify the pumba pod that co-exists with jiva controller] **************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:96
2020-05-07T11:27:05.447027 (delta: 2.047098)         elapsed: 100.23859 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n sam -o jsonpath='{.items[?(@.spec.nodeName==''\"e2e1-node3\"'')].metadata.name}'", "delta": "0:00:01.142059", "end": "2020-05-07 11:27:06.997598", "rc": 0, "start": "2020-05-07 11:27:05.855539", "stderr": "", "stderr_lines": [], "stdout": "pumba-8n2q2", "stdout_lines": ["pumba-8n2q2"]}

TASK [Inject egress delay of 60000ms on jiva controller for 60000ms] ***********
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:104
2020-05-07T11:27:07.108557 (delta: 1.661426)         elapsed: 101.90012 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-8n2q2 -n sam -- pumba netem --interface eth0 --duration 60000ms delay --time 60000 re2:k8s_pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-rep-con", "delta": "0:01:04.026839", "end": "2020-05-07 11:28:11.446860", "rc": 0, "start": "2020-05-07 11:27:07.420021", "stderr": "time=\"2020-05-07T11:27:08Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2020-05-07T11:27:10Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3 for 1m0s\" \ntime=\"2020-05-07T11:27:10Z\" level=info msg=\"Start netem for container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2020-05-07T11:28:10Z\" level=info msg=\"Stopping netem on container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3\" \ntime=\"2020-05-07T11:28:10Z\" level=info msg=\"Stop netem for container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3 on 'eth0'\" ", "stderr_lines": ["time=\"2020-05-07T11:27:08Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2020-05-07T11:27:10Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3 for 1m0s\" ", "time=\"2020-05-07T11:27:10Z\" level=info msg=\"Start netem for container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2020-05-07T11:28:10Z\" level=info msg=\"Stopping netem on container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3\" ", "time=\"2020-05-07T11:28:10Z\" level=info msg=\"Stop netem for container 2be7900f6ca1034d13ed3958fd8983128868a29ff592f35fc6b0954853a06bc3 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Verifying the Replica getting disconnected] ******************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:112
2020-05-07T11:28:11.555851 (delta: 64.446557)         elapsed: 166.347414 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-5b599bccd6-bxwb9 -n openebs -c pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-con curl http://\"10.98.207.108\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.743726", "end": "2020-05-07 11:28:13.561326", "rc": 0, "start": "2020-05-07 11:28:11.817600", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1150  100  1150    0     0   631k      0 --:--:-- --:--:-- --:--:-- 1123k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1150  100  1150    0     0   631k      0 --:--:-- --:--:-- --:--:-- 1123k"], "stdout": "2", "stdout_lines": ["2"]}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:123
2020-05-07T11:28:13.690269 (delta: 2.134312)         elapsed: 168.481832 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n sam", "delta": "0:00:01.352733", "end": "2020-05-07 11:28:15.359624", "rc": 0, "start": "2020-05-07 11:28:14.006891", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps \"pumba\" deleted", "stdout_lines": ["daemonset.apps \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:129
2020-05-07T11:28:15.443671 (delta: 1.753299)         elapsed: 170.235234 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n sam", "delta": "0:00:01.217599", "end": "2020-05-07 11:28:16.925101", "rc": 0, "start": "2020-05-07 11:28:15.707502", "stderr": "", "stderr_lines": [], "stdout": "pumba-8n2q2   1/1   Terminating   0     2m19s\npumba-ktwnz   1/1   Terminating   0     2m19s\npumba-lvjcm   1/1   Terminating   0     2m19s", "stdout_lines": ["pumba-8n2q2   1/1   Terminating   0     2m19s", "pumba-ktwnz   1/1   Terminating   0     2m19s", "pumba-lvjcm   1/1   Terminating   0     2m19s"]}

TASK [Verifying the replicas post network recovery] ****************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:139
2020-05-07T11:28:17.024095 (delta: 1.579719)         elapsed: 171.815658 ****** 
FAILED - RETRYING: Verifying the replicas post network recovery (10 retries left).
FAILED - RETRYING: Verifying the replicas post network recovery (9 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-5b599bccd6-bxwb9 -n openebs -c pvc-457dc60b-1eb7-467a-b32e-499a322b6dca-ctrl-con curl http://\"10.98.207.108\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.719610", "end": "2020-05-07 11:28:53.051402", "rc": 0, "start": "2020-05-07 11:28:51.331792", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1150  100  1150    0     0   292k      0 --:--:-- --:--:-- --:--:-- 1123k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1150  100  1150    0     0   292k      0 --:--:-- --:--:-- --:--:-- 1123k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:85
2020-05-07T11:28:53.185760 (delta: 36.161575)         elapsed: 207.977323 ***** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-05-07T11:28:53.327709 (delta: 0.141873)         elapsed: 208.119272 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n sam -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.246464", "end": "2020-05-07 11:28:54.883642", "rc": 0, "start": "2020-05-07 11:28:53.637178", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-07T11:06:18Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-07T11:06:18Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-05-07T11:28:55.067525 (delta: 1.739718)         elapsed: 209.859088 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n sam -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.405790", "end": "2020-05-07 11:28:56.781056", "rc": 0, "start": "2020-05-07 11:28:55.375266", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:94
2020-05-07T11:28:56.893052 (delta: 1.825461)         elapsed: 211.684615 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:97
2020-05-07T11:28:56.988896 (delta: 0.095753)         elapsed: 211.780459 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:109
2020-05-07T11:28:57.077600 (delta: 0.088594)         elapsed: 211.869163 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:120
2020-05-07T11:28:57.360932 (delta: 0.283257)         elapsed: 212.152495 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-07T11:28:57.506635 (delta: 0.145637)         elapsed: 212.298198 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-07T11:28:57.589080 (delta: 0.082371)         elapsed: 212.380643 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-07T11:28:57.676664 (delta: 0.087471)         elapsed: 212.468227 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-07T11:28:57.767418 (delta: 0.090648)         elapsed: 212.558981 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "47915e31a46564f7297b4020a66371f050b5979d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0ecc5235fdbbc77eca4a60ab61ea7117", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1588850937.85-86436125594338/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-07T11:29:00.081696 (delta: 2.314201)         elapsed: 214.873259 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.910956", "end": "2020-05-07 11:29:01.245638", "rc": 0, "start": "2020-05-07 11:29:00.334682", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-replica-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-replica-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-07T11:29:01.336102 (delta: 1.254336)         elapsed: 216.127665 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T10:25:28Z", "generation": 9, "name": "openebs-replica-network-delay", "resourceVersion": "5007254", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-replica-network-delay", "uid": "d7e69c8f-8e93-4d43-8e26-f9a19b723ebe"}, "spec": {"testMetadata": {"chaostype": "openebs/jiva_replica_network_delay"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=48   changed=32   unreachable=0    failed=0   

2020-05-07T11:29:02.742860 (delta: 1.406535)         elapsed: 217.534423 ****** 
=============================================================================== 
```