### PR TITLE
feat[pool-failure]: Included a test case to verify the pool expansion while pool pod failure

### DIFF
--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/README.md
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/README.md
@@ -1,0 +1,30 @@
+## Experiment Metadata
+
+| Type       | Description                                           | Storage      | Applications | K8s Platform |
+| ---------- | ----------------------------------------------------- | ------------ | ------------ | ------------ |
+| CHAOS      | Restart the pool pod while CSPC pool expansion is in progress | OpenBS cStor | Any          | Any          |
+
+## Entry-Criteria
+
+- K8s nodes should be ready.
+- cStor CSPC should be created.
+- Application should be deployed using with volume provisioned through CSI provisioner.
+- Uncliamed BlockDevices should be available to expand the pool.
+
+## Exit-Criteria
+
+- Pool expansion should be expanded successfully and the application is still up and running.
+
+## Procedure
+
+- This chaos test checks if the cspc pool expanded succesfully upon the restart of the pool pod.
+- This litmusbook accepts the parameters in form of job environmental variables.
+- This job patched the respective CSPC pool to expand the cspc pool and verifying the status of cspi. 
+
+## Litmusbook Environment Variables
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| POOL_NAME     | CSPC Pool name to expand                               |
+| POOL_TYPE     | CSPC pool raid type [stripe,mirror,raidz,raidz2]       |
+| OPERATOR_NS   | Nmaespace where the openebs is deployed                |

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/README.md
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/README.md
@@ -8,23 +8,23 @@
 
 - K8s nodes should be ready.
 - cStor CSPC should be created.
-- Application should be deployed using with volume provisioned through CSI provisioner.
-- Uncliamed BlockDevices should be available to expand the pool.
+- Application should be deployed using volume provisioned through CSI provisioner.
+- Unclaimed BlockDevices should be available to expand the pool.
 
 ## Exit-Criteria
 
-- Pool expansion should be expanded successfully and the application is still up and running.
+- Pool should be expanded successfully and the application should be still up and running without any disruption.
 
 ## Procedure
 
-- This chaos test checks if the cspc pool expanded succesfully upon the restart of the pool pod.
+- This chaos test checks if the cspc pool can be expanded successfully even if the respective pool pod is restarted.
 - This litmusbook accepts the parameters in form of job environmental variables.
-- This job patched the respective CSPC pool to expand the cspc pool and verifying the status of cspi. 
+- This job patches the respective CSPC pool to expand the cspc pool and verifying the status of cspi. 
 
 ## Litmusbook Environment Variables
 
 | Parameters    | Description                                            |
 | ------------- | ------------------------------------------------------ |
-| POOL_NAME     | CSPC Pool name to expand                               |
+| CSPC_NAME     | CSPC Pool name to expand                               |
 | POOL_TYPE     | CSPC pool raid type [stripe,mirror,raidz,raidz2]       |
 | OPERATOR_NS   | Nmaespace where the openebs is deployed                |

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml
@@ -7,7 +7,7 @@
 
     - name: Obtain the pool pod name to perform the chaos 
       shell: >
-         kubectl get po -n  {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ cspi_name.stdout }}
+         kubectl get po -n  {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ cspiname.stdout }}
          -o custom-columns=:.metadata.name --no-headers
       register: cspc_pool_pod
 
@@ -75,7 +75,7 @@
 
     - name: Restart the pool pod when the pool expansion is in progress
       shell: >
