### PR TITLE
feat(pool-chaos): Included a test case to kill the cspc pool-mgmt container

### DIFF
--- a/chaoslib/openebs/cstor_cspc_pool_kill.yml
+++ b/chaoslib/openebs/cstor_cspc_pool_kill.yml
@@ -30,7 +30,7 @@
   register: cspi_status
   until: "'ONLINE' in cspi_status.stdout"
   delay: 2
-  retries: 150
+  retries: 30
 
 - name: Get the pod of pool deployment status
   shell: >
@@ -41,7 +41,7 @@
   register: pool_pod_status
   until: "'Running' in pool_pod_status.stdout"
   delay: 2
-  retries: 150
+  retries: 30
 
 - name: Obtain the pool pod name
   shell: >
@@ -61,7 +61,7 @@
   register: runningStatusCount
   until: "runningStatusCount.stdout == \"3\""
   delay: 2
-  retries: 150
+  retries: 30
 
 - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
   vars:

--- a/chaoslib/openebs/cstor_cspc_pool_kill.yml
+++ b/chaoslib/openebs/cstor_cspc_pool_kill.yml
@@ -1,0 +1,123 @@
+- name: Derive PV from application PVC 
+  shell: >
+    kubectl get pvc {{ app_pvc }}
+    -o custom-columns=:spec.volumeName -n {{ app_ns }}
+    --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Obtain the CSPI name from cvr
+  shell: >
+    kubectl get cvr -n {{ operator_ns }}
+    -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+    -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpoolinstance\.openebs\.io\/name}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  register: pool_deployment
+
+- name: Select random pool deployment to kill the pool container
+  set_fact:
+     cspi_name: "{{ item }}"
+  with_random_choice: "{{ pool_deployment.stdout_lines }}"  
+
+- name: Verify the status of cspi
+  shell: >
+    kubectl get cspi -n {{ operator_ns }} {{ cspi_name }} --no-headers
+    -o custom-columns=:.status.phase
+  args:
+    executable: /bin/bash
+  register: cspi_status
+  until: "'ONLINE' in cspi_status.stdout"
+  delay: 2
+  retries: 150
+
+- name: Get the pod of pool deployment status
+  shell: >
+    kubectl get pods -n {{ operator_ns }} --no-headers 
+    -l openebs.io/cstor-pool-instance={{ cspi_name }} -o custom-columns=:.status.phase
+  args:
+    executable: /bin/bash
+  register: pool_pod_status
+  until: "'Running' in pool_pod_status.stdout"
+  delay: 2
+  retries: 150
+
+- name: Obtain the pool pod name
+  shell: >
+    kubectl get pods -n {{ operator_ns }} --no-headers
+    -l openebs.io/cstor-pool-instance={{ cspi_name }} -o custom-columns=:.metadata.name
+  args:
+    executable: /bin/bash
+  register: cstor_pool_pod
+
+- name: Get the runningStatus of pool pod
+  shell: >
+    kubectl get pod {{ cstor_pool_pod.stdout }} -n {{ operator_ns }}
+    -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+    grep -w running | wc -l
+  args:
+    executable: /bin/bash
+  register: runningStatusCount
+  until: "runningStatusCount.stdout == \"3\""
+  delay: 2
+  retries: 150
+
+- include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
+  vars:
+    action: "killapp"
+    namespace: "{{ operator_ns }}"
+    app_pod: "{{ cstor_pool_pod.stdout }}"
+    app_container: "{{ container_name }}"
+  when: cri == 'docker'
+
+- include_tasks: /chaoslib/containerd_chaos/openebs-pool-failure.yml
+  vars:
+    action: "killapp"
+    namespace: "{{ operator_ns }}"
+    app_pod: "{{ cstor_pool_pod.stdout }}"
+    app_container: "{{ container_name }}"
+  when: cri == 'containerd'
+
+- include_tasks: /chaoslib/crio_chaos/openebs-pool-failure.yml
+  vars:
+    action: "killapp"
+    namespace: "{{ operator_ns }}"
+    app_pod: "{{ cstor_pool_pod.stdout }}"
+    app_container: "{{ container_name }}"
+  when: cri == 'cri-o'
+
+- name: Verify the status of cspi post fault injection
+  shell: >
+    kubectl get cspi -n {{ operator_ns }} {{ cspi_name }} --no-headers
+    -o custom-columns=:.status.phase          
+  args:
+    executable: /bin/bash
+  register: aft_cspi_status
+  until: "'ONLINE' in aft_cspi_status.stdout"
+  delay: 2
+  retries: 150
+
+- name: Check for pool pod in running state post chaos
+  shell: >
+    kubectl get pods -n {{ operator_ns }} --no-headers
+    -l openebs.io/cstor-pool-instance={{ cspi_name }} -o custom-columns=:.status.phase
+  args:
+    executable: /bin/bash
+  register: aft_pool_pod_status
+  until: "'Running' in aft_pool_pod_status.stdout"
+  delay: 2
+  retries: 150
+
+- name: Get the runningStatus of pool pod
+  shell: >
+    kubectl get pod {{ cstor_pool_pod.stdout }} -n {{ operator_ns }}
+    -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+    grep -w running | wc -l
+  args:
+    executable: /bin/bash
+  register: runningStatusCount
+  until: "runningStatusCount.stdout == \"3\""
+  delay: 2
+  retries: 150
+

