### PR TITLE
refactor[yaml]: Modified the command for verification of replica disconnection

### DIFF
--- a/chaoslib/openebs/jiva_replica_network_delay.yaml
+++ b/chaoslib/openebs/jiva_replica_network_delay.yaml
@@ -93,7 +93,15 @@
     executable: /bin/bash
   register: rcount_before
 
-- name: Identify the pumba pod that co-exists with jiva controller
+- name: Getting the RestartCount before injecting delay
+  shell: >
+   kubectl get pod "{{ jiva_replica_pod.stdout }}" -n {{ operator_ns }} --no-headers 
+   -o jsonpath='{.status.containerStatuses[].restartCount}'
+  args:
+    executable: /bin/bash
+  register: restart_count_before
+
+- name: Identify the pumba pod that co-exists with jiva replica (targeted for network delay)
   shell: >
     kubectl get pods -l app=pumba -n {{ app_ns }} 
     -o jsonpath='{.items[?(@.spec.nodeName==''"{{ node.stdout }}"'')].metadata.name}'
@@ -101,7 +109,7 @@
     executable: /bin/bash
   register: pumba_pod
 
-- name: Inject egress delay of {{network_delay}}ms on jiva controller for {{ chaos_duration }}ms
+- name: Inject egress delay of {{network_delay}}ms on jiva replica for {{ chaos_duration }}ms
   shell: >
     kubectl exec {{ pumba_pod.stdout }} -n {{ app_ns }} 
     -- pumba netem --interface eth0 --duration {{ chaos_duration }}ms delay
@@ -111,12 +119,12 @@
 
 - name: Verifying the Replica getting disconnected
   shell: >
-   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
-   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+   kubectl get pod "{{ jiva_replica_pod.stdout }}" -n {{ operator_ns }} --no-headers 
+   -o jsonpath='{.status.containerStatuses[].restartCount}'
   args:
     executable: /bin/bash
   register: resp
-  until: resp.stdout != rcount_before.stdout
+  until: resp.stdout != restart_count_before.stdout
   retries: 10
   delay: 15
 


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
After removing the delay, replica is getting attached very fast and controller is not able to catch the  disconnection as the delay is removed. So for verification of replica disconnection restart count have been used here.