-         kubectl delete po -n {{ operator_ns }} {{ cspc_pool_pod.stdout_lines }}
+         kubectl delete po -n {{ operator_ns }} {{ cspc_pool_pod.stdout }} --grace-period=0 --force
       args:
         executable: /bin/bash
 

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml
@@ -1,0 +1,93 @@
+---
+    - name: Get the cspi name to get the pool pod
+      shell: >
+         kubectl get cspi -n {{ operator_ns }} -l kubernetes.io/hostname={{ outer_item }},openebs.io/cstor-pool-cluster={{ pool_name }} 
+         -o custom-columns=:.metadata.name --no-headers
+      register: cspiname
+
+    - name: Obtain the pool pod name to perform the chaos 
+      shell: >
+         kubectl get po -n  {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ cspi_name.stdout }}
+         -o custom-columns=:.metadata.name --no-headers
+      register: cspc_pool_pod
+
+    - name: Getting the Unclaimed block-device from each node
+      shell: >
+        kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ outer_item }} 
+        -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | grep -v sparse | head -n "{{ disk_count }}"
+      register: blockDevice
+      until: "((blockDevice.stdout_lines|unique)|length) == (disk_count)|int"
+      delay: 5
+      retries: 10
+     
+    - name: Obtain the index position of the nodes from cspc json spec
+      shell: ./node_index_count {{ outer_item }} ./cspc-pool-expansion.json
+      register: index_count
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0/blockDevices/0", "value": {"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "stripe"
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0", "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"}],"type": "mirror"}}]'                  
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "mirror"
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }}
+            {{ pool_name }} --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0",
+            "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},
+            {"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"},
+            {"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'"}],"type": "raidz"}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "raidz1"
+
+    - block:
+        - name: Patch the CSPC to expand the pool size
+          shell: >
+            kubectl patch cspc -n {{ operator_ns }} {{ pool_name }}
+            --type='json' -p='[{"op": "add", "path": "/spec/pools/{{ index_count.stdout }}/dataRaidGroups/0",
+            "value": {"blockDevices": [{"blockDeviceName": "'{{ blockDevice.stdout_lines[0] }}'"},
+            {"blockDeviceName": "'{{ blockDevice.stdout_lines[1] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[2] }}'"},
+            {"blockDeviceName": "'{{ blockDevice.stdout_lines[3] }}'"},{"blockDeviceName": "'{{ blockDevice.stdout_lines[4] }}'"},
+            {"blockDeviceName": "'{{ blockDevice.stdout_lines[5] }}'"}],"type": "raidz2"}}]'
+          args:
+            executable: /bin/bash
+          register: patch_cspc
+          failed_when: "'patched' not in patch_cspc.stdout"
+      when: pool_type == "raidz2"
+
+    - name: Restart the pool pod when the pool expansion is in progress
+      shell: >
+         kubectl delete po -n {{ operator_ns }} {{ cspc_pool_pod.stdout_lines }}
+      args:
+        executable: /bin/bash
+
+    - name: Check if the newly added Blockdevice is in Claimed state
+      shell: >
+        kubectl get blockdevice -n {{ operator_ns }} {{ item }}
+        --no-headers -o custom-columns=:.status.claimState
+      args:
+        executable: /bin/bash
+      register: bd_state
+      with_items:
+        - "{{ blockDevice.stdout_lines }}"
+      until: "'Claimed' in bd_state.stdout"
+      delay: 5
+      retries: 60

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/node_index_count
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/node_index_count
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+declare -i index=-1
+nodeName=$1
+while read i; do
+index=$(( index + 1 ))
+if [[ $i == *"$nodeName"* ]]; then
+  break
+fi
+done <<<$(jq -c '.spec.pools[]' $2)
+echo $index
+

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/run_litmus_test.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/run_litmus_test.yml
@@ -23,8 +23,8 @@ spec:
             #value: log_plays, actionable, default
             value: default
 
-            # Provide POOL_NAME to expand
-          - name: POOL_NAME
+            # Provide CSPC_NAME to expand
+          - name: CSPC_NAME
             value: ''
 
            # Provide the value for POOL_TYPE to expand

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/run_litmus_test.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/run_litmus_test.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cspc-pool-failure-expansion-inprogress-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cspc-failure-pool-expansion
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # Provide POOL_NAME to expand
+          - name: POOL_NAME
+            value: ''
+
+           # Provide the value for POOL_TYPE to expand
+           # stripe,mirror,raidz1,raidz2
+          - name: POOL_TYPE
+            value: ''
+
+           # Namespace where the OpenEBS components are deployed
+          - name: OPERATOR_NS
+            value: ''
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test.yml
@@ -1,0 +1,113 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+         ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Obtain the kubernetes host names from cspc
+          shell: >
+            kubectl get cspc -n {{ operator_ns }}
+            -o jsonpath='{range .items[?(@.metadata.name=="{{ pool_name }}")]}{range .spec.pools[*].nodeSelector}{.kubernetes\.io\/hostname}{"\n"}{end}'
+          register: nodes
+
+        - name: Obtain the CSPI name to verify the status
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: cspi_name
+
+        - name: Obtain the CSPI size before expand the pool
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.status.capacity.total --no-headers | tr -d G
+          args:
+            executable: /bin/bash
+          register: cspi_bfr_expansion
+
+        - name: Obtain the cspc pool spec in json format
+          shell: kubectl get cspc -n {{ operator_ns }} {{ pool_name }} -o json > ./cspc-pool-expansion.json
+          args:
+            executable: /bin/bash
+
+        - name: set the value for the disk count to fetch the unclaimed blockDevice from each node
+          set_fact:
+            disk_count: "{{ item.value.count }}"
+          loop: "{{ lookup('dict', bd_count) }}"
+          when: "'{{ pool_type }}' in item.key"
+
+        - name: Add the block devices and patch the CSPC to expand the pool
+          include_tasks: add_blockdevice.yml
+          with_items: "{{ nodes.stdout_lines }}"
+          loop_control:
+            loop_var: outer_item
+
+        - name: Verify the status of CSPI after expanding the pool
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.phase}'
+          args:
+            executable: /bin/bash
+          register: cspi_status
+          with_items: "{{ cspi_name.stdout_lines }}"
+          until: "'ONLINE' in cspi_status.stdout"
+          delay: 5
+          retries: 30
+
+        - name: Verify if cStor Pool pods are Running after pool expansion
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item }}
+            --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: pool_count
+          with_items: "{{ cspi_name.stdout_lines }}"
+          until: "((pool_count.stdout_lines|unique)|length) == 1 and 'Running' in pool_count.stdout"
+          retries: 30
+          delay: 10
+
+        - name: sleep for 120 seconds and continue with play
+          wait_for: timeout=120
+
+        - name: Obtain the CSPI size after expand the pool
+          shell: >
+            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
+            -o custom-columns=:.status.capacity.total --no-headers | tr -d G
+          args:
+            executable: /bin/bash
+          register: cspi_after_expansion
+
+        - name: check if the CSPC pool has been expanded
+          shell: if (( $(echo "{{ item[1] }} > {{ item[0] }}" | bc -l) )) ; then echo "pass"; else echo "fail";fi;
+          args:
+            executable: /bin/bash
+          register: pool_status
+          failed_when: "'pass' not in pool_status.stdout"
+          with_together:
+             - "{{ cspi_bfr_expansion.stdout_lines }}"
+             - "{{ cspi_after_expansion.stdout_lines }}"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+          - set_fact:
+              flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test.yml
@@ -33,7 +33,7 @@
         - name: Obtain the CSPI size before expand the pool
           shell: >
             kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
