### PR TITLE
refactor[script]: Modified the node_failure case

### DIFF
--- a/experiments/chaos/node_failure/prerequisites.yml
+++ b/experiments/chaos/node_failure/prerequisites.yml
@@ -1,0 +1,46 @@
+---
+- name: Identify the storage class used by the PVC
+  shell: >
+    kubectl get pvc {{ pvc }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:spec.storageClassName
+  args:
+    executable: /bin/bash
+  register: storage_class
+
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }}
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
+- name: Record the storage class name
+  set_fact: 
+    sc: "{{ storage_class.stdout }}"
+
+- name: Record the storage provisioner name
+  set_fact:
+    stg_prov: "{{ provisioner.stdout }}"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
+        kubectl get pv {{ pv.stdout }} --no-headers
+        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "openebs.io/provisioner-iscsi"

--- a/experiments/chaos/node_failure/run_litmus_test.yml
+++ b/experiments/chaos/node_failure/run_litmus_test.yml
@@ -55,6 +55,9 @@ spec:
           - name: APP_LABEL
             value: 'name=percona'
 
+          - name: APP_PVC
+            value: ''
+            
           # The platform where k8s cluster is created.
           - name: PLATFORM
             value: "vmware"

--- a/experiments/chaos/node_failure/test.yml
+++ b/experiments/chaos/node_failure/test.yml
@@ -26,6 +26,8 @@
               - "Namespace    : {{ namespace }}"
               - "Label        : {{ label }}"
 
+        - include: prerequisites.yml
+
         - name: Identify the chaos util to be invoked
           template:
             src: chaosutil.j2
@@ -147,6 +149,7 @@
           until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
           retries: 60
           delay: 10
+          when: stg_engine == 'cstor'
 
           ### Due to node shutdown, the application pod will be in containercreating state due to multi-attach error.
           ### As a workaround, the node CR can be deleted which can forcefully remove the terminating pod.

--- a/experiments/chaos/node_failure/test_vars.yml
+++ b/experiments/chaos/node_failure/test_vars.yml
@@ -5,6 +5,8 @@ test_name: node-failure
 
 namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 
+pvc: "{{ lookup('env','APP_PVC') }}"
+
 label: "{{ lookup('env','APP_LABEL') }}"
 
 platform: "{{ lookup('env','PLATFORM') }}"


### PR DESCRIPTION
Signed-off-by: somesh kumar <somesh.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Modified the node_failure case. Put the cvr status check for cstor volumes only.

