### PR TITLE
refactor[csi-provision]: Modified the test to provision csi driver

### DIFF
--- a/providers/csi-provisioner/patch.j2
+++ b/providers/csi-provisioner/patch.j2
@@ -4,7 +4,7 @@
     "spec": {
      "containers": [
       {
-       "name": "cstor-csi-plugin",
+       "name": "openebs-csi-plugin",
        "env": [
         {
            "name": "REMOUNT",

--- a/providers/csi-provisioner/run_litmus_test.yml
+++ b/providers/csi-provisioner/run_litmus_test.yml
@@ -28,9 +28,6 @@ spec:
           - name: SNAPSHOT_CLASS
             value: csi-cstor
 
-          - name: NODE_OS
-            value: ubuntu-16.04
-
           - name: CSPC
             value: cstor-sparse-pool
 

--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -17,111 +17,54 @@
           vars:
             status: 'SOT'
 
-        - block:
+        - name: Downloading the csi-operator file
+          get_url:
+            url: "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/csi-operator.yaml"
+            dest: "{{ playbook_dir }}/csi-operator.yaml"
+            force: yes
+          register: status
+          until:  "'OK' in status.msg"
+          delay: 5
+          retries: 3
 
-           - name: Downloading the csi-operator file
-             get_url:
-               url: "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator.yaml"
-               dest: "{{ playbook_dir }}/csi-operator.yaml"
-               force: yes
-             register: status
-             until:  "'OK' in status.msg"
-             delay: 5
-             retries: 3
+        - name: Update the desired image tag for openebs-plugin
+          replace:
+            path: "{{ playbook_dir }}/csi-operator.yaml"
+            regexp: "cstor-csi-driver:ci"
+            replace: "cstor-csi-driver:{{ image_tag }}"
 
-           - name: Update the desired image tag for openebs-plugin
-             replace:
-               path: "{{ playbook_dir }}/csi-operator.yaml"
-               regexp: "cstor-csi-driver:ci"
-               replace: "cstor-csi-driver:{{ image_tag }}"
+        - name: Change the OpenEBS component labels to desired version csi provisioner spec
+          replace:
+            path: "{{ playbook_dir }}/csi-operator.yaml"
+            regexp: 'openebs.io/version: dev'
+            replace: "openebs.io/version: {{ image_tag }}"
+          
+        - name: Deploy CSI Driver 
+          shell: >
+            kubectl apply -f csi-operator.yaml --validate=false
+          args:
+            executable: /bin/bash
+          register: deploy_status
+          failed_when: "deploy_status.rc != 0"
 
-           - name: Change the OpenEBS component labels to desired version csi provisioner spec
-             replace:
-               path: "{{ playbook_dir }}/csi-operator.yaml"
-               regexp: 'openebs.io/version: dev'
-               replace: "openebs.io/version: {{ image_tag }}"
-             
-           - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04
-             shell: >
-               kubectl apply -f csi-operator.yaml
-             args:
-               executable: /bin/bash
-             register: deploy_status
-             failed_when: "deploy_status.rc != 0"
+        - name: Identify the patch to be invoked
+          template:
+            src: patch.j2
+            dest: patch.yml
 
-           - name: Identify the patch to be invoked
-             template:
-               src: patch.j2
-               dest: patch.yml
+        # By default, volume mount is disabled. When it is enabled, the below patching tasks should be ignored.
 
-           # By default, volume mount is disabled. When it is enabled, the below patching tasks should be ignored.
+        - name: Patching openebs cstor csi-driver statefulset to allow volume remount
+          shell: >
+            kubectl patch statefulset openebs-cstor-csi-controller -n {{ operator_ns }} --patch "$(cat patch.yml)"
+          register: patch_status
+          failed_when: "'patched' not in patch_status.stdout"
 
-           - name: Patching openebs cstor csi-driver statefulset to allow volume remount
-             shell: >
-               kubectl patch statefulset openebs-cstor-csi-controller -n {{ operator_ns }} --patch "$(cat patch.yml)"
-             register: patch_status
-             failed_when: "'patched' not in patch_status.stdout"
-
-           - name: Patching openebs cstor csi-driver daemonset to allow volume remount
-             shell: >
-               kubectl patch daemonset openebs-cstor-csi-node -n {{ operator_ns }} --patch "$(cat patch.yml)"
-             register: patch_status
-             failed_when: "'patched' not in patch_status.stdout"
-
-          when: node_os == "ubuntu-16.04" or node_os == "centos"
-
-        - block:
-
-           - name: Downloading the csi-operator file
-             get_url:
-               url: "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator-ubuntu-18.04.yaml"
-               dest: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
-               force: yes
-             register: status
-             until:  "'OK' in status.msg"
-             delay: 5
-             retries: 3
-
-           - name: Update the desired image tag for openebs-plugin
-             replace:
-               path: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
-               regexp: "cstor-csi-driver:ci"
-               replace: "cstor-csi-driver:{{ image_tag }}"
-
-           - name: Change the OpenEBS component labels to desired version csi provisioner spec
-             replace:
-               path: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
-               regexp: 'openebs.io/version: dev'
-               replace: "openebs.io/version: {{ image_tag }}"               
-
-           - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04
-             shell: >
-               kubectl apply -f csi-operator-ubuntu-18.04.yaml
-             args:
-               executable: /bin/bash
-             register: deploy_status
-             failed_when: "deploy_status.rc != 0"
-
-           # By default, volume mount is disabled. When it is enabled, the below patching tasks should be ignored.
-
-           - name: Identify the patch to be invoked
-             template:
-               src: patch.j2
-               dest: patch.yml
-
-           - name: Patching openebs cstor csi-driver statefulset to allow volume remount
-             shell: >
-               kubectl patch statefulset openebs-cstor-csi-controller -n {{ operator_ns }} --patch "$(cat patch.yml)"
-             register: patch_status
-             failed_when: "'patched' not in patch_status.stdout"
-
-           - name: Patching openebs cstor csi-driver daemonset to allow volume remount
-             shell: >
-               kubectl patch daemonset openebs-cstor-csi-node -n {{ operator_ns }} --patch "$(cat patch.yml)"
-             register: patch_status
-             failed_when: "'patched' not in patch_status.stdout"
-
-          when: node_os == "ubuntu-18.04"
+        - name: Patching openebs cstor csi-driver daemonset to allow volume remount
+          shell: >
+            kubectl patch daemonset openebs-cstor-csi-node -n {{ operator_ns }} --patch "$(cat patch.yml)"
+          register: patch_status
+          failed_when: "'patched' not in patch_status.stdout"
 
         - name: check if csi-controller pod is running
           shell: >

--- a/providers/csi-provisioner/test_vars.yml
+++ b/providers/csi-provisioner/test_vars.yml
@@ -10,8 +10,6 @@ storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 
 replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
 
-node_os: "{{ lookup('env','NODE_OS') }}"
-
 image_tag: "{{ lookup('env','IMAGE_TAG') }}"
 
 snapshot_class: "{{ lookup('env','SNAPSHOT_CLASS') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the csi provision test case to obtain the generic csi-provisioner spec yaml form cstor operator repo instead of operator specific yaml from csi-cstor repo

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