-            -o custom-columns=:.status.capacity.total --no-headers | tr -d G
+            -o custom-columns=:.status.capacity.total --no-headers | tr -d G | tr -d M | tr -d k
           args:
             executable: /bin/bash
           register: cspi_bfr_expansion
@@ -84,7 +84,7 @@
         - name: Obtain the CSPI size after expand the pool
           shell: >
             kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
-            -o custom-columns=:.status.capacity.total --no-headers | tr -d G
+            -o custom-columns=:.status.capacity.total --no-headers | tr -d G | tr -d M | tr -d k
           args:
             executable: /bin/bash
           register: cspi_after_expansion

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test_vars.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test_vars.yml
@@ -1,7 +1,7 @@
 # Test-specific parameters
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
 test_name: cspc-pool-failure-expansion-in-progress
-pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_name: "{{ lookup('env',CSPC_NAME') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
 
 bd_count:

--- a/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test_vars.yml
+++ b/experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/test_vars.yml
@@ -1,0 +1,16 @@
+# Test-specific parameters
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+test_name: cspc-pool-failure-expansion-in-progress
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_type: "{{ lookup('env','POOL_TYPE') }}"
+
+bd_count:
+   stripe:
+      count: 1
+   mirror:
+      count: 2
+   raidz1:
+      count: 3
+   raidz2:
+      count: 6
+

--- a/experiments/functional/day2_ops/cspc_pool/pool_expansion/test.yml
+++ b/experiments/functional/day2_ops/cspc_pool/pool_expansion/test.yml
@@ -33,7 +33,7 @@
         - name: Obtain the CSPI size before expand the pool
           shell: >
             kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
-            -o custom-columns=:.status.capacity.total --no-headers | tr -d G
+            -o custom-columns=:.status.capacity.total --no-headers | tr -d G | tr -d M | tr -d k
           args:
             executable: /bin/bash
           register: cspi_bfr_expansion
@@ -84,7 +84,7 @@
         - name: Obtain the CSPI size after expand the pool
           shell: >
             kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }}
