### PR TITLE
refactor(pool-creation): Modified the tasks to verify the cspi status 

### DIFF
--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -113,6 +113,17 @@
               delay: 30
               retries: 10
 
+            - name: Verify the status of CSPI
+              shell: >
+                kubectl get cspi -n {{ operator_ns}} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+                -o custom-columns=:.status.phase --no-headers
+              args:
+                executable: /bin/bash
+              register: cspi_status
+              until: "((cspi_status.stdout_lines|unique)|length) == 1 and 'ONLINE' in cspi_status.stdout"
+              delay: 5
+              retries: 60
+
             - name: Obtain the CSPI name to verify the status
               shell: >
                 kubectl get cspi -n {{ operator_ns}} -l openebs.io/cstor-pool-cluster={{ pool_name }}
@@ -120,17 +131,6 @@
               args:
                 executable: /bin/bash
               register: cspi_name
-
-            - name: Verify the status of CSPI
-              shell: >
-                kubectl get cspi -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
-              args:
-                executable: /bin/bash
-              register: cspi_status
-              with_items: "{{ cspi_name.stdout_lines }}"
-              until: "'ONLINE' in cspi_status.stdout"
-              delay: 5
-              retries: 30
 
             - name: Verify if the cStor Pool pods are Running
               shell: >


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the tasks to verify the cspi status in pool creation test case

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
