### PR TITLE
refact(exp): changed namespace to operator_ns in target network loss experiment for jiva

### DIFF
--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -207,7 +207,7 @@
           vars:
             status: "induce"
             target_pod: "{{ controller_pod.stdout }}"
-            operator_namespace: "{{ namespace }}"
+            operator_namespace: "{{ operator_ns }}"
             containername: "{{ pv.stdout }}-ctrl-con"
           when: 
             - cri == 'containerd' or cri =='cri-o'  
@@ -243,7 +243,7 @@
           vars:
             status: "remove"
             target_pod: "{{ controller_pod.stdout }}"
-            operator_namespace: "{{ namespace }}"
+            operator_namespace: "{{ operator_ns }}"
             containername: "{{ pv.stdout }}-ctrl-con"
           when: 
             - cri == 'containerd' or cri =='cri-o'  

--- a/experiments/chaos/openebs_target_network_loss/test.yml
+++ b/experiments/chaos/openebs_target_network_loss/test.yml
@@ -105,7 +105,7 @@
 
             - name: Patching jiva controller deployment to allow security privileged
               shell: >
-                kubectl patch deployment {{ pv.stdout }}-ctrl -n {{ namespace }}
+                kubectl patch deployment {{ pv.stdout }}-ctrl -n {{ operator_ns }}
                 --patch "$(cat patch.yml)"
               register: patch_status
               failed_when: "'patched' not in patch_status.stdout"
@@ -117,7 +117,7 @@
             - name: Identify the jiva controller pod belonging to the PV
               shell: > 
                 kubectl get pods -l openebs.io/controller=jiva-controller
-                -n {{ namespace }} --no-headers | grep {{ pv.stdout }} 
+                -n {{ operator_ns }} --no-headers | grep {{ pv.stdout }} 
                 | awk '{print $1}'
               args:
                 executable: /bin/bash
@@ -125,7 +125,7 @@
 
             - name: Check for the jiva controller container status
               shell: >
-                kubectl get pods {{ controller_pod.stdout }} -n {{ namespace }} 
+                kubectl get pods {{ controller_pod.stdout }} -n {{ operator_ns }} 
                 -o jsonpath='{.status.containerStatuses[?(@.name=="{{ pv.stdout}}-ctrl-con")].state}' | grep running
               args:
                 executable: /bin/bash


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- As jiva controllers and replicas are now in openebs namespace, so changed the namespace values to operator_ns

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/openebs/e2e-tests/issues/408

