### PR TITLE
refact(exp): refactor the zfspv-provisioner litmusbook for using CentOS based operator file

### DIFF
--- a/providers/zfs-localpv-provisioner/run_litmus_test.yml
+++ b/providers/zfs-localpv-provisioner/run_litmus_test.yml
@@ -34,6 +34,13 @@ spec:
           - name: ZFS_DRIVER_IMAGE
             value: ''
 
+            ## This env will be used to select zfs-operator file for 
+            ## specific Operating system on which k8s cluster is created
+            ## For ubuntu based cluster give value as `ubuntu` (for both either 18.04 or 16.04)
+            ## For CentOS based cluster give value as either `centos7` or `centos8` accordingly
+          - name: OS_NAME  
+            value: ''  
+
             ## Storage class will be created with the name provided here
           - name: STORAGE_CLASS  
             value: ''

--- a/providers/zfs-localpv-provisioner/test.yml
+++ b/providers/zfs-localpv-provisioner/test.yml
@@ -21,16 +21,39 @@
 
           - include_tasks: /utils/zpool_creation/create_zpool.yml
         
-          - name: Download OpenEBS ZFS driver file
+          - name: Download OpenEBS ZFS driver file when OS is ubuntu
             get_url:
               url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ zfs_branch }}/deploy/zfs-operator.yaml
               dest: ./zfs_operator.yml
               force: yes
             register: result
+            when: lookup('env','OS_NAME') == 'ubuntu'
             until: "'OK' in result.msg"
             delay: 5
             retries: 3
-              
+
+          - name: Download OpenEBS ZFS driver file when OS is CentOS7
+            get_url:
+              url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ zfs_branch }}/deploy/operators/centos7/zfs-operator.yaml
+              dest: ./zfs_operator.yml
+              force: yes
+            register: result
+            when: lookup('env','OS_NAME') == 'centos7'
+            until: "'OK' in result.msg"
+            delay: 5
+            retries: 3
+
+          - name: Download OpenEBS ZFS driver file when OS is CentOS8
+            get_url:
+              url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ zfs_branch }}/deploy/operators/centos8/zfs-operator.yaml
+              dest: ./zfs_operator.yml
+              force: yes
+            register: result
+            when: lookup('env','OS_NAME') == 'centos8'
+            until: "'OK' in result.msg"
+            delay: 5
+            retries: 3
+    
           - name: Update the openebs zfs-driver image tag
             replace:
               path: ./zfs_operator.yml


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Previously we're using zfs-operator file for ubuntu based only. 
  As now zfs-localpv is supported on CentOS based clusters as well, so refactored the litmusbook to download operator file according to the Operating-system (ubuntu, centos7, centos8)
- for this we have to give this value in OS_NAME env in the run_litmus_test.yml file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #411

