### PR TITLE
refact(exp): checking pod status before taking volume snapshot

### DIFF
--- a/experiments/functional/zfs-LocalPV/zfspv-snapshot/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-snapshot/test.yml
@@ -100,6 +100,16 @@
               delay: 2
               retries: 20
 
+            - name: Verify that the application pod is not present after scaling down the deployment
+              shell: >
+                kubectl get pods -n {{ app_ns }} 
+              args:
+                executable: /bin/bash
+              register: app_pod_status
+              until: "app_pod_name.stdout not in app_pod_status.stdout"
+              delay: 2
+              retries: 20
+
             - name: create snapshot   
               shell: >
                 kubectl create -f snapshot.yml


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR checks the pod status after scaling down the application deployment before taking the application consistent zfs volume snaphsot

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #444 
