### PR TITLE
refact(exp): filter the application pod name based on app_label in a namespace

### DIFF
--- a/experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml
@@ -32,14 +32,14 @@
 
         - name: Get the application pod name
           shell: >
-            kubectl get pod -n {{ namespace }} --no-headers -o custom-columns=:.metadata.name
+            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: app_pod_name
 
         - name: Check if the application pod is in running state
           shell: >
-            kubectl get pods -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash
           register: pod_status
@@ -138,7 +138,7 @@
 
         - name: Get the application pod name
           shell: >
-            kubectl get pod -n {{ namespace }} --no-headers -o custom-columns=:.metadata.name
+            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: rescheduled_pod_name

--- a/experiments/functional/cStor/cstor-csi-volume-scaleup/test.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaleup/test.yml
@@ -32,14 +32,14 @@
         
         - name: Get the application pod name
           shell: >
-            kubectl get pod -n {{ namespace }} --no-headers -o custom-columns=:.metadata.name
+            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: app_pod_name
 
         - name: Check if the application pod is in running state
           shell: >
-            kubectl get pods -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+            kubectl get pods -n {{ namespace }} -l {{ label }}--no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash
           register: pod_status
@@ -162,7 +162,7 @@
 
         - name: Get the application pod name
           shell: >
-            kubectl get pod -n {{ namespace }} --no-headers -o custom-columns=:.metadata.name
+            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o custom-columns=:.metadata.name
           args:
             executable: /bin/bash
           register: rescheduled_pod_name


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- filter the application pod name based on app_label in a namespace
- In pipelines we have liveness pod as well in app_namespaces