**Special notes for your reviewer**:
```
PLAY [localhost] ***************************************************************
2020-05-11T16:00:23.350133 (delta: 0.085217)         elapsed: 0.085217 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:2
2020-05-11T16:00:23.367714 (delta: 0.017492)         elapsed: 0.102798 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:11
2020-05-11T16:00:34.283636 (delta: 10.915842)         elapsed: 11.01872 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:2
2020-05-11T16:00:34.436954 (delta: 0.153239)         elapsed: 11.172038 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n test4 --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.588601", "end": "2020-05-11 16:00:36.629603", "rc": 0, "start": "2020-05-11 16:00:35.041002", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-standalone", "stdout_lines": ["openebs-jiva-standalone"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:10
2020-05-11T16:00:36.755864 (delta: 2.318733)         elapsed: 13.490948 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-standalone --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.078630", "end": "2020-05-11 16:00:38.072197", "rc": 0, "start": "2020-05-11 16:00:36.993567", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:18
2020-05-11T16:00:38.151052 (delta: 1.395068)         elapsed: 14.886136 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-standalone"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:22
2020-05-11T16:00:38.288895 (delta: 0.137768)         elapsed: 15.023979 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:27
2020-05-11T16:00:38.406617 (delta: 0.117633)         elapsed: 15.141701 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n test4 --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.090061", "end": "2020-05-11 16:00:39.786878", "rc": 0, "start": "2020-05-11 16:00:38.696817", "stderr": "", "stderr_lines": [], "stdout": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d", "stdout_lines": ["pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:35
2020-05-11T16:00:39.885483 (delta: 1.478794)         elapsed: 16.620567 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.098097", "end": "2020-05-11 16:00:41.258851", "rc": 0, "start": "2020-05-11 16:00:40.160754", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:43
2020-05-11T16:00:41.366505 (delta: 1.480946)         elapsed: 18.101589 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_replica_network_delay/test_prerequisites.yml:48
2020-05-11T16:00:41.499455 (delta: 0.132867)         elapsed: 18.234539 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cc41594b9e756bd386a5f8aefa6f4406bb8500fb", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "c4e8e343052a60e26ff990195e2675d5", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1589212841.56-144357794147255/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:18
2020-05-11T16:00:42.701164 (delta: 1.20163)         elapsed: 19.436248 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_replica_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_replica_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:21
2020-05-11T16:00:42.868816 (delta: 0.167583)         elapsed: 19.6039 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_replica_network_delay.yaml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:27
2020-05-11T16:00:43.132377 (delta: 0.263482)         elapsed: 19.867461 ******* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-05-11T16:00:43.313964 (delta: 0.181514)         elapsed: 20.049048 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-05-11T16:00:43.424462 (delta: 0.110425)         elapsed: 20.159546 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:29
2020-05-11T16:00:43.528443 (delta: 0.10391)         elapsed: 20.263527 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-11T16:00:43.678680 (delta: 0.150162)         elapsed: 20.413764 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "443a1dcd12c02b289a1b7a96be0b3ba148072b96", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4a2eb222bfccd1a2105b7468f0c61247", "mode": "0644", "owner": "root", "size": 464, "src": "/root/.ansible/tmp/ansible-tmp-1589212843.75-6496238984937/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-11T16:00:44.364492 (delta: 0.685725)         elapsed: 21.099576 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.006096", "end": "2020-05-11 16:00:45.657371", "rc": 0, "start": "2020-05-11 16:00:44.651275", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-replica-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-replica-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-11T16:00:45.762540 (delta: 1.397953)         elapsed: 22.497624 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T10:25:28Z", "generation": 16, "name": "openebs-replica-network-delay", "resourceVersion": "6449782", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-replica-network-delay", "uid": "d7e69c8f-8e93-4d43-8e26-f9a19b723ebe"}, "spec": {"testMetadata": {"chaostype": "openebs/jiva_replica_network_delay"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-11T16:00:47.777400 (delta: 2.014778)         elapsed: 24.512484 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-11T16:00:47.889628 (delta: 0.112073)         elapsed: 24.624712 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-11T16:00:47.997765 (delta: 0.108045)         elapsed: 24.732849 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:36
2020-05-11T16:00:48.124399 (delta: 0.126552)         elapsed: 24.859483 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : test4", 
        "Label        : app=busybox-sts", 
        "PVC          : openebs-busybox", 
        "StorageClass : openebs-jiva-standalone"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:47
2020-05-11T16:00:48.319208 (delta: 0.194712)         elapsed: 25.054292 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-05-11T16:00:48.549825 (delta: 0.230508)         elapsed: 25.284909 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n test4 -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.205403", "end": "2020-05-11 16:00:50.105455", "rc": 0, "start": "2020-05-11 16:00:48.900052", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-11T06:14:31Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-11T06:14:31Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-05-11T16:00:50.224462 (delta: 1.674552)         elapsed: 26.959546 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n test4 -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.295454", "end": "2020-05-11 16:00:51.791960", "rc": 0, "start": "2020-05-11 16:00:50.496506", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:56
2020-05-11T16:00:51.938952 (delta: 1.713541)         elapsed: 28.674036 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n test4 -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.507346", "end": "2020-05-11 16:00:53.781297", "rc": 0, "start": "2020-05-11 16:00:52.273951", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-4b2gb", "stdout_lines": ["app-busybox-85d45b855f-4b2gb"]}

TASK [Create some test data in the mysql database] *****************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:64
2020-05-11T16:00:53.868754 (delta: 1.929718)         elapsed: 30.603838 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:78
2020-05-11T16:00:54.003973 (delta: 0.134966)         elapsed: 30.739057 ******* 
included: /chaoslib/openebs/jiva_replica_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:1
2020-05-11T16:00:54.292887 (delta: 0.288827)         elapsed: 31.027971 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n test4", "delta": "0:00:01.589616", "end": "2020-05-11 16:00:56.205702", "rc": 0, "start": "2020-05-11 16:00:54.616086", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/pumba unchanged", "stdout_lines": ["daemonset.apps/pumba unchanged"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:9
2020-05-11T16:00:56.331309 (delta: 2.038071)         elapsed: 33.066393 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n test4 | sort | uniq", "delta": "0:00:01.152595", "end": "2020-05-11 16:00:57.854758", "rc": 0, "start": "2020-05-11 16:00:56.702163", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:21
2020-05-11T16:00:57.984968 (delta: 1.653587)         elapsed: 34.720052 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -o custom-columns=:spec.volumeName -n test4 --no-headers", "delta": "0:00:01.368550", "end": "2020-05-11 16:00:59.678141", "rc": 0, "start": "2020-05-11 16:00:58.309591", "stderr": "", "stderr_lines": [], "stdout": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d", "stdout_lines": ["pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d"]}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:30
2020-05-11T16:00:59.763736 (delta: 1.778676)         elapsed: 36.49882 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume=\"pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d\" -n openebs --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:01.141713", "end": "2020-05-11 16:01:01.164657", "rc": 0, "start": "2020-05-11 16:01:00.022944", "stderr": "", "stderr_lines": [], "stdout": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-74c9d6bbd4-jzmgs", "stdout_lines": ["pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-74c9d6bbd4-jzmgs"]}

TASK [Record the jiva controller container name] *******************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:38
2020-05-11T16:01:01.258395 (delta: 1.494407)         elapsed: 37.993479 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_name": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-con"}, "changed": false}

TASK [Identify the jiva replica pod belonging to the PV] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:43
2020-05-11T16:01:01.390940 (delta: 0.13247)         elapsed: 38.126024 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n openebs --no-headers | grep pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d | awk 'FNR == 1 {print}'| awk {'print $1'}", "delta": "0:00:01.551783", "end": "2020-05-11 16:01:03.355618", "rc": 0, "start": "2020-05-11 16:01:01.803835", "stderr": "", "stderr_lines": [], "stdout": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-1-6cb78946dd-l4zzm", "stdout_lines": ["pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-1-6cb78946dd-l4zzm"]}

TASK [Record the jiva replica container name] **********************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:52
2020-05-11T16:01:03.452757 (delta: 2.061741)         elapsed: 40.187841 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_name": "pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-con"}, "changed": false}

TASK [Get the node on which the jiva replica is scheduled] *********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:57
2020-05-11T16:01:03.586104 (delta: 0.133253)         elapsed: 40.321188 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-1-6cb78946dd-l4zzm -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.240117", "end": "2020-05-11 16:01:05.064620", "rc": 0, "start": "2020-05-11 16:01:03.824503", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1", "stdout_lines": ["e2e1-node1"]}

TASK [Get controller svc] ******************************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:65
2020-05-11T16:01:05.180598 (delta: 1.594426)         elapsed: 41.915682 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume=\"pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d\" -n openebs -o=jsonpath='{.items[0].spec.clusterIP}'", "delta": "0:00:01.310673", "end": "2020-05-11 16:01:06.773096", "failed_when_result": false, "rc": 0, "start": "2020-05-11 16:01:05.462423", "stderr": "", "stderr_lines": [], "stdout": "10.102.106.146", "stdout_lines": ["10.102.106.146"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:74
2020-05-11T16:01:06.863723 (delta: 1.682924)         elapsed: 43.598807 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-74c9d6bbd4-jzmgs -n openebs -c pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:10.589684", "end": "2020-05-11 16:01:17.779360", "rc": 0, "start": "2020-05-11 16:01:07.189676", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease\nHit:2 http://security.ubuntu.com/ubuntu xenial-security InRelease\nHit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease\nHit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\njq is already the newest version (1.5+dfsg-1ubuntu0.1).\n0 upgraded, 0 newly installed, 0 to remove and 33 not upgraded.\nReading package lists...\nBuilding dependency tree...\nReading state information...\niproute2 is already the newest version (4.3.0-1ubuntu3.16.04.5).\n0 upgraded, 0 newly installed, 0 to remove and 33 not upgraded.", "stdout_lines": ["Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease", "Hit:2 http://security.ubuntu.com/ubuntu xenial-security InRelease", "Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease", "Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "jq is already the newest version (1.5+dfsg-1ubuntu0.1).", "0 upgraded, 0 newly installed, 0 to remove and 33 not upgraded.", "Reading package lists...", "Building dependency tree...", "Reading state information...", "iproute2 is already the newest version (4.3.0-1ubuntu3.16.04.5).", "0 upgraded, 0 newly installed, 0 to remove and 33 not upgraded."]}

TASK [Install jq package inside a replica container] ***************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:81
2020-05-11T16:01:17.866822 (delta: 11.002968)         elapsed: 54.601906 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-1-6cb78946dd-l4zzm -n openebs -c pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:15.947270", "end": "2020-05-11 16:01:34.134593", "rc": 0, "start": "2020-05-11 16:01:18.187323", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1101 kB]\nGet:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [624 kB]\nGet:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6680 B]\nGet:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1470 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1029 kB]\nGet:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.7 kB]\nGet:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]\nFetched 16.4 MB in 4s (3907 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 1s (221 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5294 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libatm1 libmnl0 libxtables11\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2 libatm1 libmnl0 libxtables11\n0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 586 kB of archives.\nAfter this operation, 1809 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]\nFetched 586 kB in 1s (477 kB/s)\nSelecting previously unselected package libatm1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5306 files and directories currently installed.)\r\nPreparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...\r\nUnpacking libatm1:amd64 (1:2.5.1-1.5) ...\r\nSelecting previously unselected package libmnl0:amd64.\r\nPreparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...\r\nUnpacking libmnl0:amd64 (1.0.3-5) ...\r\nSelecting previously unselected package iproute2.\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSelecting previously unselected package libxtables11:amd64.\r\nPreparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...\r\nUnpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...\r\nSetting up libatm1:amd64 (1:2.5.1-1.5) ...\r\nSetting up libmnl0:amd64 (1.0.3-5) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...\r\nSetting up libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu11) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1101 kB]", "Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [624 kB]", "Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6680 B]", "Get:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1470 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1029 kB]", "Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.7 kB]", "Get:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]", "Fetched 16.4 MB in 4s (3907 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 1s (221 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5294 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libatm1 libmnl0 libxtables11", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2 libatm1 libmnl0 libxtables11", "0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.", "Need to get 586 kB of archives.", "After this operation, 1809 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.5 [523 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]", "Fetched 586 kB in 1s (477 kB/s)", "Selecting previously unselected package libatm1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5306 files and directories currently installed.)", "Preparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...", "Unpacking libatm1:amd64 (1:2.5.1-1.5) ...", "Selecting previously unselected package libmnl0:amd64.", "Preparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...", "Unpacking libmnl0:amd64 (1.0.3-5) ...", "Selecting previously unselected package iproute2.", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.5_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Selecting previously unselected package libxtables11:amd64.", "Preparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...", "Unpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ...", "Setting up libatm1:amd64 (1:2.5.1-1.5) ...", "Setting up libmnl0:amd64 (1.0.3-5) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.5) ...", "Setting up libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu11) ..."]}

TASK [Getting the ReplicaCount before injecting delay] *************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:88
2020-05-11T16:01:34.234213 (delta: 16.367294)         elapsed: 70.969297 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-74c9d6bbd4-jzmgs -n openebs -c pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-con curl http://\"10.102.106.146\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.436126", "end": "2020-05-11 16:01:35.987674", "rc": 0, "start": "2020-05-11 16:01:34.551548", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1158  100  1158    0     0   378k      0 --:--:-- --:--:-- --:--:-- 1130k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1158  100  1158    0     0   378k      0 --:--:-- --:--:-- --:--:-- 1130k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the RestartCount before injecting delay] *************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:96
2020-05-11T16:01:36.085367 (delta: 1.851078)         elapsed: 72.820451 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod \"pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-1-6cb78946dd-l4zzm\" -n openebs --no-headers -o jsonpath='{.status.containerStatuses[].restartCount}'", "delta": "0:00:01.147084", "end": "2020-05-11 16:01:37.563286", "rc": 0, "start": "2020-05-11 16:01:36.416202", "stderr": "", "stderr_lines": [], "stdout": "4", "stdout_lines": ["4"]}

TASK [Identify the pumba pod that co-exists with jiva replica (targeted for network delay)] ***
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:104
2020-05-11T16:01:37.644932 (delta: 1.559271)         elapsed: 74.380016 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n test4 -o jsonpath='{.items[?(@.spec.nodeName==''\"e2e1-node1\"'')].metadata.name}'", "delta": "0:00:01.191302", "end": "2020-05-11 16:01:39.072284", "rc": 0, "start": "2020-05-11 16:01:37.880982", "stderr": "", "stderr_lines": [], "stdout": "pumba-htk27", "stdout_lines": ["pumba-htk27"]}

TASK [Inject egress delay of 60000ms on jiva replica for 60000ms] **************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:112
2020-05-11T16:01:39.210029 (delta: 1.565029)         elapsed: 75.945113 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-htk27 -n test4 -- pumba netem --interface eth0 --duration 60000ms delay --time 60000 re2:k8s_pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-con", "delta": "0:01:04.775896", "end": "2020-05-11 16:02:44.240075", "rc": 0, "start": "2020-05-11 16:01:39.464179", "stderr": "time=\"2020-05-11T16:01:40Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2020-05-11T16:01:43Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76 for 1m0s\" \ntime=\"2020-05-11T16:01:43Z\" level=info msg=\"Start netem for container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2020-05-11T16:02:43Z\" level=info msg=\"Stopping netem on container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76\" \ntime=\"2020-05-11T16:02:43Z\" level=info msg=\"Stop netem for container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76 on 'eth0'\" ", "stderr_lines": ["time=\"2020-05-11T16:01:40Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2020-05-11T16:01:43Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76 for 1m0s\" ", "time=\"2020-05-11T16:01:43Z\" level=info msg=\"Start netem for container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2020-05-11T16:02:43Z\" level=info msg=\"Stopping netem on container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76\" ", "time=\"2020-05-11T16:02:43Z\" level=info msg=\"Stop netem for container 749caf4337845944f7220fea20a0eb643ea09f0ee59fd0fbe994d4561a915e76 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Verifying the Replica getting disconnected] ******************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:120
2020-05-11T16:02:44.432166 (delta: 65.222059)         elapsed: 141.16725 ****** 
FAILED - RETRYING: Verifying the Replica getting disconnected (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod \"pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-rep-1-6cb78946dd-l4zzm\" -n openebs --no-headers -o jsonpath='{.status.containerStatuses[].restartCount}'", "delta": "0:00:01.298973", "end": "2020-05-11 16:03:02.828373", "rc": 0, "start": "2020-05-11 16:03:01.529400", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:131
2020-05-11T16:03:02.919572 (delta: 18.487334)         elapsed: 159.654656 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n test4", "delta": "0:00:01.105444", "end": "2020-05-11 16:03:04.345608", "rc": 0, "start": "2020-05-11 16:03:03.240164", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps \"pumba\" deleted", "stdout_lines": ["daemonset.apps \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:137
2020-05-11T16:03:04.437312 (delta: 1.517621)         elapsed: 161.172396 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n test4", "delta": "0:00:01.731330", "end": "2020-05-11 16:03:06.495274", "rc": 0, "start": "2020-05-11 16:03:04.763944", "stderr": "", "stderr_lines": [], "stdout": "pumba-htk27   1/1   Terminating   0     18m\npumba-l6s28   0/1   Terminating   0     18m\npumba-w4zqc   0/1   Terminating   0     18m", "stdout_lines": ["pumba-htk27   1/1   Terminating   0     18m", "pumba-l6s28   0/1   Terminating   0     18m", "pumba-w4zqc   0/1   Terminating   0     18m"]}

TASK [Verifying the replicas post network recovery] ****************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:147
2020-05-11T16:03:06.658874 (delta: 2.221489)         elapsed: 163.393958 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-74c9d6bbd4-jzmgs -n openebs -c pvc-9f7a4367-b396-41b7-b36b-28e93291bb2d-ctrl-con curl http://\"10.102.106.146\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.405324", "end": "2020-05-11 16:03:08.319048", "rc": 0, "start": "2020-05-11 16:03:06.913724", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1158  100  1158    0     0   407k      0 --:--:-- --:--:-- --:--:--  565k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1158  100  1158    0     0   407k      0 --:--:-- --:--:-- --:--:--  565k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:85
2020-05-11T16:03:08.414816 (delta: 1.75584)         elapsed: 165.1499 ********* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-05-11T16:03:08.609028 (delta: 0.194081)         elapsed: 165.344112 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n test4 -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.082663", "end": "2020-05-11 16:03:09.921648", "rc": 0, "start": "2020-05-11 16:03:08.838985", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-11T06:14:31Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-11T06:14:31Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-05-11T16:03:10.035802 (delta: 1.426705)         elapsed: 166.770886 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n test4 -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.180337", "end": "2020-05-11 16:03:11.536831", "rc": 0, "start": "2020-05-11 16:03:10.356494", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:94
2020-05-11T16:03:11.646932 (delta: 1.611064)         elapsed: 168.382016 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:97
2020-05-11T16:03:11.800270 (delta: 0.153155)         elapsed: 168.535354 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:109
2020-05-11T16:03:11.917100 (delta: 0.116745)         elapsed: 168.652184 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_replica_network_delay/test.yml:120
2020-05-11T16:03:12.024343 (delta: 0.107164)         elapsed: 168.759427 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-11T16:03:12.199358 (delta: 0.174954)         elapsed: 168.934442 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-11T16:03:12.329620 (delta: 0.130041)         elapsed: 169.064704 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-11T16:03:12.498715 (delta: 0.169013)         elapsed: 169.233799 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-11T16:03:12.648941 (delta: 0.150155)         elapsed: 169.384025 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "47915e31a46564f7297b4020a66371f050b5979d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0ecc5235fdbbc77eca4a60ab61ea7117", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1589212992.75-22064289805413/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-11T16:03:15.428078 (delta: 2.779068)         elapsed: 172.163162 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.897166", "end": "2020-05-11 16:03:16.579509", "rc": 0, "start": "2020-05-11 16:03:15.682343", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-replica-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-replica-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-11T16:03:16.649536 (delta: 1.220696)         elapsed: 173.38462 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-07T10:25:28Z", "generation": 17, "name": "openebs-replica-network-delay", "resourceVersion": "6450416", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-replica-network-delay", "uid": "d7e69c8f-8e93-4d43-8e26-f9a19b723ebe"}, "spec": {"testMetadata": {"chaostype": "openebs/jiva_replica_network_delay"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=49   changed=33   unreachable=0    failed=0   

2020-05-11T16:03:18.035167 (delta: 1.385571)         elapsed: 174.770251 ****** 
=============================================================================== 
```
