### PR TITLE
refactor[upgrade]: Modified the tasks to verify the replica version

### DIFF
--- a/providers/openebs/bulk-upgrade/test.yml
+++ b/providers/openebs/bulk-upgrade/test.yml
@@ -546,6 +546,10 @@
               with_items:
                   - "{{ pv_name.stdout_lines }}"              
 
+            - name: Create an empty list of cstor replicas
+              set_fact:
+                cstor_replicas: []
+
             - name: Obtain the CVR name to verify the current version
               shell: >
                 kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ item }}
@@ -555,6 +559,11 @@
               with_items:
                   - "{{ pv_name.stdout_lines }}"              
 
+            - name: Build a list of replica pods
+              set_fact:
+                cstor_replicas: "{{ cstor_replicas }} + [ '{{ item.stdout }}' ]"
+              with_items: "{{ cvr_name.results }}"
+
             - name: Check if the CVRs are upgraded to newer version
               shell: >
                  kubectl get cvr -n {{ operator_ns }} {{ item }}
@@ -562,7 +571,7 @@
               register: cvr_version
               failed_when: "cvr_version.stdout != new_version"
               with_items:
-                  - "{{ cvr_name.stdout_lines }}"
+                  - "{{ cstor_replicas }}"
 
           when: upgrade_cstor == "true"
 
@@ -630,21 +639,30 @@
               with_items:
                   - "{{ jiva_pv_name.stdout_lines }}"              
 
+            - name: Create an empty list of jiva replicas
+              set_fact:
+                jiva_replicas: []
+
             - name: Obtain the name of the replica
               shell: >
                 kubectl get deploy -n {{ operator_ns }} -l openebs.io/persistent-volume={{ item }},openebs.io/replica=jiva-replica
                 -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
               register: rep_name
               with_items:
-                  - "{{ jiva_pv_name.stdout_lines }}"              
+                  - "{{ jiva_pv_name.stdout_lines }}"
+
+            - name: Build a list of replica pods
+              set_fact:
+                jiva_replicas: "{{ jiva_replicas }} + [ '{{ item.stdout }}' ]"
+              with_items: "{{ rep_name.results }}"
 
             - name: Check if the replica has been upgraded to latest version
               shell: >
-                kubectl get deploy -n {{ operator_ns }} 
+                kubectl get deploy -n {{ operator_ns }}
                 -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].metadata.labels.openebs\.io\/version}'
               register: rep_version
               with_items:
-                  - "{{ rep_name.stdout_lines }}"
+                  - "{{ jiva_replicas }}"
               failed_when: "rep_version.stdout != new_version"
 
           when: upgrade_jiva == "true"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>
- Modified the condition to verify the replica version
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
