### PR TITLE
refactor[csi-provision]: Modified the csi provision test removing the patch of remount env from csi statefulset

### DIFF
--- a/providers/csi-provisioner/test.yml
+++ b/providers/csi-provisioner/test.yml
@@ -53,13 +53,6 @@
             dest: patch.yml
 
         # By default, volume mount is disabled. When it is enabled, the below patching tasks should be ignored.
-
-        - name: Patching openebs cstor csi-driver statefulset to allow volume remount
-          shell: >
-            kubectl patch statefulset openebs-cstor-csi-controller -n {{ operator_ns }} --patch "$(cat patch.yml)"
-          register: patch_status
-          failed_when: "'patched' not in patch_status.stdout"
-
         - name: Patching openebs cstor csi-driver daemonset to allow volume remount
           shell: >
             kubectl patch daemonset openebs-cstor-csi-node -n {{ operator_ns }} --patch "$(cat patch.yml)"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- CSI remount env is needed only for daemonset

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
