### PR TITLE
refactor[yaml]: Modified the access mode check of jiva replicas

### DIFF
--- a/funclib/openebs/access-mode-check.yml
+++ b/funclib/openebs/access-mode-check.yml
@@ -6,12 +6,16 @@
          register: pv_name
          changed_when: True
 
-       - name: Get the nodes count
-         shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | wc -l
+       - name: Get the controller deployment name 
+         shell: kubectl get deployment -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
          args:
            executable: /bin/bash
-         register: node_count
+         register: ctrl_deployment
 
+       - name: Obtaining the replication factor count from controller deployment
+         shell: kubectl get deployments {{ ctrl_deployment.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'    
+         register: replication_factor_count
+       
        - name: Get the maya-apiserver pod name
          shell:  kubectl get pods -n {{ operator_ns }} -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'
          args:
@@ -35,7 +39,7 @@
          args:
            executable: /bin/bash
          register: result
-         until: result.stdout| int == node_count.stdout | int
+         until: result.stdout| int == replication_factor_count.stdout | int
          delay: 30
          retries: 30
          changed_when: True


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified the access mode check of jiva replicas. Earlier replica access mode(RW) was getting verified with node count. Now, modified the verification with replication factor.
**Special notes for your reviewer**:
```
TASK [Check the replicas access mode] ******************************************
2020-05-11T06:17:36.355341 (delta: 0.092535)         elapsed: 73.526677 ******* 
included: /funclib/openebs/access-mode-check.yml for 127.0.0.1

TASK [Get the pv name] *********************************************************
2020-05-11T06:17:36.572819 (delta: 0.217402)         elapsed: 73.744155 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n test4 -o jsonpath='{.spec.volumeName}'", "delta": "0:00:01.265351", "end": "2020-05-11 06:17:38.081565", "rc": 0, "start": "2020-05-11 06:17:36.816214", "stderr": "", "stderr_lines": [], "stdout": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d", "stdout_lines": ["pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d"]}

TASK [Get the controller deployment name] **************************************
2020-05-11T06:17:38.168237 (delta: 1.59534)         elapsed: 75.339573 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n openebs -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=\"pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d\" -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.159486", "end": "2020-05-11 06:17:39.573842", "rc": 0, "start": "2020-05-11 06:17:38.414356", "stderr": "", "stderr_lines": [], "stdout": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl", "stdout_lines": ["pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl"]}

TASK [Obtaining the replication factor count from controller deployment] *******
2020-05-11T06:17:39.673517 (delta: 1.505198)         elapsed: 76.844853 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployments pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl -n openebs -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'", "delta": "0:00:01.093443", "end": "2020-05-11 06:17:41.039495", "rc": 0, "start": "2020-05-11 06:17:39.946052", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Get the maya-apiserver pod name] *****************************************
2020-05-11T06:17:41.130413 (delta: 1.456825)         elapsed: 78.301749 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.345116", "end": "2020-05-11 06:17:42.743526", "rc": 0, "start": "2020-05-11 06:17:41.398410", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-7d458584b7-4wpvg", "stdout_lines": ["maya-apiserver-7d458584b7-4wpvg"]}

TASK [Get the volume list] *****************************************************
2020-05-11T06:17:42.851149 (delta: 1.720658)         elapsed: 80.022485 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-7d458584b7-4wpvg -n openebs -- mayactl volume list", "delta": "0:00:01.731389", "end": "2020-05-11 06:17:45.024933", "rc": 0, "start": "2020-05-11 06:17:43.293544", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Namespace  Name                                      Status   Type  Capacity  StorageClass             Access Mode\n---------  ----                                      ------   ----  --------  -------------            -----------\nopenebs    pvc-12851d3b-0671-4682-9a8b-6410de57e50e  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-24f3fee9-3ad5-4120-adb0-cd57663ba48e  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-457dc60b-1eb7-467a-b32e-499a322b6dca  Running  jiva  5Gi       openebs-jiva-default     ReadWriteOnce\nopenebs    pvc-496e906c-1d10-4aa5-814d-3caa36b86744  Running  jiva  5G        jiva-snapshot-sc-9lk9n   ReadWriteOnce\nopenebs    pvc-5aed2b1c-93d0-472d-ab4f-c53713aa103c  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-68b0e596-f11b-41f0-ad19-5315f187efc9  Running  jiva  5Gi       jiva                     ReadWriteOnce\nopenebs    pvc-6a8d538c-3a4a-4d6c-a449-32418b72df8a  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-76cc7125-ec3f-45ff-a2d2-a2d4e096e908  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce\nopenebs    pvc-a1033627-da56-4e1c-9c5e-dcd09089b577  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "stdout_lines": ["Namespace  Name                                      Status   Type  Capacity  StorageClass             Access Mode", "---------  ----                                      ------   ----  --------  -------------            -----------", "openebs    pvc-12851d3b-0671-4682-9a8b-6410de57e50e  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-24f3fee9-3ad5-4120-adb0-cd57663ba48e  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-457dc60b-1eb7-467a-b32e-499a322b6dca  Running  jiva  5Gi       openebs-jiva-default     ReadWriteOnce", "openebs    pvc-496e906c-1d10-4aa5-814d-3caa36b86744  Running  jiva  5G        jiva-snapshot-sc-9lk9n   ReadWriteOnce", "openebs    pvc-5aed2b1c-93d0-472d-ab4f-c53713aa103c  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-68b0e596-f11b-41f0-ad19-5315f187efc9  Running  jiva  5Gi       jiva                     ReadWriteOnce", "openebs    pvc-6a8d538c-3a4a-4d6c-a449-32418b72df8a  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-76cc7125-ec3f-45ff-a2d2-a2d4e096e908  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce", "openebs    pvc-a1033627-da56-4e1c-9c5e-dcd09089b577  Running  jiva  5Gi       openebs-jiva-standalone  ReadWriteOnce"]}

TASK [Get the replicas access mode] ********************************************
2020-05-11T06:17:45.128881 (delta: 2.277659)         elapsed: 82.300217 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-7d458584b7-4wpvg -n openebs -- mayactl volume describe --volname \"pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d\" -n test4 | grep 'RW' | wc -l", "delta": "0:00:02.000952", "end": "2020-05-11 06:17:47.384185", "rc": 0, "start": "2020-05-11 06:17:45.383233", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [debug] *******************************************************************
2020-05-11T06:17:47.489298 (delta: 2.360346)         elapsed: 84.660634 ******* 
ok: [127.0.0.1] => {
    "msg": "All the replicas are in sync"
}

TASK [set_fact] ****************************************************************
2020-05-11T06:17:47.630494 (delta: 0.141119)         elapsed: 84.80183 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

```