### PR TITLE
add(storage-class): Added single-replica storage-class yaml in csi-provisioner

### DIFF
--- a/providers/csi-provisioner/csi-cstor-sc.j2
+++ b/providers/csi-provisioner/csi-cstor-sc.j2
@@ -11,3 +11,17 @@ parameters:
   cas-type: cstor
   cstorPoolCluster: {{ cspc }}
   replicaCount: "{{ replica_count }}"
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ storage_class }}-single-replica
+  annotations:
+    openebs.io/cas-type: cstor
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  cas-type: cstor
+  cstorPoolCluster: {{ cspc }}
+  replicaCount: "1"

--- a/providers/csi-provisioner/csi-cstor-xfs-sc.j2
+++ b/providers/csi-provisioner/csi-cstor-xfs-sc.j2
@@ -10,3 +10,16 @@ parameters:
   replicaCount: "{{ replica_count }}"
   cstorPoolCluster: {{ cspc }}
   fsType: xfs
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ storage_class }}-xfs-single-replica
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  cas-type: cstor
+  replicaCount: "1"
+  cstorPoolCluster: {{ cspc }}
+  fsType: xfs


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR adds single-replica storage-class in csi-provisioner setup test
- This SC can be used for e.g. in scaling up volumes