### PR TITLE
refactor[pool-scaleup]: Modified the patch command for the pool scaleup test case

### DIFF
--- a/experiments/functional/day2_ops/cspc_pool/pool_scaleup/add_blockdevice.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_scaleup/add_blockdevice.yml
@@ -13,7 +13,7 @@
     - block:
         - name: Patch the CSPC to expand the pool size
           shell: >
-            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "stripe", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "stripe" }]}}]'
+             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"dataRaidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'" }]}], "nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"dataRaidGroupType": "stripe"}}}]'
           args:
             executable: /bin/bash
           register: patch_cspc
@@ -23,7 +23,7 @@
     - block:
         - name: Patch the CSPC to expand the pool size
           shell: >
-             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "mirror", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "mirror" }]}}]'
+             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"dataRaidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"}]}], "nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"dataRaidGroupType": "mirror"}}}]'
           args:
             executable: /bin/bash
           register: patch_cspc
@@ -33,7 +33,7 @@
     - block:
         - name: Patch the CSPC to expand the pool size
           shell: >
-            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "raidz", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'", "capacity": "", "devLink": "" },,{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "raidz" }]}}]'
+             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"dataRaidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'"}]}], "nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"dataRaidGroupType": "raidz"}}}]'
           args:
             executable: /bin/bash
           register: patch_cspc
@@ -43,7 +43,7 @@
     - block:
         - name: Patch the CSPC to expand the pool size
           shell: >
-            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"cacheFile": "", "compression": "off", "defaultRaidGroupType": "raidz2", "overProvisioning": false, "priorityClassName": ""}, "raidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[3] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[4] }}'", "capacity": "", "devLink": "" },{"blockDeviceName": "'{{ blockDevice.stdout_lines[5] }}'", "capacity": "", "devLink": "" }], "isReadCache": false, "isSpare": false, "isWriteCache": false, "type": "raidz2" }]}}]'
+             kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/0", "value": {"dataRaidGroups": [{"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[3] }}'"}]}], "nodeSelector": {"kubernetes.io/hostname": "'{{ outer_item }}'"},   "poolConfig": {"dataRaidGroupType": "raidz2"}}}]'
           args:
             executable: /bin/bash
           register: patch_cspc


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Changed the patch command for pool scaleup test case

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
