### PR TITLE
refactor[test]: Updated the storage class for memcheck testcase job

### DIFF
--- a/experiments/functional/custom/tests/memcheck/run_litmus_test.yml
+++ b/experiments/functional/custom/tests/memcheck/run_litmus_test.yml
@@ -22,7 +22,7 @@ spec:
             value: default
 
           - name: PROVIDER_STORAGE_CLASS
-            value: openebs-standard
+            value: openebs-jiva-default
 
           - name: APP_NAMESPACE
             value: memleak

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -19,7 +19,7 @@
         - block: 
 
             - name: Getting the compute node name
-              shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'}
+              shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -n "{{ maxpool_count }}"
               register: nodes
 
             - name: Replacing the pool type in SPC spec

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -19,7 +19,7 @@
         - block: 
 
             - name: Getting the compute node name
-              shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -n "{{ maxpool_count }}"
+              shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'}
               register: nodes
 
             - name: Replacing the pool type in SPC spec

--- a/providers/openebs/installers/operator/openebs-provision/test.yml
+++ b/providers/openebs/installers/operator/openebs-provision/test.yml
@@ -167,63 +167,6 @@
               register: service_account
               failed_when: 'service_account.stdout == ""'
 
-            - block:
-         
-                - name: Downloading openebs cspc-operator.yaml
-                  get_url:
-                    url: "{{ cspc_operator_link }}"
-                    dest: "{{ playbook_dir }}/{{ cspc_operator }}"
-                    force: yes
-                  register: result
-                  until:  "'OK' in result.msg"
-                  delay: 5
-                  retries: 3
-
-                - name: Change CSPC operator image
-                  replace:
-                    path: "{{ cspc_operator }}"
-                    regexp: quay.io/openebs/cspc-operator:ci
-                    replace: quay.io/openebs/cspc-operator:{{ release_version }}
-
-                - name: Change OPENEBS_IO_CSPI_MGMT image
-                  replace:
-                    path: "{{ cspc_operator }}"
-                    regexp: quay.io/openebs/cspi-mgmt:ci
-                    replace: quay.io/openebs/cspi-mgmt:{{ release_version }}
-
-                - name: Change OPENEBS_IO_CSTOR_POOL image
-                  replace:
-                    path: "{{ cspc_operator }}"
-                    regexp: quay.io/openebs/cstor-pool:ci
-                    replace: quay.io/openebs/cstor-pool:{{ release_version }}
-
-                - name: Change openebs maya exporter image in cspc spec
-                  replace:
-                    path: "{{ cspc_operator }}"
-                    regexp: quay.io/openebs/m-exporter:ci
-                    replace: quay.io/openebs/m-exporter:{{ release_version }}
-                  
-                - name: Change the service account name in CSPC operator
-                  replace:
-                    path: "{{ cspc_operator }}"
-                    regexp: 'serviceAccountName: openebs-maya-operator'
-                    replace: 'serviceAccountName: "{{ service_account.stdout }}"'
-
-                - name: Applying CSPC operator
-                  shell: kubectl apply -f {{ cspc_operator }}
-                  args:
-                    executable: /bin/bash
-                  ignore_errors: true
-
-                - name: Checking OpenEBS-CSPC-Operator is running
-                  shell: kubectl get pods -n {{ operator_ns }} -o jsonpath='{.items[?(@.metadata.labels.name=="cspc-operator")].status.phase}'
-                  register: cspc_status
-                  until: "'Running' in cspc_status.stdout"
-                  delay: 5
-                  retries: 120
-              
-              when: "release_version is version('1.2.0', '>=') or release_version == 'ci'"
-
             - name: Verify that rolling update of maya-apiserver is completed
               shell: >
                 kubectl get pods --no-headers -n {{ operator_ns }}
@@ -311,16 +254,6 @@
 
         - block:
 
-            - name: Downloading openebs cspc-operator.yaml
-              get_url:
-                url: "{{ cspc_operator_link }}"
-                dest: "{{ playbook_dir }}/{{ cspc_operator }}"
-                force: yes
-              register: result
-              until:  "'OK' in result.msg"
-              delay: 5
-              retries: 3                
-
             - name: Downloading openebs-operator.yaml
               get_url:
                 url: "{{ openebs_operator_link }}"
@@ -330,12 +263,6 @@
               until:  "'OK' in result.msg"
               delay: 5
               retries: 3
-
-            - name: Cleaning cspc operator
-              shell: kubectl delete -f {{ cspc_operator }}
-              args:
-                executable: /bin/bash
-              ignore_errors: True
 
             - name: Cleaning openebs operator
               shell: kubectl delete -f {{ openebs_operator }}
@@ -357,7 +284,6 @@
                 - "openebs-admission-server"
                 - "openebs-localpv-provisioner"
                 - "openebs-ndm"
-                - "cspc-operator"
               delay: 30
               retries: 100
 

--- a/providers/openebs/installers/operator/openebs-provision/test_vars.yml
+++ b/providers/openebs/installers/operator/openebs-provision/test_vars.yml
@@ -1,9 +1,7 @@
 kubeapply: kubectl --kubeconfig /root/admin.conf
 openebs_operator_link: "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"
-cspc_operator_link: "https://raw.githubusercontent.com/openebs/openebs/master/k8s/cstor-operator.yaml"
 openebs_link: "https://openebs.github.io/charts/openebs-operator-{{ lookup('env','RELEASE_VERSION') }}.yaml"
 openebs_operator: openebs-operator.yaml
-cspc_operator: cstor-operator.yaml
 psp_spec: openebs_psp.yaml
 test_name: openebs-provision
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Updated the storage class for memcheck test case 
- Removed the v1/beta cstor operator task from openebs provision test.

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