-            -o custom-columns=:.status.capacity.total --no-headers | tr -d G
+            -o custom-columns=:.status.capacity.total --no-headers | tr -d G | tr -d M | tr -d k
           args:
             executable: /bin/bash
           register: cspi_after_expansion


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Created the CSPC pool and performing the day_2 operation of pool expansion and verify the expansion is successfully done. In this test case while expanding the pool we forcefully deleting the pool pod to verify the pool expansion status
- For performing this chaos this test will get the  `POOL_NAME` as a env in run_litmus_test, and obtain the cspi list based on cspc pool and the pool expansion process will starts.

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [x] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [x] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
d2iq@rack2:~/sathya$ kubectl logs -f cspc-pool-failure-expansion-inprogress-5njhm-r4stb -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-06-25T06:55:17.000299 (delta: 0.042198)         elapsed: 0.042198 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-06-25T06:55:17.013235 (delta: 0.012902)         elapsed: 0.055134 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-06-25T06:55:24.598435 (delta: 7.585186)         elapsed: 7.640334 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-06-25T06:55:24.658826 (delta: 0.060366)         elapsed: 7.700725 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-06-25T06:55:24.702500 (delta: 0.043641)         elapsed: 7.744399 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-06-25T06:55:24.746840 (delta: 0.044293)         elapsed: 7.788739 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-06-25T06:55:24.820446 (delta: 0.073571)         elapsed: 7.862345 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8c61de66e8e1bf709f7c1ffa17e7882dc849257e", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "edc58ef1be1599b522c96ef4d226911a", "mode": "0644", "owner": "root", "size": 440, "src": "/root/.ansible/tmp/ansible-tmp-1593068124.86-26091516733261/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-06-25T06:55:25.388273 (delta: 0.567786)         elapsed: 8.430172 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.734180", "end": "2020-06-25 06:55:26.375287", "rc": 0, "start": "2020-06-25 06:55:25.641107", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cspc-pool-failure-expansion-in-progress \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cspc-pool-failure-expansion-in-progress ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-06-25T06:55:26.429751 (delta: 1.041442)         elapsed: 9.47165 ********* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-06-25T06:45:35Z", "generation": 3, "name": "cspc-pool-failure-expansion-in-progress", "resourceVersion": "281651", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cspc-pool-failure-expansion-in-progress", "uid": "477e424d-d1a2-4a76-bd65-8cd517438a39"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-06-25T06:55:27.234731 (delta: 0.804915)         elapsed: 10.27663 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-06-25T06:55:27.275685 (delta: 0.040909)         elapsed: 10.317584 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-06-25T06:55:27.318449 (delta: 0.042731)         elapsed: 10.360348 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the kubernetes host names from cspc] ******************************
2020-06-25T06:55:27.360193 (delta: 0.041708)         elapsed: 10.402092 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspc -n openebs -o jsonpath='{range .items[?(@.metadata.name==\"cstor-cspc-pool\")]}{range .spec.pools[*].nodeSelector}{.kubernetes\\.io\\/hostname}{\"\\n\"}{end}'", "delta": "0:00:01.024643", "end": "2020-06-25 06:55:28.533708", "rc": 0, "start": "2020-06-25 06:55:27.509065", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node3.mayalabs.io\nd2iq-node2.mayalabs.io\nd2iq-node1.mayalabs.io", "stdout_lines": ["d2iq-node3.mayalabs.io", "d2iq-node2.mayalabs.io", "d2iq-node1.mayalabs.io"]}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-06-25T06:55:28.602262 (delta: 1.242)         elapsed: 11.644161 ********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.735425", "end": "2020-06-25 06:55:29.498543", "rc": 0, "start": "2020-06-25 06:55:28.763118", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-92p7\ncstor-cspc-pool-mgfc\ncstor-cspc-pool-vkvd", "stdout_lines": ["cstor-cspc-pool-92p7", "cstor-cspc-pool-mgfc", "cstor-cspc-pool-vkvd"]}

TASK [Obtain the CSPI size before expand the pool] *****************************
2020-06-25T06:55:29.545592 (delta: 0.943283)         elapsed: 12.587491 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-pool -o custom-columns=:.status.capacity.total --no-headers | tr -d G | tr -d M | tr -d k", "delta": "0:00:00.882386", "end": "2020-06-25 06:55:30.573087", "rc": 0, "start": "2020-06-25 06:55:29.690701", "stderr": "", "stderr_lines": [], "stdout": "48200612\n48200612\n48200612", "stdout_lines": ["48200612", "48200612", "48200612"]}

TASK [Obtain the cspc pool spec in json format] ********************************
2020-06-25T06:55:30.616888 (delta: 1.07125)         elapsed: 13.658787 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspc -n openebs cstor-cspc-pool -o json > ./cspc-pool-expansion.json", "delta": "0:00:00.782884", "end": "2020-06-25 06:55:31.542130", "rc": 0, "start": "2020-06-25 06:55:30.759246", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-06-25T06:55:31.590163 (delta: 0.973243)         elapsed: 14.632062 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz1', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz1", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}}) => {"ansible_facts": {"disk_count": "1"}, "changed": false, "item": {"key": "stripe", "value": {"count": 1}}}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}

TASK [Add the block devices and patch the CSPC to expand the pool] *************
2020-06-25T06:55:31.706742 (delta: 0.116543)         elapsed: 14.748641 ******* 
included: /experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml for 127.0.0.1
included: /experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml for 127.0.0.1
included: /experiments/chaos/cspc_pool_failure/pool_expansion_inprogress/add_blockdevice.yml for 127.0.0.1