--- a/experiments/chaos/cspc_pool_failure/container_failure/README.md
+++ b/experiments/chaos/cspc_pool_failure/container_failure/README.md
@@ -59,17 +59,8 @@ The configmap data will be utilised by litmus experiments as its variables while
 | APP_LABEL     | Unique Labels in `key=value` format of application deployment |
 | APP_PVC       | Name of persistent volume claim used for app's volume mounts |
 
-### Chaos 
-
-| Parameter        | Description                      |
-| ---------------- | -------------------------------- |
-| CHAOS_TYPE       | The type of chaos to be induced. |
-| CHAOS_ITERATIONS | The number of chaos iterations   |
-
 ### Health Checks 
 
 | Parameter              | Description                                                  |
 | ---------------------- | ------------------------------------------------------------ |
-| LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
-| LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
 | DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery. To check against busybox set value: "busybox" and for percona, set value: "mysql"|

--- a/experiments/chaos/cspc_pool_failure/container_failure/README.md
+++ b/experiments/chaos/cspc_pool_failure/container_failure/README.md
@@ -2,7 +2,7 @@
 
 | Type  | Description                                         | Storage | K8s Platform |
 | ----- | --------------------------------------------------- | ------- | ------------ |
-| Chaos | Kill the pool pod and check if gets scheduled again | OpenEBS | Any          |
+| Chaos | Kill the CSPC pool pod container and check if gets scheduled again | OpenEBS | Any          |
 
 ## Entry-Criteria
 
@@ -58,6 +58,13 @@ The configmap data will be utilised by litmus experiments as its variables while
 | APP_NAMESPACE | Namespace in which application pods are deployed             |
 | APP_LABEL     | Unique Labels in `key=value` format of application deployment |
 | APP_PVC       | Name of persistent volume claim used for app's volume mounts |
+
+### chaos parameters
+
+| Parameter     | Description                                                  |
+| ------------- | ------------------------------------------------------------ |
+| CONTAINER_RUNTIME | Type of container run time used (docker,containerd,cri-o)|
+| CONTAINER_NAME    | Name of the container to perform the chaos (cstor-pool or cstor-pool-mgmt) |
 
 ### Health Checks 
 

--- a/experiments/chaos/cspc_pool_failure/container_failure/README.md
+++ b/experiments/chaos/cspc_pool_failure/container_failure/README.md
@@ -1,0 +1,75 @@
+## Experiment Metadata
+
+| Type  | Description                                         | Storage | K8s Platform |
+| ----- | --------------------------------------------------- | ------- | ------------ |
+| Chaos | Kill the pool pod and check if gets scheduled again | OpenEBS | Any          |
+
+## Entry-Criteria
+
+- Application services are accessible & pods are healthy
+- Application writes are successful 
+
+## Exit-Criteria
+
+- Application services are accessible & pods are healthy
+- Data written prior to chaos is successfully retrieved/read
+- Database consistency is maintained as per db integrity check utils
+- Storage target pods are healthy
+
+## Notes
+
+- Typically used as a disruptive test, to cause loss of access to storage pool by killing it.
+- The pool pod should start again and it should be healthy.
+
+## Associated Utils 
+
+- `cstor_cspc_pool_kill.yml`,`pod_failure_by_sigkill.yaml`
+
+### Procedure
+
+This scenario validates the behaviour of application and OpenEBS persistent volumes in the amidst of chaos induced on storage pool. The litmus experiment fails the specified pool and thereby losing the access to volumes being created on it.
+
+After injecting the chaos into the component specified via environmental variable, litmus experiment observes the behaviour of corresponding OpenEBS PV and the application which consumes the volume.
+
+Based on the value of env DATA_PERSISTENCE, the corresponding data consistency util will be executed. At present only busybox and percona-mysql are supported. Along with specifying env in the litmus experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the litmus pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+
+The configmap data will be utilised by litmus experiments as its variables while executing the scenario. Based on the data provided, litmus checks if the data is consistent after recovering from induced chaos.
+
+## Litmusbook Environment Variables
+
+### Application
+
+| Parameter     | Description                                                  |
+| ------------- | ------------------------------------------------------------ |
+| APP_NAMESPACE | Namespace in which application pods are deployed             |
+| APP_LABEL     | Unique Labels in `key=value` format of application deployment |
+| APP_PVC       | Name of persistent volume claim used for app's volume mounts |
+
+### Chaos 
+
+| Parameter        | Description                      |
+| ---------------- | -------------------------------- |
+| CHAOS_TYPE       | The type of chaos to be induced. |
+| CHAOS_ITERATIONS | The number of chaos iterations   |
+
+### Health Checks 
+
+| Parameter              | Description                                                  |
+| ---------------------- | ------------------------------------------------------------ |
+| LIVENESS_APP_NAMESPACE | Namespace in which external liveness pods are deployed, if any |
+| LIVENESS_APP_LABEL     | Unique Labels in `key=value` format for external liveness pod, if any |
+| DATA_PERSISTENCE       | Data accessibility & integrity verification post recovery. To check against busybox set value: "busybox" and for percona, set value: "mysql"|

