### PR TITLE
refactor(experiment): Added target_affinity_check env in target-failure experiment

### DIFF
--- a/experiments/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/experiments/chaos/openebs_target_failure/run_litmus_test.yml
@@ -75,6 +75,9 @@ spec:
           - name: DEPLOY_TYPE
             value: deployment
 
+          - name: TARGET_AFFINITY_CHECK
+            value: 'enable'
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/openebs_target_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 

--- a/experiments/chaos/openebs_target_failure/test.yml
+++ b/experiments/chaos/openebs_target_failure/test.yml
@@ -194,14 +194,14 @@
             #operator_ns: works by var scope
             app_label: "{{ label }}"
             app_pvc: "{{ pvc }}"
-          when: deploy_type == 'deployment'
+          when: deploy_type == 'deployment' and target_affinity_check == 'enable'
 
           ## Check statefulset application-target pod affinity
         - include_tasks: /utils/scm/openebs/sts_target_affinity_check.yml
           vars:
             app_ns: "{{ namespace }}"
             app_label: "{{ label }}"
-          when: deploy_type == 'statefulset'
+          when: deploy_type == 'statefulset' and target_affinity_check == 'enable'
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/openebs_target_failure/test_vars.yml
+++ b/experiments/chaos/openebs_target_failure/test_vars.yml
@@ -30,4 +30,4 @@ deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"
 
 cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
 
-target_affinity_check: "{{ lookup('env','TARGET_AFFINITY') }}"
+target_affinity_check: "{{ lookup('env','TARGET_AFFINITY_CHECK') }}"

--- a/experiments/chaos/openebs_target_failure/test_vars.yml
+++ b/experiments/chaos/openebs_target_failure/test_vars.yml
@@ -29,3 +29,5 @@ chaos_duration: 120
 deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"
 
 cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
+
+target_affinity_check: "{{ lookup('env','TARGET_AFFINITY') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- We can enable / disable the target affinity check from env to use accordingly.