TASK [Get the cspi name to get the pool pod] ***********************************
2020-06-25T06:55:31.881565 (delta: 0.17477)         elapsed: 14.923464 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io,openebs.io/cstor-pool-cluster=cstor-cspc-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.925830", "end": "2020-06-25 06:55:32.959648", "rc": 0, "start": "2020-06-25 06:55:32.033818", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-92p7", "stdout_lines": ["cstor-cspc-pool-92p7"]}

TASK [Obtain the pool pod name to perform the chaos] ***************************
2020-06-25T06:55:33.004994 (delta: 1.123369)         elapsed: 16.046893 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-pool-92p7 -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.978087", "end": "2020-06-25 06:55:34.126917", "rc": 0, "start": "2020-06-25 06:55:33.148830", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-92p7-5966cdb857-xcdll", "stdout_lines": ["cstor-cspc-pool-92p7-5966cdb857-xcdll"]}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-06-25T06:55:34.174023 (delta: 1.168994)         elapsed: 17.215922 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node3.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:00.901765", "end": "2020-06-25 06:55:35.224554", "rc": 0, "start": "2020-06-25 06:55:34.322789", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-357eeb58371b74d641516544361a1825", "stdout_lines": ["blockdevice-357eeb58371b74d641516544361a1825"]}

TASK [Obtain the index position of the nodes from cspc json spec] **************
2020-06-25T06:55:35.284456 (delta: 1.110393)         elapsed: 18.326355 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "./node_index_count d2iq-node3.mayalabs.io ./cspc-pool-expansion.json", "delta": "0:00:00.703825", "end": "2020-06-25 06:55:36.135285", "rc": 0, "start": "2020-06-25 06:55:35.431460", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:36.183413 (delta: 0.898922)         elapsed: 19.225312 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cspc -n openebs cstor-cspc-pool --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/pools/0/dataRaidGroups/0/blockDevices/0\", \"value\": {\"blockDeviceName\": \"'blockdevice-357eeb58371b74d641516544361a1825'\"}}]'", "delta": "0:00:01.154619", "end": "2020-06-25 06:55:37.494723", "failed_when_result": false, "rc": 0, "start": "2020-06-25 06:55:36.340104", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.cstor.openebs.io/cstor-cspc-pool patched", "stdout_lines": ["cstorpoolcluster.cstor.openebs.io/cstor-cspc-pool patched"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:37.549566 (delta: 1.366116)         elapsed: 20.591465 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:37.601616 (delta: 0.052012)         elapsed: 20.643515 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:37.648232 (delta: 0.046579)         elapsed: 20.690131 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restart the pool pod when the pool expansion is in progress] *************
2020-06-25T06:55:37.699738 (delta: 0.05144)         elapsed: 20.741637 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po -n openebs cstor-cspc-pool-92p7-5966cdb857-xcdll --grace-period=0 --force", "delta": "0:00:00.917312", "end": "2020-06-25 06:55:38.764298", "rc": 0, "start": "2020-06-25 06:55:37.846986", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"cstor-cspc-pool-92p7-5966cdb857-xcdll\" force deleted", "stdout_lines": ["pod \"cstor-cspc-pool-92p7-5966cdb857-xcdll\" force deleted"]}

TASK [Check if the newly added Blockdevice is in Claimed state] ****************
2020-06-25T06:55:38.810267 (delta: 1.110471)         elapsed: 21.852166 ******* 
changed: [127.0.0.1] => (item=blockdevice-357eeb58371b74d641516544361a1825) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-357eeb58371b74d641516544361a1825 --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.742777", "end": "2020-06-25 06:55:39.710226", "item": "blockdevice-357eeb58371b74d641516544361a1825", "rc": 0, "start": "2020-06-25 06:55:38.967449", "stderr": "", "stderr_lines": [], "stdout": "Claimed", "stdout_lines": ["Claimed"]}

TASK [Get the cspi name to get the pool pod] ***********************************
2020-06-25T06:55:39.763400 (delta: 0.953096)         elapsed: 22.805299 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io,openebs.io/cstor-pool-cluster=cstor-cspc-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.719818", "end": "2020-06-25 06:55:40.647121", "rc": 0, "start": "2020-06-25 06:55:39.927303", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-vkvd", "stdout_lines": ["cstor-cspc-pool-vkvd"]}

TASK [Obtain the pool pod name to perform the chaos] ***************************
2020-06-25T06:55:40.693258 (delta: 0.929804)         elapsed: 23.735157 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-pool-vkvd -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.749163", "end": "2020-06-25 06:55:41.589142", "rc": 0, "start": "2020-06-25 06:55:40.839979", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-vkvd-6f86c97875-kfks8", "stdout_lines": ["cstor-cspc-pool-vkvd-6f86c97875-kfks8"]}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-06-25T06:55:41.643550 (delta: 0.950255)         elapsed: 24.685449 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node2.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:00.802703", "end": "2020-06-25 06:55:42.634465", "rc": 0, "start": "2020-06-25 06:55:41.831762", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-1a2a4a44b799f19916e7c4b0c7cc0324", "stdout_lines": ["blockdevice-1a2a4a44b799f19916e7c4b0c7cc0324"]}

