### PR TITLE
Enabled the tasks to gathering the facts in test cases

### DIFF
--- a/experiments/functional/cstor-volume-migration/test.yml
+++ b/experiments/functional/cstor-volume-migration/test.yml
@@ -2,7 +2,6 @@
 
 - hosts: localhost
   connection: local
-  gather_facts: False
 
   vars_files:
     - test_vars.yml

--- a/experiments/functional/cvr-scaleup/test.yml
+++ b/experiments/functional/cvr-scaleup/test.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: localhost
   connection: local
-  gather_facts: False
 
   vars_files:
     - test_vars.yml


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Enable the tasks to gather the facts in cvr scaleup and cvr migration test cases as it needed to run the fetch_data_from replicas.yml util

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
