### PR TITLE
add(sc): adding storage class yaml for btrfs file system in zfspv-provisioner

### DIFF
--- a/providers/zfs-localpv-provisioner/openebs-zfspv-sc.j2
+++ b/providers/zfs-localpv-provisioner/openebs-zfspv-sc.j2
@@ -60,6 +60,26 @@ volumeBindingMode: WaitForFirstConsumer
 ##  - key: kubernetes.io/hostname
 ##    values:
 
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}-btrfs"
+parameters:
+  volblocksize: "{{ record_size }}"
+  compression: "{{ compress }}" 
+  dedup: "{{ de_dup }}"
+  fstype: "btrfs"
+  poolname: "{{ pool_name }}"
+provisioner: zfs.csi.openebs.io
+volumeBindingMode: WaitForFirstConsumer
+## To create ZPOOL on only some of the node then mention node names in values with allowedTopologies 
+##allowedTopologies:
+##- matchLabelExpressions:
+##  - key: kubernetes.io/hostname
+##    values:
+
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- b-tree file-system support is now added in zfs-localpv. This PR adds a storage class yaml for btrfs file system.

Will add zfspv related test cases for `btrfs` in pipeline soon.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #435 

 