TASK [Obtain the index position of the nodes from cspc json spec] **************
2020-06-25T06:55:42.686460 (delta: 1.042866)         elapsed: 25.728359 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "./node_index_count d2iq-node2.mayalabs.io ./cspc-pool-expansion.json", "delta": "0:00:00.645156", "end": "2020-06-25 06:55:43.476410", "rc": 0, "start": "2020-06-25 06:55:42.831254", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:43.521477 (delta: 0.834984)         elapsed: 26.563376 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cspc -n openebs cstor-cspc-pool --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/pools/1/dataRaidGroups/0/blockDevices/0\", \"value\": {\"blockDeviceName\": \"'blockdevice-1a2a4a44b799f19916e7c4b0c7cc0324'\"}}]'", "delta": "0:00:01.142876", "end": "2020-06-25 06:55:44.816611", "failed_when_result": false, "rc": 0, "start": "2020-06-25 06:55:43.673735", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.cstor.openebs.io/cstor-cspc-pool patched", "stdout_lines": ["cstorpoolcluster.cstor.openebs.io/cstor-cspc-pool patched"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:44.866533 (delta: 1.345022)         elapsed: 27.908432 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:44.921585 (delta: 0.055012)         elapsed: 27.963484 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:44.971119 (delta: 0.049465)         elapsed: 28.013018 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restart the pool pod when the pool expansion is in progress] *************
2020-06-25T06:55:45.021711 (delta: 0.050557)         elapsed: 28.06361 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po -n openebs cstor-cspc-pool-vkvd-6f86c97875-kfks8 --grace-period=0 --force", "delta": "0:00:00.755913", "end": "2020-06-25 06:55:45.928493", "rc": 0, "start": "2020-06-25 06:55:45.172580", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"cstor-cspc-pool-vkvd-6f86c97875-kfks8\" force deleted", "stdout_lines": ["pod \"cstor-cspc-pool-vkvd-6f86c97875-kfks8\" force deleted"]}

TASK [Check if the newly added Blockdevice is in Claimed state] ****************
2020-06-25T06:55:45.974555 (delta: 0.952809)         elapsed: 29.016454 ******* 
changed: [127.0.0.1] => (item=blockdevice-1a2a4a44b799f19916e7c4b0c7cc0324) => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-1a2a4a44b799f19916e7c4b0c7cc0324 --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.755821", "end": "2020-06-25 06:55:46.891242", "item": "blockdevice-1a2a4a44b799f19916e7c4b0c7cc0324", "rc": 0, "start": "2020-06-25 06:55:46.135421", "stderr": "", "stderr_lines": [], "stdout": "Claimed", "stdout_lines": ["Claimed"]}

TASK [Get the cspi name to get the pool pod] ***********************************
2020-06-25T06:55:46.944129 (delta: 0.969537)         elapsed: 29.986028 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io,openebs.io/cstor-pool-cluster=cstor-cspc-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.928891", "end": "2020-06-25 06:55:48.030725", "rc": 0, "start": "2020-06-25 06:55:47.101834", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-mgfc", "stdout_lines": ["cstor-cspc-pool-mgfc"]}

TASK [Obtain the pool pod name to perform the chaos] ***************************
2020-06-25T06:55:48.075409 (delta: 1.131243)         elapsed: 31.117308 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-pool-mgfc -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.903081", "end": "2020-06-25 06:55:49.126809", "rc": 0, "start": "2020-06-25 06:55:48.223728", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-pool-mgfc-5f74f984d6-94kjv", "stdout_lines": ["cstor-cspc-pool-mgfc-5f74f984d6-94kjv"]}

TASK [Getting the Unclaimed block-device from each node] ***********************
2020-06-25T06:55:49.178820 (delta: 1.103376)         elapsed: 32.220719 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=d2iq-node1.mayalabs.io -o jsonpath='{.items[?(@.status.claimState==\"Unclaimed\")].metadata.name}' | tr \" \" \"\\n\" | grep -v sparse | head -n \"1\"", "delta": "0:00:00.945260", "end": "2020-06-25 06:55:50.274145", "rc": 0, "start": "2020-06-25 06:55:49.328885", "stderr": "", "stderr_lines": [], "stdout": "blockdevice-74581b930362b0bfb5d6cdb89513e95e", "stdout_lines": ["blockdevice-74581b930362b0bfb5d6cdb89513e95e"]}

