### PR TITLE
refactor[pool-scaleup]: Modified the patch command for the pool expansion test case

### DIFF
--- a/experiments/functional/day2_ops/cspc_pool/pool_expansion/add_blockdevice.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_expansion/add_blockdevice.yml
@@ -18,7 +18,7 @@
     - block:
         - name: Patch the CSPC to expand the pool size
           shell: >
-            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/raidGroups/0/blockDevices/0", "value": {"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"}}]'
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0/blockDevices/0", "value": {"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"}}]'
           args:
             executable: /bin/bash
           register: patch_cspc
@@ -28,7 +28,7 @@
     - block:
         - name: Patch the CSPC to expand the pool size
           shell: >
-            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/raidGroups/0", "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"}],"type": "mirror"}}]'                  
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0", "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"}],"type": "mirror"}}]'                  
           args:
             executable: /bin/bash
           register: patch_cspc
@@ -39,7 +39,7 @@
         - name: Patch the CSPC to expand the pool size
           shell: >
             kubectl patch cspc -n {{ operator_ns }}
-            {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/raidGroups/0",
+            {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0",
             "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},
             {"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"},
             {"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'"}],"type": "raidz"}}]'
@@ -53,7 +53,7 @@
         - name: Patch the CSPC to expand the pool size
           shell: >
             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }}
-            --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/raidGroups/0",
+            --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0",
             "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},
             {"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'"},
             {"blockDeviceName": "'{{ blockDevice.stdout_lines[3] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[4] }}'"},


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the patch command for the pool expansion test case

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