**Special notes for your reviewer**:
```

PLAY [localhost] ***************************************************************
2020-05-13T03:14:11.980195 (delta: 0.111473)         elapsed: 0.111473 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/node_failure/test.yml:2
2020-05-13T03:14:12.004075 (delta: 0.023832)         elapsed: 0.135353 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:13
2020-05-13T03:14:24.187221 (delta: 12.183104)         elapsed: 12.318499 ****** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-05-13T03:14:24.364024 (delta: 0.176691)         elapsed: 12.495302 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-05-13T03:14:24.511706 (delta: 0.147596)         elapsed: 12.642984 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:15
2020-05-13T03:14:24.652434 (delta: 0.140628)         elapsed: 12.783712 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-13T03:14:24.798288 (delta: 0.145779)         elapsed: 12.929566 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "984ebc2882d067cf86b84134c02b29af128a0539", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "68fccee348c495fd9ac54ccd51afd692", "mode": "0644", "owner": "root", "size": 425, "src": "/root/.ansible/tmp/ansible-tmp-1589339664.88-146252467963650/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-13T03:14:25.822787 (delta: 1.024405)         elapsed: 13.954065 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.943314", "end": "2020-05-13 03:14:27.239651", "rc": 0, "start": "2020-05-13 03:14:26.296337", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-13T03:14:27.330616 (delta: 1.507729)         elapsed: 15.461894 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-12T09:50:40Z", "generation": 2, "name": "node-failure", "resourceVersion": "7023298", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/node-failure", "uid": "7758ce51-959b-48f2-bf84-86bb66f52cb5"}, "spec": {"testMetadata": {"chaostype": "node-failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-13T03:14:29.315189 (delta: 1.984493)         elapsed: 17.446467 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-13T03:14:29.398417 (delta: 0.083053)         elapsed: 17.529695 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-13T03:14:29.477175 (delta: 0.078686)         elapsed: 17.608453 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/node_failure/test.yml:22
2020-05-13T03:14:29.556036 (delta: 0.078786)         elapsed: 17.687314 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-busybox-ns", 
        "Label        : app=busybox-sts"
    ]
}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/node_failure/prerequisites.yml:2
2020-05-13T03:14:29.716122 (delta: 0.160009)         elapsed: 17.8474 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.600230", "end": "2020-05-13 03:14:31.646771", "rc": 0, "start": "2020-05-13 03:14:30.046541", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/node_failure/prerequisites.yml:10
2020-05-13T03:14:31.766574 (delta: 2.050324)         elapsed: 19.897852 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.710432", "end": "2020-05-13 03:14:33.751250", "rc": 0, "start": "2020-05-13 03:14:32.040818", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:18
2020-05-13T03:14:33.910847 (delta: 2.144198)         elapsed: 22.042125 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:22
2020-05-13T03:14:34.043571 (delta: 0.13264)         elapsed: 22.174849 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/node_failure/prerequisites.yml:27
2020-05-13T03:14:34.184088 (delta: 0.140234)         elapsed: 22.315366 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.311240", "end": "2020-05-13 03:14:36.002920", "rc": 0, "start": "2020-05-13 03:14:34.691680", "stderr": "", "stderr_lines": [], "stdout": "pvc-d1f47a5e-64b1-4719-a1fe-09b1f0da2b8d", "stdout_lines": ["pvc-d1f47a5e-64b1-4719-a1fe-09b1f0da2b8d"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/node_failure/prerequisites.yml:35
2020-05-13T03:14:36.097028 (delta: 1.91286)         elapsed: 24.228306 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-d1f47a5e-64b1-4719-a1fe-09b1f0da2b8d --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.248157", "end": "2020-05-13 03:14:37.599516", "rc": 0, "start": "2020-05-13 03:14:36.351359", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:43
2020-05-13T03:14:37.688720 (delta: 1.591621)         elapsed: 25.819998 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/node_failure/test.yml:31
2020-05-13T03:14:37.838813 (delta: 0.150023)         elapsed: 25.970091 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "c3d158e37e6690e06d2df05aaab730ac04f28e26", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "bf958392dd91677ad0cb84dfd8db23cf", "mode": "0644", "owner": "root", "size": 59, "src": "/root/.ansible/tmp/ansible-tmp-1589339677.92-213401255996256/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/node_failure/test.yml:36
2020-05-13T03:14:38.412846 (delta: 0.57396)         elapsed: 26.544124 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "chaoslib/vmware_chaos/vm_power_operations.yml"}, "ansible_included_var_files": ["/experiments/chaos/node_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/node_failure/test.yml:39
2020-05-13T03:14:38.586820 (delta: 0.173878)         elapsed: 26.718098 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/vmware_chaos/vm_power_operations.yml"}, "changed": false}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/node_failure/test.yml:43
2020-05-13T03:14:38.743192 (delta: 0.156256)         elapsed: 26.87447 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1589339678.81-261099017763164/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/node_failure/test.yml:48
2020-05-13T03:14:39.435707 (delta: 0.69242)         elapsed: 27.566985 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/node_failure/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/node_failure/test.yml:51
2020-05-13T03:14:39.556945 (delta: 0.121128)         elapsed: 27.688223 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [Verify if the application is running.] ***********************************
task path: /experiments/chaos/node_failure/test.yml:57
2020-05-13T03:14:39.741681 (delta: 0.184634)         elapsed: 27.872959 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-05-13T03:14:39.893220 (delta: 0.151462)         elapsed: 28.024498 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=\"busybox-sts\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.203266", "end": "2020-05-13 03:14:41.415372", "rc": 0, "start": "2020-05-13 03:14:40.212106", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-12T15:31:49Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-12T15:31:49Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-05-13T03:14:41.575090 (delta: 1.681798)         elapsed: 29.706368 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.labels.app==\"busybox-sts\")].status.phase}'", "delta": "0:00:01.546882", "end": "2020-05-13 03:14:43.473354", "rc": 0, "start": "2020-05-13 03:14:41.926472", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/node_failure/test.yml:67
2020-05-13T03:14:43.677090 (delta: 2.101938)         elapsed: 31.808368 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l app=busybox-sts --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.081118", "end": "2020-05-13 03:14:45.109558", "rc": 0, "start": "2020-05-13 03:14:44.028440", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-bmfnz", "stdout_lines": ["app-busybox-85d45b855f-bmfnz"]}

TASK [Obtain PVC name from the application mount] ******************************
task path: /experiments/chaos/node_failure/test.yml:74
2020-05-13T03:14:45.199576 (delta: 1.522402)         elapsed: 33.330854 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods \"app-busybox-85d45b855f-bmfnz\" -n \"app-busybox-ns\" -o yaml | grep claimName | awk '{print $2}'", "delta": "0:00:01.349841", "end": "2020-05-13 03:14:46.820996", "rc": 0, "start": "2020-05-13 03:14:45.471155", "stderr": "", "stderr_lines": [], "stdout": "openebs-busybox", "stdout_lines": ["openebs-busybox"]}

TASK [Obtain the Persistent Volume name] ***************************************
task path: /experiments/chaos/node_failure/test.yml:82
2020-05-13T03:14:46.906420 (delta: 1.706782)         elapsed: 35.037698 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc \"openebs-busybox\" -n \"app-busybox-ns\" --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:01.244107", "end": "2020-05-13 03:14:48.415626", "failed_when_result": false, "rc": 0, "start": "2020-05-13 03:14:47.171519", "stderr": "", "stderr_lines": [], "stdout": "pvc-d1f47a5e-64b1-4719-a1fe-09b1f0da2b8d", "stdout_lines": ["pvc-d1f47a5e-64b1-4719-a1fe-09b1f0da2b8d"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/node_failure/test.yml:92
2020-05-13T03:14:48.542225 (delta: 1.635737)         elapsed: 36.673503 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2020-05-13T03:14:48.757883 (delta: 0.21558)         elapsed: 36.889161 ******** 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/nodefailurejiva bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-bmfnz -n app-busybox-ns -- sh -c \"dd if=/dev/urandom of=/busybox/nodefailurejiva bs=4k count=1024\"", "delta": "0:00:01.608107", "end": "2020-05-13 03:14:50.658110", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/nodefailurejiva bs=4k count=1024", "rc": 0, "start": "2020-05-13 03:14:49.050003", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.038141 seconds, 104.9MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.038141 seconds, 104.9MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/nodefailurejiva > /busybox/nodefailurejiva-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-bmfnz -n app-busybox-ns -- sh -c \"md5sum /busybox/nodefailurejiva > /busybox/nodefailurejiva-pre-chaos-md5\"", "delta": "0:00:01.654512", "end": "2020-05-13 03:14:52.553577", "failed_when_result": false, "item": "md5sum /busybox/nodefailurejiva > /busybox/nodefailurejiva-pre-chaos-md5", "rc": 0, "start": "2020-05-13 03:14:50.899065", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=sync;sync;sync) => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-bmfnz -n app-busybox-ns -- sh -c \"sync;sync;sync\"", "delta": "0:00:01.818758", "end": "2020-05-13 03:14:54.777928", "failed_when_result": false, "item": "sync;sync;sync", "rc": 0, "start": "2020-05-13 03:14:52.959170", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:21
2020-05-13T03:14:54.894577 (delta: 6.13655)         elapsed: 43.025855 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:27
2020-05-13T03:14:55.032009 (delta: 0.137267)         elapsed: 43.163287 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:37
2020-05-13T03:14:55.115851 (delta: 0.083696)         elapsed: 43.247129 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:44
2020-05-13T03:14:55.199368 (delta: 0.083448)         elapsed: 43.330646 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:51
2020-05-13T03:14:55.307186 (delta: 0.107739)         elapsed: 43.438464 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:61
2020-05-13T03:14:55.402618 (delta: 0.095345)         elapsed: 43.533896 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:70
2020-05-13T03:14:55.499622 (delta: 0.096933)         elapsed: 43.6309 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for application] *****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:83
2020-05-13T03:14:55.608415 (delta: 0.107954)         elapsed: 43.739693 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:90
2020-05-13T03:14:55.699492 (delta: 0.090994)         elapsed: 43.83077 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:98
2020-05-13T03:14:55.791868 (delta: 0.092269)         elapsed: 43.923146 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get Application pod Node to perform chaos] *******************************
task path: /experiments/chaos/node_failure/test.yml:101
2020-05-13T03:14:55.949730 (delta: 0.157792)         elapsed: 44.081008 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod app-busybox-85d45b855f-bmfnz -n app-busybox-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.319422", "end": "2020-05-13 03:14:57.591454", "rc": 0, "start": "2020-05-13 03:14:56.272032", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node2", "stdout_lines": ["e2e1-node2"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:110
2020-05-13T03:14:57.730571 (delta: 1.780766)         elapsed: 45.861849 ******* 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2020-05-13T03:14:57.993363 (delta: 0.262703)         elapsed: 46.124641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.32.1.1 vim-cmd vmsvc/getallvms | grep e2e1-k8s-node2 | awk '{print $1}'", "delta": "0:00:02.256750", "end": "2020-05-13 03:15:00.505570", "rc": 0, "start": "2020-05-13 03:14:58.248820", "stderr": "Warning: Permanently added '10.32.1.1' (RSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '10.32.1.1' (RSA) to the list of known hosts."], "stdout": "215", "stdout_lines": ["215"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2020-05-13T03:15:00.609409 (delta: 2.614709)         elapsed: 48.740687 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.32.1.1 vim-cmd vmsvc/power.off 215", "delta": "0:00:07.153978", "end": "2020-05-13 03:15:08.012405", "failed_when_result": false, "rc": 0, "start": "2020-05-13 03:15:00.858427", "stderr": "", "stderr_lines": [], "stdout": "Powering off VM:", "stdout_lines": ["Powering off VM:"]}

TASK [Check the node status] ***************************************************
task path: /experiments/chaos/node_failure/test.yml:117
2020-05-13T03:15:08.225545 (delta: 7.616044)         elapsed: 56.356823 ******* 
FAILED - RETRYING: Check the node status (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get nodes e2e1-node2 --no-headers", "delta": "0:00:01.206080", "end": "2020-05-13 03:15:41.164707", "rc": 0, "start": "2020-05-13 03:15:39.958627", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node2   NotReady   <none>   106d   v1.17.2", "stdout_lines": ["e2e1-node2   NotReady   <none>   106d   v1.17.2"]}

TASK [Wait for the application pod to get evicted] *****************************
task path: /experiments/chaos/node_failure/test.yml:127
2020-05-13T03:15:41.305428 (delta: 33.079811)         elapsed: 89.436706 ****** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 300, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [check the application status] ********************************************
task path: /experiments/chaos/node_failure/test.yml:132
2020-05-13T03:20:42.213025 (delta: 300.907477)         elapsed: 390.344303 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o custom-columns=:.status.phase", "delta": "0:00:01.285684", "end": "2020-05-13 03:20:44.111587", "rc": 0, "start": "2020-05-13 03:20:42.825903", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Check if the CVRs are in healthy state] **********************************
task path: /experiments/chaos/node_failure/test.yml:142
2020-05-13T03:20:44.211140 (delta: 1.997967)         elapsed: 392.342418 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the node CR] ******************************************************
task path: /experiments/chaos/node_failure/test.yml:157
2020-05-13T03:20:44.307484 (delta: 0.096275)         elapsed: 392.438762 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete node e2e1-node2", "delta": "0:00:01.169051", "end": "2020-05-13 03:20:45.775390", "failed_when_result": false, "rc": 0, "start": "2020-05-13 03:20:44.606339", "stderr": "", "stderr_lines": [], "stdout": "node \"e2e1-node2\" deleted", "stdout_lines": ["node \"e2e1-node2\" deleted"]}

TASK [wait for the application pod to start] ***********************************
task path: /experiments/chaos/node_failure/test.yml:165
2020-05-13T03:20:45.905300 (delta: 1.597637)         elapsed: 394.036578 ****** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 360, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Check if the application pod is rescheduled] *****************************
task path: /experiments/chaos/node_failure/test.yml:169
2020-05-13T03:26:46.643463 (delta: 360.738087)         elapsed: 754.774741 **** 
FAILED - RETRYING: Check if the application pod is rescheduled (45 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (44 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (43 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (42 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (41 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (40 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (39 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (38 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (37 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (36 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (35 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (34 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (33 retries left).
changed: [127.0.0.1] => {"attempts": 14, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o wide | grep -v e2e1-node2 | awk '{print $3}'", "delta": "0:00:01.108803", "end": "2020-05-13 03:29:19.214366", "rc": 0, "start": "2020-05-13 03:29:18.105563", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the rescheduled pod name] *****************************************
task path: /experiments/chaos/node_failure/test.yml:182
2020-05-13T03:29:19.299618 (delta: 152.656087)         elapsed: 907.430896 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.060729", "end": "2020-05-13 03:29:20.686508", "rc": 0, "start": "2020-05-13 03:29:19.625779", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-x2qz6", "stdout_lines": ["app-busybox-85d45b855f-x2qz6"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/node_failure/test.yml:190
2020-05-13T03:29:20.774510 (delta: 1.474744)         elapsed: 908.905788 ****** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2020-05-13T03:29:20.948561 (delta: 0.173979)         elapsed: 909.079839 ****** 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/nodefailurejiva bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/nodefailurejiva bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/nodefailurejiva > /busybox/nodefailurejiva-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/nodefailurejiva > /busybox/nodefailurejiva-pre-chaos-md5", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=sync;sync;sync)  => {"changed": false, "item": "sync;sync;sync", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:21
2020-05-13T03:29:21.094474 (delta: 0.145245)         elapsed: 909.225752 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-85d45b855f-x2qz6 -n app-busybox-ns", "delta": "0:00:34.740547", "end": "2020-05-13 03:29:56.130228", "rc": 0, "start": "2020-05-13 03:29:21.389681", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-85d45b855f-x2qz6\" deleted", "stdout_lines": ["pod \"app-busybox-85d45b855f-x2qz6\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:27
2020-05-13T03:29:56.287183 (delta: 35.192616)         elapsed: 944.418461 ***** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns", "delta": "0:00:01.398778", "end": "2020-05-13 03:29:58.006617", "rc": 0, "start": "2020-05-13 03:29:56.607839", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS    RESTARTS   AGE\napp-busybox-85d45b855f-dfknj   1/1     Running   0          35s", "stdout_lines": ["NAME                           READY   STATUS    RESTARTS   AGE", "app-busybox-85d45b855f-dfknj   1/1     Running   0          35s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:37
2020-05-13T03:29:58.118784 (delta: 1.831503)         elapsed: 946.250062 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.077647", "end": "2020-05-13 03:29:59.458482", "rc": 0, "start": "2020-05-13 03:29:58.380835", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-dfknj", "stdout_lines": ["app-busybox-85d45b855f-dfknj"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:44
2020-05-13T03:29:59.546094 (delta: 1.427232)         elapsed: 947.677372 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-85d45b855f-dfknj\")].status.phase}'", "delta": "0:00:01.075596", "end": "2020-05-13 03:30:00.915180", "rc": 0, "start": "2020-05-13 03:29:59.839584", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:51
2020-05-13T03:30:01.013000 (delta: 1.466832)         elapsed: 949.144278 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-85d45b855f-dfknj\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:01.464604", "end": "2020-05-13 03:30:02.761834", "rc": 0, "start": "2020-05-13 03:30:01.297230", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-05-13T03:29:25Z]]", "stdout_lines": ["map[running:map[startedAt:2020-05-13T03:29:25Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:61
2020-05-13T03:30:02.915895 (delta: 1.902824)         elapsed: 951.047173 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-dfknj -n app-busybox-ns -- sh -c \"md5sum /busybox/nodefailurejiva > /busybox/nodefailurejiva-post-chaos-md5\"", "delta": "0:00:01.627347", "end": "2020-05-13 03:30:05.017388", "failed_when_result": false, "rc": 0, "start": "2020-05-13 03:30:03.390041", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:70
2020-05-13T03:30:05.114046 (delta: 2.198078)         elapsed: 953.245324 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-dfknj -n app-busybox-ns -- sh -c \"diff /busybox/nodefailurejiva-pre-chaos-md5 /busybox/nodefailurejiva-post-chaos-md5\"", "delta": "0:00:01.545892", "end": "2020-05-13 03:30:06.993600", "failed_when_result": false, "rc": 0, "start": "2020-05-13 03:30:05.447708", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for application] *****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:83
2020-05-13T03:30:07.081313 (delta: 1.967164)         elapsed: 955.212591 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:90
2020-05-13T03:30:07.176937 (delta: 0.095553)         elapsed: 955.308215 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:98
2020-05-13T03:30:07.273126 (delta: 0.096096)         elapsed: 955.404404 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/node_failure/test.yml:199
2020-05-13T03:30:07.397787 (delta: 0.124593)         elapsed: 955.529065 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:209
2020-05-13T03:30:07.580666 (delta: 0.182809)         elapsed: 955.711944 ****** 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2020-05-13T03:30:07.846957 (delta: 0.262081)         elapsed: 955.978235 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.32.1.1 vim-cmd vmsvc/getallvms | grep e2e1-k8s-node2 | awk '{print $1}'", "delta": "0:00:02.387101", "end": "2020-05-13 03:30:10.589916", "rc": 0, "start": "2020-05-13 03:30:08.202815", "stderr": "", "stderr_lines": [], "stdout": "215", "stdout_lines": ["215"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2020-05-13T03:30:10.684762 (delta: 2.837735)         elapsed: 958.81604 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.32.1.1 vim-cmd vmsvc/power.on 215", "delta": "0:00:02.959988", "end": "2020-05-13 03:30:14.085029", "failed_when_result": false, "rc": 0, "start": "2020-05-13 03:30:11.125041", "stderr": "", "stderr_lines": [], "stdout": "Powering on VM:", "stdout_lines": ["Powering on VM:"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:216
2020-05-13T03:30:14.328645 (delta: 3.643806)         elapsed: 962.459923 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-05-13T03:30:14.498834 (delta: 0.170081)         elapsed: 962.630112 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-05-13T03:30:14.595198 (delta: 0.096157)         elapsed: 962.726476 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-05-13T03:30:14.686094 (delta: 0.090815)         elapsed: 962.817372 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-05-13T03:30:14.776646 (delta: 0.090436)         elapsed: 962.907924 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "cad674606733d8b7d866b5f49971647a70c2b6c0", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "159ae1f9ce03ff4606f1339d21689e05", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1589340614.87-146145580152657/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-05-13T03:30:17.347116 (delta: 2.570374)         elapsed: 965.478394 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.933728", "end": "2020-05-13 03:30:18.585311", "rc": 0, "start": "2020-05-13 03:30:17.651583", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-05-13T03:30:18.675166 (delta: 1.327985)         elapsed: 966.806444 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-05-12T09:50:40Z", "generation": 3, "name": "node-failure", "resourceVersion": "7028734", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/node-failure", "uid": "7758ce51-959b-48f2-bf84-86bb66f52cb5"}, "spec": {"testMetadata": {"chaostype": "node-failure"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=55   changed=35   unreachable=0    failed=0   

2020-05-13T03:30:19.968152 (delta: 1.292919)         elapsed: 968.09943 ******* 
=============================================================================== 
```