TASK [Obtain the index position of the nodes from cspc json spec] **************
2020-06-25T06:55:50.323059 (delta: 1.144203)         elapsed: 33.364958 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "./node_index_count d2iq-node1.mayalabs.io ./cspc-pool-expansion.json", "delta": "0:00:00.743430", "end": "2020-06-25 06:55:51.214282", "rc": 0, "start": "2020-06-25 06:55:50.470852", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:51.258367 (delta: 0.935275)         elapsed: 34.300266 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cspc -n openebs cstor-cspc-pool --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/pools/2/dataRaidGroups/0/blockDevices/0\", \"value\": {\"blockDeviceName\": \"'blockdevice-74581b930362b0bfb5d6cdb89513e95e'\"}}]'", "delta": "0:00:02.240559", "end": "2020-06-25 06:55:53.647393", "failed_when_result": false, "rc": 0, "start": "2020-06-25 06:55:51.406834", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.cstor.openebs.io/cstor-cspc-pool patched", "stdout_lines": ["cstorpoolcluster.cstor.openebs.io/cstor-cspc-pool patched"]}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:53.696566 (delta: 2.438164)         elapsed: 36.738465 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:53.743902 (delta: 0.047302)         elapsed: 36.785801 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patch the CSPC to expand the pool size] **********************************
2020-06-25T06:55:53.790966 (delta: 0.047024)         elapsed: 36.832865 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restart the pool pod when the pool expansion is in progress] *************
2020-06-25T06:55:53.837465 (delta: 0.046465)         elapsed: 36.879364 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po -n openebs cstor-cspc-pool-mgfc-5f74f984d6-94kjv --grace-period=0 --force", "delta": "0:00:01.730297", "end": "2020-06-25 06:55:55.710564", "rc": 0, "start": "2020-06-25 06:55:53.980267", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"cstor-cspc-pool-mgfc-5f74f984d6-94kjv\" force deleted", "stdout_lines": ["pod \"cstor-cspc-pool-mgfc-5f74f984d6-94kjv\" force deleted"]}

TASK [Check if the newly added Blockdevice is in Claimed state] ****************
2020-06-25T06:55:55.755943 (delta: 1.918445)         elapsed: 38.797842 ******* 
FAILED - RETRYING: Check if the newly added Blockdevice is in Claimed state (60 retries left).
changed: [127.0.0.1] => (item=blockdevice-74581b930362b0bfb5d6cdb89513e95e) => {"attempts": 2, "changed": true, "cmd": "kubectl get blockdevice -n openebs blockdevice-74581b930362b0bfb5d6cdb89513e95e --no-headers -o custom-columns=:.status.claimState", "delta": "0:00:00.749025", "end": "2020-06-25 06:56:02.522145", "item": "blockdevice-74581b930362b0bfb5d6cdb89513e95e", "rc": 0, "start": "2020-06-25 06:56:01.773120", "stderr": "", "stderr_lines": [], "stdout": "Claimed", "stdout_lines": ["Claimed"]}

TASK [Verify the status of CSPI after expanding the pool] **********************
2020-06-25T06:56:02.574557 (delta: 6.818563)         elapsed: 45.616456 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-pool-92p7) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-pool-92p7\")].status.phase}'", "delta": "0:00:00.909896", "end": "2020-06-25 06:56:03.637308", "item": "cstor-cspc-pool-92p7", "rc": 0, "start": "2020-06-25 06:56:02.727412", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-pool-mgfc) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-pool-mgfc\")].status.phase}'", "delta": "0:00:00.908845", "end": "2020-06-25 06:56:04.681133", "item": "cstor-cspc-pool-mgfc", "rc": 0, "start": "2020-06-25 06:56:03.772288", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}
changed: [127.0.0.1] => (item=cstor-cspc-pool-vkvd) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -o jsonpath='{.items[?(@.metadata.name==\"cstor-cspc-pool-vkvd\")].status.phase}'", "delta": "0:00:00.946842", "end": "2020-06-25 06:56:05.765853", "item": "cstor-cspc-pool-vkvd", "rc": 0, "start": "2020-06-25 06:56:04.819011", "stderr": "", "stderr_lines": [], "stdout": "ONLINE", "stdout_lines": ["ONLINE"]}

