### PR TITLE
feat[csi-network-delay]: Included condition to perform the network delay in cstor csi volumes

### DIFF
--- a/experiments/chaos/openebs_target_network_delay/chaosutil.j2
+++ b/experiments/chaos/openebs_target_network_delay/chaosutil.j2
@@ -1,4 +1,4 @@
-{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+{% if stg_prov is defined and (stg_prov == 'openebs.io/provisioner-iscsi' or stg_prov == 'cstor.csi.openebs.io') %}
   {% if stg_engine is defined and stg_engine == 'cstor' and cri == 'docker' %}
     chaosutil: openebs/cstor_target_network_delay.yaml
   {% elif stg_engine is defined and stg_engine == 'cstor' and (cri == 'containerd' or cri == 'cri-o') %}

--- a/experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
+++ b/experiments/chaos/openebs_target_network_delay/test_prerequisites.yml
@@ -45,6 +45,28 @@
         stg_engine: "{{ openebs_stg_engine.stdout }}"
   when: stg_prov == "openebs.io/provisioner-iscsi"
 
+- block:
+  - name: Derive PV name from PVC to query storage engine type (openebs)
+    shell: >
+      kubectl get pvc {{ pvc }} -n {{ namespace }}
+      --no-headers -o custom-columns=:spec.volumeName
+    args:
+      executable: /bin/bash
+    register: pv
+
+  - name: Check for presence & value of cas type annotation
+    shell: >
+      kubectl get pv {{ pv.stdout }} --no-headers
+      -o jsonpath="{.spec.csi.volumeAttributes.openebs\\.io/cas-type}"
+    args:
+      executable: /bin/bash
+    register: openebs_stg_engine
+
+  - name: Record the storage engine name
+    set_fact:
+      stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "cstor.csi.openebs.io"
+
 - name: Identify the chaos util to be invoked 
   template:
     src: chaosutil.j2


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- This test case is about to perform network delay on the cstor csi target cstor-istgt container
- In this test first pumba daemonset is deployed in the nodes to perform the chaos, Identified the pumba pod which scheduled on the target pod scheduled node.
- Finally it perform the netem delay of 60s in the cstor-istgt container and verifying the application data persistence
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Apr 15 2020, 17:20:14) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/openebs_target_network_delay/test.yml

