### PR TITLE
refactor(yaml):deploy csi provisioner from cstor-csi repo

### DIFF
--- a/providers/csi-provisioner/patch.j2
+++ b/providers/csi-provisioner/patch.j2
@@ -4,7 +4,7 @@
     "spec": {
      "containers": [
       {
-       "name": "openebs-csi-plugin",
+       "name": "cstor-csi-plugin",
        "env": [
         {
            "name": "REMOUNT",

--- a/providers/csi-provisioner/run_litmus_test.yml
+++ b/providers/csi-provisioner/run_litmus_test.yml
@@ -34,6 +34,9 @@ spec:
           - name: CSPC
             value: cstor-sparse-pool
 
+          - name: IMAGE_TAG
+            value: "1.9.0"
+
           - name: REPLICA_COUNT
             value: "3"
 

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -18,61 +18,101 @@
 
         - block:
 
-            - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04 
-              shell: >
-                kubectl apply -f https://raw.githubusercontent.com/openebs/charts/master/docs/csi-operator-1.9.0.yaml
-              args:
-                executable: /bin/bash
+           - name: Downloading the csi-operator file
+             get_url:
+               url: "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator.yaml"
+               dest: "{{ playbook_dir }}/csi-operator.yaml"
+               force: yes
+             register: status
+             until:  "'OK' in status.msg"
+             delay: 5
+             retries: 3
 
-                #            - name: Identify the patch to be invoked
-                #template:
-                #src: patch.j2
-                #dest: patch.yml
+           - name: Update the desired image tag for openebs-plugin
+             replace:
+               path: "{{ playbook_dir }}/csi-operator.yaml"
+               regexp: "cstor-csi-driver:ci"
+               replace: "cstor-csi-driver:{{ image_tag }}"
 
-                #- name: Patching openebs cstor csi-driver statefulset to allow volume remount
-                #shell: >
-                #kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch "$(cat patch.yml)"
-                #register: patch_status
-                #failed_when: "'patched' not in patch_status.stdout"
+           - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04
+             shell: >
+               kubectl apply -f csi-operator.yaml
+             args:
+               executable: /bin/bash
+             register: deploy_status
+             failed_when: "deploy_status.rc != 0"
 
-                #- name: Patching openebs cstor csi-driver daemonset to allow volume remount
-                #shell: >
-                #kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch "$(cat patch.yml)"
-                #register: patch_status
-                #failed_when: "'patched' not in patch_status.stdout"
+           - name: Identify the patch to be invoked
+             template:
+               src: patch.j2
+               dest: patch.yml
+
+           # By default, volume mount is disabled. When it is enabled, the below patching tasks should be ignored.
+
+           - name: Patching openebs cstor csi-driver statefulset to allow volume remount
+             shell: >
+               kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch "$(cat patch.yml)"
+             register: patch_status
+             failed_when: "'patched' not in patch_status.stdout"
+
+           - name: Patching openebs cstor csi-driver daemonset to allow volume remount
+             shell: >
+               kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch "$(cat patch.yml)"
+             register: patch_status
+             failed_when: "'patched' not in patch_status.stdout"
 
           when: node_os == "ubuntu-16.04" or node_os == "centos"
 
         - block:
 
-            - name: Deploy CSI Driver if os is ubuntu 18.04
-              shell: >
-                kubectl apply -f https://raw.githubusercontent.com/openebs/csi/master/deploy/csi-operator-ubuntu-18.04.yaml
-              args:
-                executable: /bin/bash
+           - name: Downloading the csi-operator file
+             get_url:
+               url: "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator-ubuntu-18.04.yaml"
+               dest: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
+               force: yes
+             register: status
+             until:  "'OK' in status.msg"
+             delay: 5
+             retries: 3
 
-                #- name: Identify the patch to be invoked
-                #template:
-                #src: patch.j2
-                #dest: patch.yml
+           - name: Update the desired image tag for openebs-plugin
+             replace:
+               path: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
+               regexp: "cstor-csi-driver:ci"
+               replace: "cstor-csi-driver:{{ image_tag }}"
 
-                #  - name: Patching openebs cstor csi-driver statefulset to allow volume remount
-                #shell: >
-                #kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch "$(cat patch.yml)"
-                #register: patch_status
-                #failed_when: "'patched' not in patch_status.stdout"
-              
-                # - name: Patching openebs cstor csi-driver daemonset to allow volume remount
-                #shell: >
-                #kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch "$(cat patch.yml)"
-                #register: patch_status
-                #failed_when: "'patched' not in patch_status.stdout"    
+           - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04
+             shell: >
+               kubectl apply -f csi-operator-ubuntu-18.04.yaml
+             args:
+               executable: /bin/bash
+             register: deploy_status
+             failed_when: "deploy_status.rc != 0"
+
+           # By default, volume mount is disabled. When it is enabled, the below patching tasks should be ignored.
+
+           - name: Identify the patch to be invoked
+             template:
+               src: patch.j2
+               dest: patch.yml
+
+           - name: Patching openebs cstor csi-driver statefulset to allow volume remount
+             shell: >
+               kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch "$(cat patch.yml)"
+             register: patch_status
+             failed_when: "'patched' not in patch_status.stdout"
+
+           - name: Patching openebs cstor csi-driver daemonset to allow volume remount
+             shell: >
+               kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch "$(cat patch.yml)"
+             register: patch_status
+             failed_when: "'patched' not in patch_status.stdout"
 
           when: node_os == "ubuntu-18.04"
 
         - name: check if csi-controller pod is running
           shell: >
-            kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller 
+            kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller
             --no-headers -o custom-columns=:status.phase
           args:
             executable: /bin/bash
@@ -83,7 +123,7 @@
 
         - name: Obtain the desired number of openebs-csi-node pods
           shell: >
-            kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers 
+            kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers
             -o custom-columns=:status.desiredNumberScheduled
           args:
             executable: /bin/bash
@@ -91,7 +131,7 @@
 
         - name: Check if the desired count matches the ready pods
           command: >
-            kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers 
+            kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers
             -o custom-columns=:status.numberReady
           args:
             executable: /bin/bash
@@ -111,7 +151,7 @@
             executable: /bin/bash
           register: sc_result
           failed_when: "sc_result.rc != 0"
-          
+
         - name: Update the storage class template with the variables for FSType xfs.
           template:
             src: csi-cstor-xfs-sc.j2
@@ -123,7 +163,7 @@
             executable: /bin/bash
           register: xfs_sc_result
           failed_when: "xfs_sc_result.rc != 0"
-          
+
         - name: Update the volume snapshotclass template with the variables
           template:
             src: snapshot-class.j2
@@ -131,11 +171,11 @@
 
         - name: Create volume snapshotclass
           shell: kubectl apply -f snapshot-class.yml
-          args: 
+          args:
             executable: /bin/bash
           register: result
           failed_when: "result.rc != 0"
-              
+
         - set_fact:
             flag: "Pass"
 

--- a/providers/csi-provisioner/test_vars.yml
+++ b/providers/csi-provisioner/test_vars.yml
@@ -12,4 +12,6 @@ replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
 
 node_os: "{{ lookup('env','NODE_OS') }}"
 
+image_tag: "{{ lookup('env','IMAGE_TAG') }}"
+
 snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Picking up the manifest from cstor-csi repo based on base os
- patching the daemonset to enable remount

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```PLAY [localhost] ***************************************************************
2020-05-08T00:20:54.795384 (delta: 0.054938)         elapsed: 0.054938 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-05-08T00:20:54.807464 (delta: 0.012045)         elapsed: 0.067018 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-05-08T00:21:03.575633 (delta: 8.768148)         elapsed: 8.835187 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-05-08T00:21:03.658828 (delta: 0.083131)         elapsed: 8.918382 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-05-08T00:21:03.727025 (delta: 0.068113)         elapsed: 8.986579 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-05-08T00:21:03.798014 (delta: 0.070915)         elapsed: 9.057568 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-05-08T00:21:03.903970 (delta: 0.105908)         elapsed: 9.163524 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "af580fd43c60b8040cbac636c779b0cb4ebf449b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2d66fb549be9e3c9cae61b70ee95b9e0", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1588897263.96-150061503079527/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-05-08T00:21:04.641202 (delta: 0.737184)         elapsed: 9.900756 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.890321", "end": "2020-05-08 00:21:05.838856", "rc": 0, "start": "2020-05-08 00:21:04.948535", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-05-08T00:21:05.895123 (delta: 1.253858)         elapsed: 11.154677 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T23:38:44Z", "generation": 5, "name": "csi-provision", "resourceVersion": "279737", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "8d0d20ea-99c9-4cd2-9bc1-c1b4f2e39ed1"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-05-08T00:21:06.995531 (delta: 1.100363)         elapsed: 12.255085 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-05-08T00:21:07.052970 (delta: 0.057395)         elapsed: 12.312524 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-05-08T00:21:07.108663 (delta: 0.055607)         elapsed: 12.368217 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Downloading the csi-operator file] ***************************************
2020-05-08T00:21:07.164558 (delta: 0.055843)         elapsed: 12.424112 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the desired image tag for openebs-plugin] *************************
2020-05-08T00:21:07.226521 (delta: 0.061874)         elapsed: 12.486075 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy CSI Driver if OS is either centos or ubuntu-16.04] ****************
2020-05-08T00:21:07.290698 (delta: 0.064127)         elapsed: 12.550252 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the patch to be invoked] ****************************************
2020-05-08T00:21:07.381991 (delta: 0.0912)         elapsed: 12.641545 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching openebs cstor csi-driver statefulset to allow volume remount] ***
2020-05-08T00:21:07.446678 (delta: 0.064633)         elapsed: 12.706232 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching openebs cstor csi-driver daemonset to allow volume remount] *****
2020-05-08T00:21:07.511355 (delta: 0.064625)         elapsed: 12.770909 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Downloading the csi-operator file] ***************************************
2020-05-08T00:21:07.580452 (delta: 0.069046)         elapsed: 12.840006 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "8f8de0fd209999ac0a590040fcf50f8712c7b9c3", "dest": "/providers/csi-provisioner/csi-operator-ubuntu-18.04.yaml", "gid": 0, "group": "root", "md5sum": "02ffa536513631f65a85a3a95a459a21", "mode": "0644", "msg": "OK (38966 bytes)", "owner": "root", "size": 38966, "src": "/root/.ansible/tmp/ansible-tmp-1588897267.64-188239298282952/tmpQsztGw", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator-ubuntu-18.04.yaml"}

TASK [Update the desired image tag for openebs-plugin] *************************
2020-05-08T00:21:09.019778 (delta: 1.43927)         elapsed: 14.279332 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Deploy CSI Driver if OS is either centos or ubuntu-16.04] ****************
2020-05-08T00:21:09.472795 (delta: 0.452957)         elapsed: 14.732349 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-operator-ubuntu-18.04.yaml", "delta": "0:00:01.389390", "end": "2020-05-08 00:21:11.034749", "failed_when_result": false, "rc": 0, "start": "2020-05-08 00:21:09.645359", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumeattachments.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role created\nserviceaccount/openebs-cstor-csi-controller-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding created\nstatefulset.apps/openebs-cstor-csi-controller created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding created\nserviceaccount/openebs-cstor-csi-node-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding created\ndaemonset.apps/openebs-cstor-csi-node created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io created", "customresourcedefinition.apiextensions.k8s.io/cstorvolumeattachments.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role created", "serviceaccount/openebs-cstor-csi-controller-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding created", "statefulset.apps/openebs-cstor-csi-controller created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding created", "serviceaccount/openebs-cstor-csi-node-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding created", "daemonset.apps/openebs-cstor-csi-node created"]}

TASK [Identify the patch to be invoked] ****************************************
2020-05-08T00:21:11.105999 (delta: 1.633148)         elapsed: 16.365553 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "dc29f6d73f188848d6676646d68e121d785c61f6", "dest": "./patch.yml", "gid": 0, "group": "root", "md5sum": "da0956e6e41007229d4d44c6c34d91a7", "mode": "0644", "owner": "root", "size": 239, "src": "/root/.ansible/tmp/ansible-tmp-1588897271.17-236884379541806/source", "state": "file", "uid": 0}

TASK [Patching openebs cstor csi-driver statefulset to allow volume remount] ***
2020-05-08T00:21:11.619226 (delta: 0.513153)         elapsed: 16.87878 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch statefulset openebs-cstor-csi-controller -n kube-system --patch \"$(cat patch.yml)\"", "delta": "0:00:00.996731", "end": "2020-05-08 00:21:12.884871", "failed_when_result": false, "rc": 0, "start": "2020-05-08 00:21:11.888140", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps/openebs-cstor-csi-controller patched", "stdout_lines": ["statefulset.apps/openebs-cstor-csi-controller patched"]}

TASK [Patching openebs cstor csi-driver daemonset to allow volume remount] *****
2020-05-08T00:21:12.953818 (delta: 1.334538)         elapsed: 18.213372 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch daemonset openebs-cstor-csi-node -n kube-system --patch \"$(cat patch.yml)\"", "delta": "0:00:01.024517", "end": "2020-05-08 00:21:14.189132", "failed_when_result": false, "rc": 0, "start": "2020-05-08 00:21:13.164615", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/openebs-cstor-csi-node patched", "stdout_lines": ["daemonset.apps/openebs-cstor-csi-node patched"]}

TASK [check if csi-controller pod is running] **********************************
2020-05-08T00:21:14.260232 (delta: 1.306358)         elapsed: 19.519786 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.048561", "end": "2020-05-08 00:21:15.484722", "rc": 0, "start": "2020-05-08 00:21:14.436161", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2020-05-08T00:21:15.549994 (delta: 1.289711)         elapsed: 20.809548 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:00.853148", "end": "2020-05-08 00:21:16.602857", "rc": 0, "start": "2020-05-08 00:21:15.749709", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if the desired count matches the ready pods] ***********************
2020-05-08T00:21:16.664037 (delta: 1.113982)         elapsed: 21.923591 ******* 
FAILED - RETRYING: Check if the desired count matches the ready pods (50 retries left).
FAILED - RETRYING: Check if the desired count matches the ready pods (49 retries left).
FAILED - RETRYING: Check if the desired count matches the ready pods (48 retries left).
FAILED - RETRYING: Check if the desired count matches the ready pods (47 retries left).
FAILED - RETRYING: Check if the desired count matches the ready pods (46 retries left).
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": ["kubectl", "get", "ds", "-n", "kube-system", "openebs-cstor-csi-node", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:01.020804", "end": "2020-05-08 00:21:48.697828", "rc": 0, "start": "2020-05-08 00:21:47.677024", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Update the storage class template with the variables.] *******************
2020-05-08T00:21:48.770290 (delta: 32.106205)         elapsed: 54.029844 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2e1cd14ff4c680a82f60423c2e8d64c4478ec859", "dest": "./csi-cstor-sc.yml", "gid": 0, "group": "root", "md5sum": "79a8cafd2b514a365fc135d49566143f", "mode": "0644", "owner": "root", "size": 294, "src": "/root/.ansible/tmp/ansible-tmp-1588897308.81-138637112925459/source", "state": "file", "uid": 0}

TASK [Create Storageclass] *****************************************************
2020-05-08T00:21:49.166114 (delta: 0.395774)         elapsed: 54.425668 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-sc.yml", "delta": "0:00:01.295619", "end": "2020-05-08 00:21:50.652945", "failed_when_result": false, "rc": 0, "start": "2020-05-08 00:21:49.357326", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-csi-cstor-sparse unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-csi-cstor-sparse unchanged"]}

TASK [Update the storage class template with the variables for FSType xfs.] ****
2020-05-08T00:21:50.729904 (delta: 1.563743)         elapsed: 55.989458 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "88abdca85a789c7afb04770311352e4d645d0e4f", "dest": "./csi-cstor-xfs-sc.yml", "gid": 0, "group": "root", "md5sum": "01c5c7d2ea105fb8c3a310d1d91903cc", "mode": "0644", "owner": "root", "size": 265, "src": "/root/.ansible/tmp/ansible-tmp-1588897310.77-248744282922355/source", "state": "file", "uid": 0}

TASK [Create Storageclass for xfs FSType] **************************************
2020-05-08T00:21:51.120499 (delta: 0.390548)         elapsed: 56.380053 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-cstor-xfs-sc.yml", "delta": "0:00:01.223321", "end": "2020-05-08 00:21:52.520449", "failed_when_result": false, "rc": 0, "start": "2020-05-08 00:21:51.297128", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-csi-cstor-sparse-xfs unchanged", "stdout_lines": ["storageclass.storage.k8s.io/openebs-csi-cstor-sparse-xfs unchanged"]}

TASK [Update the volume snapshotclass template with the variables] *************
2020-05-08T00:21:52.597460 (delta: 1.47677)         elapsed: 57.857014 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "3acc77d28b85561bea6cb391fec556265a03828d", "dest": "./snapshot-class.yml", "gid": 0, "group": "root", "md5sum": "e1dff6aa0f256084d504abf4feb4c13d", "mode": "0644", "owner": "root", "size": 251, "src": "/root/.ansible/tmp/ansible-tmp-1588897312.65-223774078207267/source", "state": "file", "uid": 0}

TASK [Create volume snapshotclass] *********************************************
2020-05-08T00:21:53.046442 (delta: 0.448931)         elapsed: 58.305996 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-class.yml", "delta": "0:00:01.406258", "end": "2020-05-08 00:21:54.625369", "failed_when_result": false, "rc": 0, "start": "2020-05-08 00:21:53.219111", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor created", "stdout_lines": ["volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor created"]}

TASK [set_fact] ****************************************************************
2020-05-08T00:21:54.695876 (delta: 1.649191)         elapsed: 59.95543 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-05-08T00:21:54.774686 (delta: 0.078431)         elapsed: 60.03424 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-05-08T00:21:54.872036 (delta: 0.0973)         elapsed: 60.13159 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-05-08T00:21:54.936563 (delta: 0.064477)         elapsed: 60.196117 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-05-08T00:21:55.086748 (delta: 0.150133)         elapsed: 60.346302 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-05-08T00:21:55.160452 (delta: 0.073664)         elapsed: 60.420006 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8465df021b7326c95c9856682eb50700e84d8dc7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "685bbc60e191086cf7d2cf0f55be2022", "mode": "0644", "owner": "root", "size": 412, "src": "/root/.ansible/tmp/ansible-tmp-1588897315.22-6939034351110/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-05-08T00:21:57.153082 (delta: 1.992571)         elapsed: 62.412636 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.820975", "end": "2020-05-08 00:21:58.159559", "rc": 0, "start": "2020-05-08 00:21:57.338584", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-05-08T00:21:58.220358 (delta: 1.067013)         elapsed: 63.479912 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T23:38:44Z", "generation": 6, "name": "csi-provision", "resourceVersion": "280212", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-provision", "uid": "8d0d20ea-99c9-4cd2-9bc1-c1b4f2e39ed1"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=26   changed=21   unreachable=0    failed=0   

```
