### PR TITLE
Fix(typo): Set default version of velero to v1.1.0

### DIFF
--- a/experiments/functional/backup_and_restore/run_litmus_test.yml
+++ b/experiments/functional/backup_and_restore/run_litmus_test.yml
@@ -53,7 +53,7 @@ spec:
             value: "openebs/velero-plugin:ci"
 
           - name: VELERO_VERSION
-            value: "v1.3.0"
+            value: "v1.1.0"
 
           #Supported values are {'minio', 'GCP'}
           - name: STORAGE_BUCKET


### PR DESCRIPTION
Signed-off-by: <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Sed Replace on velero version is happening on v1.10 in every pipeline. 

**Special notes for your reviewer**:
