### PR TITLE
refactor(Jiva-snapshot-delete): Enable experiment to restart master replica

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
+++ b/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
@@ -1,17 +1,9 @@
-- name: Get controller svc
-  shell: >
-    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume={{ pv_name }} 
-    -n {{ operator_ns }} --no-headers -o custom-columns=:spec.clusterIP
-  args:
-    executable: /bin/bash
-  register: controller_svc
-  failed_when: controller_svc.stdout == ""
-
+---
 - name: Get total replica count from controller
   vars:
     replicas_endpoint: "9501/v1/volumes"
   uri:
-    url: "http://{{ controller_svc.stdout }}:{{ replicas_endpoint }}"
+    url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
     method: GET
     return_content: yes
     status_code: 200
@@ -20,14 +12,14 @@
     body_format: json
   register: json_response
   until: json_response.json.data[0].replicaCount == 3
-  retries: 10
-  delay: 5
+  retries: 15
+  delay: 10
 
 - name: Get rw replica status from controller
   vars:
     replicas_endpoint: "9501/v1/replicas"
   uri:
-    url: "http://{{ controller_svc.stdout }}:{{ replicas_endpoint }}"
+    url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
     method: GET
     return_content: yes
     status_code: 200

--- a/experiments/functional/snapshot_deletion/jiva/test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test.yml
@@ -74,6 +74,15 @@
        - set_fact:
            pv_name: "{{ result.stdout }}"
 
+       - name: Get controller svc
+         shell: >
+           kubectl get svc -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume={{ pv_name }} 
+           -n {{ operator_ns }} --no-headers -o custom-columns=:spec.clusterIP
+         args:
+           executable: /bin/bash
+         register: controller_svc
+         failed_when: controller_svc.stdout == ""
+
        - name: Replace the data sample size with the provider sample size in {{ fio_write_yml }}
          replace:
            path: "{{ fio_write_yml }}"
@@ -111,10 +120,14 @@
 
        - name: Include replica restart test
          include: "{{ replica_restart_yml }}"
+         vars:
+           controller_service: "{{ controller_svc.stdout }}"
          with_items: "{{ iterator.stdout_lines }}"
 
        - name: Include replica count test
          include: "{{ check_replica_cnt_yml }}"
+         vars:
+           controller_service: "{{ controller_svc.stdout }}"
 
        - name: Check if fio write job is completed
          shell: >

--- a/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
@@ -1,17 +1,41 @@
-- name: Get the name of replica pods
-  shell: >
-    kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}'
-  args:
-    executable: /bin/bash
-  register: replica_pod
+# - name: Get the name of replica pods
+#   shell: >
+#     kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}'
+#   args:
+#     executable: /bin/bash
+#   register: replica_pod
 
-- name: Set the replica pod name to variable based on latest creation timestamp
+# - name: Set the replica pod name to variable based on latest creation timestamp
+#   set_fact:
+#     replica_name: "{{ replica_pod.stdout_lines[2].split()[0] }}"
+
+- name: Get replica json response from controller
+  vars:
+    replicas_endpoint: "9501/v1/replicas"
+  uri:
+    url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+    method: GET
+    return_content: yes
+    status_code: 200
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+  register: json_response
+
+- name: Set master replica ip
   set_fact:
-    replica_name: "{{ replica_pod.stdout_lines[2].split()[0] }}"
+          replica_ip: "{{ json_response.json.data[0].address | regex_replace('tcp://') | regex_replace(':9502') }}"
 
-- name: Delete replica with latest creation timestamp
+- debug:
+    var: "replica_ip"
+
+- name: Getting the master replica pod name corresponding to the IP
+  shell: kubectl get pod -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP=="{{ replica_ip }}")].metadata.name}'
+  register: replica_name
+
+- name: Delete master replica
   shell: >
-    kubectl delete pod {{ replica_name }} -n {{ operator_ns }}
+    kubectl delete pod {{ replica_name.stdout }} -n {{ operator_ns }}
   args:
     executable: /bin/bash
 
@@ -20,6 +44,3 @@
 - name: Pause for some time for a new replica to come up
   pause:
     minutes: 1
-
-
-


### PR DESCRIPTION

Signed-off-by:  <ranjanshashank855@gmail.com>


**What this PR does / why we need it**:

- Change experiment flow to restart master replica instead of random replica.


**Following is the log of ansible test container**:

- https://gist.github.com/shashank855/156d3966026c81b019c1fe2d1631065c

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
- This test case is failing against OpenEBS-1.11.0 as the shnapshots are not getting deleted.

```
root@pvc-436a7bba-54a0-48c0-9e49-44fbad368e78-ctrl-5596ffbdf5-4dvlv:/# jivactl  snapshot ls 
ID
0e3bb043-a778-417a-a0ec-b4d7fb7b9790
b312e37c-bb5f-4a75-a882-c6dc38e9726a
e36764c8-4ab8-4268-b6f1-d9388097df80
96f6921a-28bd-47c8-b2e4-41acfb7b8f3e
7a351dc6-f27b-4151-bf20-d98c637f5fa6
7066b6af-a6a4-4d36-8ff6-92d2de2fe813
2c12a9bf-ba01-4aaf-907b-d0f4f354a33d
296ba9f5-e68e-4f1c-a4c0-9ab525989f20
d05e0ade-001c-4371-87b3-e591f0c774ee
194f4b74-cc75-4665-bbf8-adc475bcade3
934a838a-efa3-43be-98a8-cb4e80d38a2f
5394b160-43e4-4f02-8d1c-cb06377dd2ab
99c44572-cd89-4327-93a9-8763a66c33a5
55ef94ee-2a9e-4200-98b7-130c5416dea7
77e64630-bc88-4035-88b2-6bfc81427890
264a15af-e77e-4a4d-a55f-6f42a0f67be3
4001ffcd-edd6-460e-872b-e5f725a803d0
```
```
jivactl  snapshot ls | wc -l
18
```