--- a/experiments/chaos/cspc_pool_failure/container_failure/data_persistence.j2
+++ b/experiments/chaos/cspc_pool_failure/container_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/cspc_pool_failure/container_failure/run_litmus_test.yml
+++ b/experiments/chaos/cspc_pool_failure/container_failure/run_litmus_test.yml
@@ -44,10 +44,10 @@ spec:
             value: ""  
 
           - name: CONTAINER_RUNTIME
-            value: docker
+            value: ""
 
           - name: CONTAINER_NAME
-            value: "cstor-pool-mgmt"
+            value: "cstor-pool"
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/chaos/cspc_pool_failure/container_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/chaos/cspc_pool_failure/container_failure/run_litmus_test.yml
+++ b/experiments/chaos/cspc_pool_failure/container_failure/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cspc-pool-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cspc-pool-failure-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: cspc-pool-failure
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: ""
+
+          - name: APP_LABEL
+            value: ""
+
+          - name: APP_PVC
+            value: ""
+
+          - name: DATA_PERSISTENCE
+            value: ""  
+
+          - name: CONTAINER_RUNTIME
+            value: docker
+
+          - name: CONTAINER_NAME
+            value: "cstor-pool-mgmt"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/cspc_pool_failure/container_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: cspc-pool-failure   

--- a/experiments/chaos/cspc_pool_failure/container_failure/test.yml
+++ b/experiments/chaos/cspc_pool_failure/container_failure/test.yml
@@ -67,8 +67,6 @@
         - include: "{{ chaos_util_path }}"
           app_ns: "{{ namespace }}"
           app_pvc: "{{ pvc }}"
-          chaos_repeat: "{{ chaos_iterations }}"
-          error_messages: "{{ pool_debug_msg }}"
           post_chaos_soak_time : "{{ chaos_duration }}"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK

--- a/experiments/chaos/cspc_pool_failure/container_failure/test.yml
+++ b/experiments/chaos/cspc_pool_failure/container_failure/test.yml
@@ -1,0 +1,121 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+
+  tasks:
+    - block:
+
+         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
+
+        - include_vars:
+            file: data_persistence.yml
+
+        - name: Record the chaos util path
+          set_fact:
+            chaos_util_path: "/chaoslib/openebs/cstor_cspc_pool_kill.yml"
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "{{ test_name }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+        
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+        
+        - name: Create some test data 
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''  
+
+        ## STORAGE FAULT INJECTION 
+
+        - include: "{{ chaos_util_path }}"
+          app_ns: "{{ namespace }}"
+          app_pvc: "{{ pvc }}"
+          chaos_repeat: "{{ chaos_iterations }}"
+          error_messages: "{{ pool_debug_msg }}"
+          post_chaos_soak_time : "{{ chaos_duration }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          include_tasks: "/utils/k8s/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+ 
+        - name: Verify application data persistence  
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != '' 
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: new_app_pod  
+
+        - name: Verify successful database delete
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'DELETE'
+            ns: "{{ namespace }}"
+            pod_name: "{{ new_app_pod.stdout }}"
+          when: data_persistence != '' 
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+         ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "{{ test_name }}"

--- a/experiments/chaos/cspc_pool_failure/container_failure/test_vars.yml
+++ b/experiments/chaos/cspc_pool_failure/container_failure/test_vars.yml
@@ -1,0 +1,10 @@
+test_name: cspc-pool-failure
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+pvc: "{{ lookup('env','APP_PVC') }}"
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+operator_ns: openebs
+pool_debug_msg: 'uncorrectable I/O failure|suspended|ERROR ZFS event'
+chaos_duration: 240
+cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
+container_name: "{{ lookup('env','CONTAINER_NAME') }}"

--- a/experiments/chaos/cspc_pool_failure/container_failure/test_vars.yml
+++ b/experiments/chaos/cspc_pool_failure/container_failure/test_vars.yml
@@ -4,7 +4,6 @@ label: "{{ lookup('env','APP_LABEL') }}"
 pvc: "{{ lookup('env','APP_PVC') }}"
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 operator_ns: openebs
-pool_debug_msg: 'uncorrectable I/O failure|suspended|ERROR ZFS event'
 chaos_duration: 240
 cri: "{{ lookup('env','CONTAINER_RUNTIME') }}"
 container_name: "{{ lookup('env','CONTAINER_NAME') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Test case to perform the chaos in cstor pool mgmt container in cspc pools

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
