### PR TITLE
refact(exp): Added the missing env  in csi-vol-scale test

### DIFF
--- a/experiments/functional/cStor/cstor-csi-volume-scaledown/run_litmus_test.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaledown/run_litmus_test.yml
@@ -37,6 +37,9 @@ spec:
           - name: APP_PVC
             value: ''
 
+          - name: APP_LABEL
+            value: ''
+            
           - name: OPENEBS_NAMESPACE
             value: "openebs"
 

--- a/experiments/functional/cStor/cstor-csi-volume-scaledown/test_vars.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaledown/test_vars.yml
@@ -4,6 +4,8 @@ namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 
 pvc_name: "{{ lookup('env','APP_PVC') }}"
 
+label: "{{ lookup('env','APP_LABEL') }}"
+
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 
 openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"

--- a/experiments/functional/cStor/cstor-csi-volume-scaleup/run_litmus_test.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaleup/run_litmus_test.yml
@@ -37,6 +37,9 @@ spec:
           - name: APP_PVC
             value: ''
 
+          - name: APP_LABEL
+            value: ''
+
           - name: OPENEBS_NAMESPACE
             value: "openebs"
 

--- a/experiments/functional/cStor/cstor-csi-volume-scaleup/test_vars.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaleup/test_vars.yml
@@ -4,6 +4,8 @@ namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 
 pvc_name: "{{ lookup('env','APP_PVC') }}"
 
+label: "{{ lookup('env','APP_LABEL') }}"
+
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 
 openebs_ns: "{{ lookup('env','OPENEBS_NAMESPACE') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR adds the missing env `app_label` in csi-vol-scaling tests. this env is used in case of checking the data-persistence

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #417

