### PR TITLE
refactor[chaos-utils]: Modified the task to get the volume mode and volume status in jiva controller

### DIFF
--- a/chaoslib/openebs/jiva_controller_network_delay.yaml
+++ b/chaoslib/openebs/jiva_controller_network_delay.yaml
@@ -68,7 +68,7 @@
 - name: Getting the ReplicaCount before injecting delay
   shell: >
    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
-   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+   -c {{ jiva_controller_name }} curl http://127.0.01:9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
   register: rcount_before
@@ -92,7 +92,7 @@
 - name: Verifying the Replica getting disconnected
   shell: >
    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
-   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+   -c {{ jiva_controller_name }} curl http://127.0.0.1:9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
   register: resp
@@ -119,7 +119,7 @@
 - name: Verifying the replicas post network recovery
   shell: >
    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ operator_ns }} 
-   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+   -c {{ jiva_controller_name }} curl http://127.0.0.1:9501/v1/volumes | jq -r '.data[].replicaCount'
   args:
     executable: /bin/bash
   register: replica

--- a/chaoslib/openebs/jiva_controller_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_controller_pod_failure.yaml
@@ -52,7 +52,7 @@
 - name: Getting the Replicastatus before killing controller
   shell: >
    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ target_ns }} 
-   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/replicas | jq -r '.data[].mode'
+   -c {{ jiva_controller_name }} curl http://127.0.0.1:9501/v1/replicas | jq -r '.data[].mode'
   args:
     executable: /bin/bash
   register: rstatus_before  
@@ -92,7 +92,7 @@
 - name: Getting the Replicastatus after killing the controller
   shell: >
    kubectl exec -it {{ jctrl_pod_after.stdout }} -n {{ target_ns }}
-   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/replicas | jq -r '.data[].mode'
+   -c {{ jiva_controller_name }} curl http://127.0.0.1:9501/v1/replicas | jq -r '.data[].mode'
   args:
     executable: /bin/bash
   register: rstatus_after


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the task to obtain the replica status and volume mode in the jiva controller
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