PLAY [localhost] ***************************************************************
2020-06-29T08:52:08.058203 (delta: 0.04023)         elapsed: 0.04023 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:2
2020-06-29T08:52:08.068623 (delta: 0.010377)         elapsed: 0.05065 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:13
2020-06-29T08:52:14.216575 (delta: 6.147938)         elapsed: 6.198602 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:17
2020-06-29T08:52:14.266607 (delta: 0.049976)         elapsed: 6.248634 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-06-29T08:52:14.343279 (delta: 0.07664)         elapsed: 6.325306 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-06-29T08:52:14.393378 (delta: 0.050008)         elapsed: 6.375405 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:2
2020-06-29T08:52:14.448764 (delta: 0.055351)         elapsed: 6.430791 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc testclaim -n percona --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:00.732013", "end": "2020-06-29 08:52:15.413283", "rc": 0, "start": "2020-06-29 08:52:14.681270", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-sc", "stdout_lines": ["cstor-cspc-disk-pool-sc"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:10
2020-06-29T08:52:15.460426 (delta: 1.011618)         elapsed: 7.442453 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc cstor-cspc-disk-pool-sc --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.625355", "end": "2020-06-29 08:52:16.207731", "rc": 0, "start": "2020-06-29 08:52:15.582376", "stderr": "", "stderr_lines": [], "stdout": "cstor.csi.openebs.io", "stdout_lines": ["cstor.csi.openebs.io"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:18
2020-06-29T08:52:16.252828 (delta: 0.792357)         elapsed: 8.234855 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "cstor-cspc-disk-pool-sc"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:22
2020-06-29T08:52:16.317520 (delta: 0.064661)         elapsed: 8.299547 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "cstor.csi.openebs.io"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:27
2020-06-29T08:52:16.377119 (delta: 0.059559)         elapsed: 8.359146 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:35
2020-06-29T08:52:16.417716 (delta: 0.040552)         elapsed: 8.399743 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:43
2020-06-29T08:52:16.464078 (delta: 0.046315)         elapsed: 8.446105 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:49
2020-06-29T08:52:16.509814 (delta: 0.045682)         elapsed: 8.491841 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc testclaim -n percona --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.643451", "end": "2020-06-29 08:52:17.295712", "rc": 0, "start": "2020-06-29 08:52:16.652261", "stderr": "", "stderr_lines": [], "stdout": "pvc-d450bfd4-226f-4286-b670-21e0be57311e", "stdout_lines": ["pvc-d450bfd4-226f-4286-b670-21e0be57311e"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:57
2020-06-29T08:52:17.337950 (delta: 0.828106)         elapsed: 9.319977 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-d450bfd4-226f-4286-b670-21e0be57311e --no-headers -o jsonpath=\"{.spec.csi.volumeAttributes.openebs\\\\.io/cas-type}\"", "delta": "0:00:00.724534", "end": "2020-06-29 08:52:18.203008", "rc": 0, "start": "2020-06-29 08:52:17.478474", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:65
2020-06-29T08:52:18.268732 (delta: 0.930747)         elapsed: 10.250759 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:70
2020-06-29T08:52:18.344056 (delta: 0.075188)         elapsed: 10.326083 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b237474002e6cd4c18d556887bbc9d5c8f487397", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "3289611cf199d1ca8c9d087069088f2a", "mode": "0644", "owner": "root", "size": 62, "src": "/root/.ansible/tmp/ansible-tmp-1593420738.39-212103365188389/source", "state": "file", "uid": 0}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/openebs_target_network_delay/test_prerequisites.yml:75
2020-06-29T08:52:18.866243 (delta: 0.522102)         elapsed: 10.84827 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "68b329da9893e34099c7d8ad5cb9c940", "mode": "0644", "owner": "root", "size": 1, "src": "/root/.ansible/tmp/ansible-tmp-1593420738.9-275230806808156/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:21
2020-06-29T08:52:19.149943 (delta: 0.283647)         elapsed: 11.13197 ******** 
ok: [127.0.0.1] => {"ansible_facts": {}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/data_persistence.yml"], "changed": false}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:24
2020-06-29T08:52:19.209043 (delta: 0.059067)         elapsed: 11.19107 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/experiments/chaos/openebs_target_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:27
2020-06-29T08:52:19.266376 (delta: 0.057299)         elapsed: 11.248403 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:31
2020-06-29T08:52:19.340447 (delta: 0.074023)         elapsed: 11.322474 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:38
2020-06-29T08:52:19.409898 (delta: 0.069412)         elapsed: 11.391925 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-06-29T08:52:19.503583 (delta: 0.093647)         elapsed: 11.48561 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d033ea974d5ef085c993c50e7a6f965c34548b8d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "847944374d12ae8e25882f4315d7c96c", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1593420739.54-231352113178798/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-06-29T08:52:19.844158 (delta: 0.340536)         elapsed: 11.826185 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.519561", "end": "2020-06-29 08:52:20.511339", "rc": 0, "start": "2020-06-29 08:52:19.991778", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-06-29T08:52:20.565162 (delta: 0.720972)         elapsed: 12.547189 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-06-29T08:21:14Z", "generation": 9, "name": "openebs-target-network-delay", "resourceVersion": "1307343", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-network-delay", "uid": "c3284f27-ca8c-4ebf-9820-6e0963b4e5c6"}, "spec": {"testMetadata": {"chaostype": "openebs/cstor_target_network_delay"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-06-29T08:52:21.384096 (delta: 0.818869)         elapsed: 13.366123 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-06-29T08:52:21.438332 (delta: 0.054168)         elapsed: 13.420359 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-06-29T08:52:21.487247 (delta: 0.048859)         elapsed: 13.469274 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:45
2020-06-29T08:52:21.539883 (delta: 0.052564)         elapsed: 13.52191 ******** 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : percona", 
        "Label        : name=percona", 
        "PVC          : testclaim", 
        "StorageClass : cstor-cspc-disk-pool-sc"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:56
2020-06-29T08:52:21.616865 (delta: 0.076927)         elapsed: 13.598892 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-06-29T08:52:21.700274 (delta: 0.083354)         elapsed: 13.682301 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.622493", "end": "2020-06-29 08:52:22.482900", "rc": 0, "start": "2020-06-29 08:52:21.860407", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-06-26T07:13:38Z]]", "stdout_lines": ["map[running:map[startedAt:2020-06-26T07:13:38Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-06-29T08:52:22.540540 (delta: 0.840218)         elapsed: 14.522567 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.702629", "end": "2020-06-29 08:52:23.457439", "rc": 0, "start": "2020-06-29 08:52:22.754810", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:65
2020-06-29T08:52:23.507121 (delta: 0.966546)         elapsed: 15.489148 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.649358", "end": "2020-06-29 08:52:24.292090", "rc": 0, "start": "2020-06-29 08:52:23.642732", "stderr": "", "stderr_lines": [], "stdout": "percona-69fcf76686-62kfd", "stdout_lines": ["percona-69fcf76686-62kfd"]}

TASK [Create some test data] ***************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:73
2020-06-29T08:52:24.340484 (delta: 0.833261)         elapsed: 16.322511 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV from application PVC] ******************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:81
2020-06-29T08:52:24.397334 (delta: 0.056787)         elapsed: 16.379361 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc testclaim -o custom-columns=:spec.volumeName -n percona --no-headers", "delta": "0:00:00.679995", "end": "2020-06-29 08:52:25.265425", "rc": 0, "start": "2020-06-29 08:52:24.585430", "stderr": "", "stderr_lines": [], "stdout": "pvc-d450bfd4-226f-4286-b670-21e0be57311e", "stdout_lines": ["pvc-d450bfd4-226f-4286-b670-21e0be57311e"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:90
2020-06-29T08:52:25.307216 (delta: 0.909848)         elapsed: 17.289243 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-d450bfd4-226f-4286-b670-21e0be57311e | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.689904", "end": "2020-06-29 08:52:26.156966", "rc": 0, "start": "2020-06-29 08:52:25.467062", "stderr": "", "stderr_lines": [], "stdout": "pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg", "stdout_lines": ["pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg"]}

TASK [Identify the patch to be invoked] ****************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:102
2020-06-29T08:52:26.206755 (delta: 0.899511)         elapsed: 18.188782 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the jiva controller pod name] ***********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:107
2020-06-29T08:52:26.258326 (delta: 0.05152)         elapsed: 18.240353 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Patching jiva controller deployment to allow security privileged] ********
task path: /experiments/chaos/openebs_target_network_delay/test.yml:116
2020-06-29T08:52:26.308368 (delta: 0.049986)         elapsed: 18.290395 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for 10s post fault injection] ***************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:123
2020-06-29T08:52:26.360462 (delta: 0.052043)         elapsed: 18.342489 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the jiva controller pod is terminated] *************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:127
2020-06-29T08:52:26.407817 (delta: 0.047299)         elapsed: 18.389844 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the new jiva controller pod belonging to the PV] ****************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:137
2020-06-29T08:52:26.456823 (delta: 0.048974)         elapsed: 18.43885 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for the jiva controller container status] **************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:146
2020-06-29T08:52:26.496960 (delta: 0.040086)         elapsed: 18.478987 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:161
2020-06-29T08:52:26.542169 (delta: 0.045175)         elapsed: 18.524196 ******* 
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
2020-06-29T08:52:26.649880 (delta: 0.107647)         elapsed: 18.631907 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n percona", "delta": "0:00:00.880818", "end": "2020-06-29 08:52:27.679265", "rc": 0, "start": "2020-06-29 08:52:26.798447", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps/pumba created", "stdout_lines": ["daemonset.apps/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
2020-06-29T08:52:27.737999 (delta: 1.088055)         elapsed: 19.720026 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n percona | sort | uniq", "delta": "0:00:00.669098", "end": "2020-06-29 08:52:49.520054", "rc": 0, "start": "2020-06-29 08:52:48.850956", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
2020-06-29T08:52:49.570720 (delta: 21.832688)         elapsed: 41.552747 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc testclaim -o custom-columns=:spec.volumeName -n percona --no-headers", "delta": "0:00:00.628547", "end": "2020-06-29 08:52:50.353309", "rc": 0, "start": "2020-06-29 08:52:49.724762", "stderr": "", "stderr_lines": [], "stdout": "pvc-d450bfd4-226f-4286-b670-21e0be57311e", "stdout_lines": ["pvc-d450bfd4-226f-4286-b670-21e0be57311e"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
2020-06-29T08:52:50.395523 (delta: 0.824764)         elapsed: 42.37755 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-d450bfd4-226f-4286-b670-21e0be57311e | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.618263", "end": "2020-06-29 08:52:51.154545", "rc": 0, "start": "2020-06-29 08:52:50.536282", "stderr": "", "stderr_lines": [], "stdout": "pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg", "stdout_lines": ["pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg"]}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
2020-06-29T08:52:51.197528 (delta: 0.801969)         elapsed: 43.179555 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.792089", "end": "2020-06-29 08:52:52.125449", "rc": 0, "start": "2020-06-29 08:52:51.333360", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1", "stdout_lines": ["e2e1-node1"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:47
2020-06-29T08:52:52.167196 (delta: 0.969618)         elapsed: 44.149223 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n percona -o jsonpath='{.items[?(@.spec.nodeName==''\"e2e1-node1\"'')].metadata.name}'", "delta": "0:00:00.764993", "end": "2020-06-29 08:52:53.067012", "rc": 0, "start": "2020-06-29 08:52:52.302019", "stderr": "", "stderr_lines": [], "stdout": "pumba-572xp", "stdout_lines": ["pumba-572xp"]}

TASK [Inject egress delay of 60000ms on cstor target for 60000ms] **************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:55
2020-06-29T08:52:53.125192 (delta: 0.957965)         elapsed: 45.107219 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-572xp -n percona -- pumba netem --interface eth0 --duration 60000ms delay --time 60000 re2:k8s_cstor-istgt_pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg", "delta": "0:01:01.635025", "end": "2020-06-29 08:53:54.894540", "rc": 0, "start": "2020-06-29 08:52:53.259515", "stderr": "time=\"2020-06-29T08:52:54Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2020-06-29T08:52:54Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 2f9e467d056c9616564e8ef1cbee2ff69433f6ea60d26db5a629b70447b9a818 for 1m0s\" \ntime=\"2020-06-29T08:52:54Z\" level=info msg=\"Start netem for container 2f9e467d056c9616564e8ef1cbee2ff69433f6ea60d26db5a629b70447b9a818 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2020-06-29T08:52:54Z\" level=error msg=\"command 'tc' not found inside the /k8s_cstor-istgt_pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg_openebs_a13b1a8e-d767-4e88-a651-52d006587bce_0 (2f9e467d056c9616564e8ef1cbee2ff69433f6ea60d26db5a629b70447b9a818) container\" ", "stderr_lines": ["time=\"2020-06-29T08:52:54Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2020-06-29T08:52:54Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 2f9e467d056c9616564e8ef1cbee2ff69433f6ea60d26db5a629b70447b9a818 for 1m0s\" ", "time=\"2020-06-29T08:52:54Z\" level=info msg=\"Start netem for container 2f9e467d056c9616564e8ef1cbee2ff69433f6ea60d26db5a629b70447b9a818 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2020-06-29T08:52:54Z\" level=error msg=\"command 'tc' not found inside the /k8s_cstor-istgt_pvc-d450bfd4-226f-4286-b670-21e0be57311e-target-69ff995d9frvhbg_openebs_a13b1a8e-d767-4e88-a651-52d006587bce_0 (2f9e467d056c9616564e8ef1cbee2ff69433f6ea60d26db5a629b70447b9a818) container\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:63
2020-06-29T08:53:54.938452 (delta: 61.813225)         elapsed: 106.920479 ***** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:67
2020-06-29T08:54:05.272272 (delta: 10.3337)         elapsed: 117.254299 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n percona", "delta": "0:00:00.641782", "end": "2020-06-29 08:54:06.046324", "rc": 0, "start": "2020-06-29 08:54:05.404542", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps \"pumba\" deleted", "stdout_lines": ["daemonset.apps \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:73
2020-06-29T08:54:06.099436 (delta: 0.827124)         elapsed: 118.081463 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n percona", "delta": "0:00:00.697405", "end": "2020-06-29 08:54:06.926074", "rc": 0, "start": "2020-06-29 08:54:06.228669", "stderr": "", "stderr_lines": [], "stdout": "pumba-2dbm2   1/1   Terminating   0     99s\npumba-572xp   1/1   Terminating   0     99s\npumba-gp5xm   1/1   Terminating   0     99s", "stdout_lines": ["pumba-2dbm2   1/1   Terminating   0     99s", "pumba-572xp   1/1   Terminating   0     99s", "pumba-gp5xm   1/1   Terminating   0     99s"]}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:169
2020-06-29T08:54:06.994585 (delta: 0.895104)         elapsed: 118.976612 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:179
2020-06-29T08:54:07.046492 (delta: 0.051871)         elapsed: 119.028519 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for 10s post fault injection] ***************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:189
2020-06-29T08:54:07.093123 (delta: 0.046592)         elapsed: 119.07515 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:193
2020-06-29T08:54:17.307641 (delta: 10.214477)         elapsed: 129.289668 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:203
2020-06-29T08:54:17.359853 (delta: 0.05217)         elapsed: 129.34188 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:215
2020-06-29T08:54:17.404182 (delta: 0.044268)         elapsed: 129.386209 ****** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-06-29T08:54:17.476102 (delta: 0.071887)         elapsed: 129.458129 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n percona -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.705916", "end": "2020-06-29 08:54:18.320411", "rc": 0, "start": "2020-06-29 08:54:17.614495", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-06-26T07:13:38Z]]", "stdout_lines": ["map[running:map[startedAt:2020-06-26T07:13:38Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-06-29T08:54:18.380265 (delta: 0.9041)         elapsed: 130.362292 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.742544", "end": "2020-06-29 08:54:19.264287", "rc": 0, "start": "2020-06-29 08:54:18.521743", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:224
2020-06-29T08:54:19.313787 (delta: 0.933482)         elapsed: 131.295814 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:227
2020-06-29T08:54:19.372947 (delta: 0.059098)         elapsed: 131.354974 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:236
2020-06-29T08:54:19.422894 (delta: 0.049868)         elapsed: 131.404921 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/openebs_target_network_delay/test.yml:247
2020-06-29T08:54:19.485963 (delta: 0.063032)         elapsed: 131.46799 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-06-29T08:54:19.597577 (delta: 0.111534)         elapsed: 131.579604 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-06-29T08:54:19.647672 (delta: 0.050039)         elapsed: 131.629699 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-06-29T08:54:19.693045 (delta: 0.045336)         elapsed: 131.675072 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-06-29T08:54:19.744080 (delta: 0.050988)         elapsed: 131.726107 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e7f0f790b1fb82156ee809c231d7445cd5cd07b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "89296e59cc89d49e5b7cbb6d0f0c8848", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1593420859.79-77682574038723/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-06-29T08:54:21.099408 (delta: 1.35529)         elapsed: 133.081435 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.641241", "end": "2020-06-29 08:54:21.883618", "rc": 0, "start": "2020-06-29 08:54:21.242377", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-06-29T08:54:21.932615 (delta: 0.833175)         elapsed: 133.914642 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-06-29T08:21:14Z", "generation": 10, "name": "openebs-target-network-delay", "resourceVersion": "1307996", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/openebs-target-network-delay", "uid": "c3284f27-ca8c-4ebf-9820-6e0963b4e5c6"}, "spec": {"testMetadata": {"chaostype": "openebs/cstor_target_network_delay"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=45   changed=28   unreachable=0    failed=0   

2020-06-29T08:54:22.562392 (delta: 0.629714)         elapsed: 134.544419 ****** 
=============================================================================== 

```

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
