### PR TITLE
Refactor the task to obtain the claimed blockdevice from cspc

### DIFF
--- a/experiments/functional/disk_replacement/run_litmus_test.yml
+++ b/experiments/functional/disk_replacement/run_litmus_test.yml
@@ -24,6 +24,7 @@ spec:
       containers:
       - name: ansibletest
         image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             value: default

--- a/experiments/functional/disk_replacement/test.yml
+++ b/experiments/functional/disk_replacement/test.yml
@@ -152,7 +152,7 @@
         - name: Obtain the Claimed block device from the targeted node
           shell: >
             kubectl get cspi -n {{ operator_ns }} {{ target_cspi }}
-            -o custom-columns=:.spec.dataRaidGroups[*].blockDevices[*].blockDeviceName --no-headers
+            -o custom-columns=:.spec.dataRaidGroups[*].blockDevices[*].blockDeviceName --no-headers | tr "," "\n"
           args:
             executable: /bin/bash
           register: claimed_bd


### PR DESCRIPTION
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