TASK [Verify if cStor Pool pods are Running after pool expansion] **************
2020-06-25T06:56:05.813512 (delta: 3.238919)         elapsed: 48.855411 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-pool-92p7) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-pool-92p7 --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.767155", "end": "2020-06-25 06:56:06.728592", "item": "cstor-cspc-pool-92p7", "rc": 0, "start": "2020-06-25 06:56:05.961437", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-pool-mgfc) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-pool-mgfc --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.772556", "end": "2020-06-25 06:56:08.643872", "item": "cstor-cspc-pool-mgfc", "rc": 0, "start": "2020-06-25 06:56:06.871316", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
changed: [127.0.0.1] => (item=cstor-cspc-pool-vkvd) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-instance=cstor-cspc-pool-vkvd --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.750407", "end": "2020-06-25 06:56:09.530359", "item": "cstor-cspc-pool-vkvd", "rc": 0, "start": "2020-06-25 06:56:08.779952", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [sleep for 120 seconds and continue with play] ****************************
2020-06-25T06:56:09.581444 (delta: 3.767864)         elapsed: 52.623343 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 120, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Obtain the CSPI size after expand the pool] ******************************
2020-06-25T06:58:10.022113 (delta: 120.440634)         elapsed: 173.064012 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-pool -o custom-columns=:.status.capacity.total --no-headers | tr -d G | tr -d M | tr -d k", "delta": "0:00:00.775852", "end": "2020-06-25 06:58:10.958545", "rc": 0, "start": "2020-06-25 06:58:10.182693", "stderr": "", "stderr_lines": [], "stdout": "96400069500\n96400069500\n96400069500", "stdout_lines": ["96400069500", "96400069500", "96400069500"]}

TASK [check if the CSPC pool has been expanded] ********************************
2020-06-25T06:58:11.018912 (delta: 0.996761)         elapsed: 174.060811 ****** 
changed: [127.0.0.1] => (item=[u'48200612', u'96400069500']) => {"changed": true, "cmd": "if (( $(echo \"96400069500 > 48200612\" | bc -l) )) ; then echo \"pass\"; else echo \"fail\";fi;", "delta": "0:00:00.824031", "end": "2020-06-25 06:58:12.026171", "failed_when_result": false, "item": ["48200612", "96400069500"], "rc": 0, "start": "2020-06-25 06:58:11.202140", "stderr": "", "stderr_lines": [], "stdout": "pass", "stdout_lines": ["pass"]}
changed: [127.0.0.1] => (item=[u'48200612', u'96400069500']) => {"changed": true, "cmd": "if (( $(echo \"96400069500 > 48200612\" | bc -l) )) ; then echo \"pass\"; else echo \"fail\";fi;", "delta": "0:00:00.834249", "end": "2020-06-25 06:58:12.996712", "failed_when_result": false, "item": ["48200612", "96400069500"], "rc": 0, "start": "2020-06-25 06:58:12.162463", "stderr": "", "stderr_lines": [], "stdout": "pass", "stdout_lines": ["pass"]}
changed: [127.0.0.1] => (item=[u'48200612', u'96400069500']) => {"changed": true, "cmd": "if (( $(echo \"96400069500 > 48200612\" | bc -l) )) ; then echo \"pass\"; else echo \"fail\";fi;", "delta": "0:00:00.657122", "end": "2020-06-25 06:58:13.823045", "failed_when_result": false, "item": ["48200612", "96400069500"], "rc": 0, "start": "2020-06-25 06:58:13.165923", "stderr": "", "stderr_lines": [], "stdout": "pass", "stdout_lines": ["pass"]}

TASK [set_fact] ****************************************************************
2020-06-25T06:58:13.879615 (delta: 2.860665)         elapsed: 176.921514 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-06-25T06:58:13.945781 (delta: 0.066133)         elapsed: 176.98768 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-06-25T06:58:14.028068 (delta: 0.082235)         elapsed: 177.069967 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-06-25T06:58:14.085662 (delta: 0.05754)         elapsed: 177.127561 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-06-25T06:58:14.138042 (delta: 0.052311)         elapsed: 177.179941 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-06-25T06:58:14.186125 (delta: 0.048047)         elapsed: 177.228024 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "6a78e940e80dcc56b5a99e6b0e92f2f0096994c9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f6115bf7dc4f15ea828bda4eb17ef8f", "mode": "0644", "owner": "root", "size": 438, "src": "/root/.ansible/tmp/ansible-tmp-1593068294.23-224891825657989/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-06-25T06:58:15.809519 (delta: 1.623357)         elapsed: 178.851418 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.645745", "end": "2020-06-25 06:58:16.620980", "rc": 0, "start": "2020-06-25 06:58:15.975235", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cspc-pool-failure-expansion-in-progress \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cspc-pool-failure-expansion-in-progress ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-06-25T06:58:16.677313 (delta: 0.867762)         elapsed: 179.719212 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-06-25T06:45:35Z", "generation": 4, "name": "cspc-pool-failure-expansion-in-progress", "resourceVersion": "282772", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cspc-pool-failure-expansion-in-progress", "uid": "477e424d-d1a2-4a76-bd65-8cd517438a39"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=45   changed=35   unreachable=0    failed=0   

2020-06-25T06:58:17.355071 (delta: 0.677723)         elapsed: 180.39697 ******* 
=============================================================================== 
```
