### PR TITLE
refactor(backup/restore): Change conditionals format over the block

### DIFF
--- a/experiments/functional/backup_and_restore/test.yml
+++ b/experiments/functional/backup_and_restore/test.yml
@@ -45,7 +45,9 @@
            - name: Writing data on application mount point
              shell: kubectl exec -it {{ app_pod.stdout }} -n {{ app_ns }} -- sh -c "cd {{ app_mount_path.stdout }} && dd if=/dev/urandom of=test.txt bs=4k count=655360"
 
-          when: "storage_engine == 'cstor' or storage_engine == 'cstor-csi' and lookup('env','COMPONENT_FAILURE') != ''"
+          when: 
+            - "storage_engine == 'cstor' or storage_engine == 'cstor-csi'" 
+            - lookup('env','COMPONENT_FAILURE') != ''
 
         - block:
             
@@ -103,7 +105,9 @@
              shell: velero backup get | grep Completed | tail -1 | awk '{print $1}'
              register: basebackup_name 
 
-          when: "storage_engine == 'cstor' or storage_engine == 'cstor-csi' and lookup('env','COMPONENT_FAILURE') != ''"
+          when: 
+            - "storage_engine == 'cstor' or storage_engine == 'cstor-csi'"
+            - lookup('env','COMPONENT_FAILURE') != ''
 
         - name: Getting state of backup
           include_tasks: "./backup-restore.yml"
@@ -117,7 +121,9 @@
           vars:
             back_up_name: "{{ backup_name }}"
             action: 'SNAPSHOT_DELETE'
-          when: "storage_engine == 'cstor' or storage_engine == 'cstor-csi' and lookup('env','COMPONENT_FAILURE') == '' and lookup('env','LOCAL_SNAPSHOT') == 'false'"
+          when: 
+            - "storage_engine == 'cstor' or storage_engine == 'cstor-csi'"
+            - lookup('env','COMPONENT_FAILURE') == '' and lookup('env','LOCAL_SNAPSHOT') == 'false'
 
         - block:
 
@@ -138,8 +144,7 @@
              delay: 5
              retries: 15
              
-          when: lookup('env','LOCAL_SNAPSHOT') == "false"
-        
+          when: lookup('env','LOCAL_SNAPSHOT') == "false"      
 
         - block: 
 
@@ -201,7 +206,9 @@
 
              when: lookup('env','RESTORE_IN_DIFF_NAMESPACE') == "true" 
           
-          when: storage_engine == "cstor" or storage_engine == 'cstor-csi' and lookup('env','LOCAL_SNAPSHOT') == "false"
+          when: 
+            - "storage_engine == 'cstor' or storage_engine == 'cstor-csi'" 
+            - lookup('env','LOCAL_SNAPSHOT') == "false"
 
         - block: 
 


### PR DESCRIPTION
Signed-off-by: <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The existing experiment is performing proper AND operations over the block.
- `<statement-1> OR <statement-1> AND <statement-3>`, this conditional format is not supported in ansible.
- Instead we can achieve the above logic as:
```
when:
     - <statement-1> or <statement-2>
     - <statement-3>
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
