### PR TITLE
fix[snapshot]: Modified the task to verify the snapshot status

### DIFF
--- a/experiments/functional/snapshot-creation/test.yml
+++ b/experiments/functional/snapshot-creation/test.yml
@@ -88,7 +88,9 @@
           args:
             executable: /bin/bash
           register: snap_list
-          failed_when: "snapshot_name not in snap_list.stdout"
+          until: "snapshot_name in snap_list.stdout"
+          delay: 5
+          retries: 30
           with_items:
             - "{{ pool_pods.results }}"
 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- In this PR modified the task to verify the snapshot is created in all the pools by waiting util the snapshot is created 

```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Apr 15 2020, 17:20:14) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/snapshot-creation/test.yml

PLAY [localhost] ***************************************************************
2020-07-17T06:46:45.668767 (delta: 0.049696)         elapsed: 0.049696 ******** 
=============================================================================== 
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:25
2020-07-17T06:46:45.678225 (delta: 0.009432)         elapsed: 0.059154 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-07-17T06:46:45.713116 (delta: 0.034869)         elapsed: 0.094045 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-07-17T06:46:45.743583 (delta: 0.030424)         elapsed: 0.124512 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:28
2020-07-17T06:46:45.773841 (delta: 0.030209)         elapsed: 0.15477 ********* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-07-17T06:46:45.838766 (delta: 0.064861)         elapsed: 0.219695 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "ae5e1fb24fe9758d6506364e5431f1b080beaace", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4c6f3ac54283a0ab817f286982e9560f", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1594968405.88-168636758817105/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-07-17T06:46:46.295869 (delta: 0.457079)         elapsed: 0.676798 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.569004", "end": "2020-07-17 06:46:47.103032", "rc": 0, "start": "2020-07-17 06:46:46.534028", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-07-17T06:46:47.130161 (delta: 0.834225)         elapsed: 1.51109 ********* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-07-17T06:46:47Z", "generation": 1, "name": "create-snapshot", "resourceVersion": "24223", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/create-snapshot", "uid": "ed1d3eb5-6c8c-40ed-96e6-0faa52b10e57"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-07-17T06:46:47.941646 (delta: 0.811448)         elapsed: 2.322575 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-07-17T06:46:47.965145 (delta: 0.023466)         elapsed: 2.346074 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-07-17T06:46:47.988808 (delta: 0.02363)         elapsed: 2.369737 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC] *************************************************
task path: /experiments/functional/snapshot-creation/test.yml:32
2020-07-17T06:46:48.015154 (delta: 0.026312)         elapsed: 2.396083 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.827675", "end": "2020-07-17 06:46:48.981451", "rc": 0, "start": "2020-07-17 06:46:48.153776", "stderr": "", "stderr_lines": [], "stdout": "pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a", "stdout_lines": ["pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a"]}

TASK [Creating snapshot.] ******************************************************
task path: /experiments/functional/snapshot-creation/test.yml:42
2020-07-17T06:46:49.007213 (delta: 0.992009)         elapsed: 3.388142 ******** 
included: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml for 127.0.0.1

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:14
2020-07-17T06:46:49.046250 (delta: 0.038999)         elapsed: 3.427179 ******** 
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: app-busybox-ns", 
        "pvc_name: openebs-busybox", 
        "snapshot_name: snapshot-busybox"
    ]
}

TASK [Update the snapshot template with the values provided.] ******************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:21
2020-07-17T06:46:49.102951 (delta: 0.056665)         elapsed: 3.48388 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cda7cffd8a1a31b4ca484f3ccab133ddda6deb33", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "c3be2cd40b743ee00a4ec5ee718a294a", "mode": "0644", "owner": "root", "size": 190, "src": "/root/.ansible/tmp/ansible-tmp-1594968409.14-159300450353037/source", "state": "file", "uid": 0}

TASK [Creating the volume snapshot] ********************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:26
2020-07-17T06:46:49.418542 (delta: 0.315543)         elapsed: 3.799471 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl apply -f snapshot.yml", "delta": "0:00:00.980290", "end": "2020-07-17 06:46:50.544744", "rc": 0, "start": "2020-07-17 06:46:49.564454", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io/snapshot-busybox created", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io/snapshot-busybox created"]}

TASK [Obtaining the storage class used from PVC] *******************************
task path: /experiments/functional/snapshot-creation/test.yml:45
2020-07-17T06:46:50.583506 (delta: 1.164903)         elapsed: 4.964435 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:00.682500", "end": "2020-07-17 06:46:51.410415", "rc": 0, "start": "2020-07-17 06:46:50.727915", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-disk", "stdout_lines": ["openebs-cstor-disk"]}

TASK [Obtaining the SPC from storage class] ************************************
task path: /experiments/functional/snapshot-creation/test.yml:51
2020-07-17T06:46:51.436380 (delta: 0.852837)         elapsed: 5.817309 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-disk --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g'", "delta": "0:00:00.818599", "end": "2020-07-17 06:46:52.395094", "rc": 0, "start": "2020-07-17 06:46:51.576495", "stderr": "", "stderr_lines": [], "stdout": " cstor-block-disk-pool\n cstor", "stdout_lines": [" cstor-block-disk-pool", " cstor"]}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /experiments/functional/snapshot-creation/test.yml:57
2020-07-17T06:46:52.483544 (delta: 1.047125)         elapsed: 6.864473 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:00.685819", "end": "2020-07-17 06:46:53.330170", "rc": 0, "start": "2020-07-17 06:46:52.644351", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-k5oa\ncstor-block-disk-pool-mk0a\ncstor-block-disk-pool-wc3k", "stdout_lines": ["cstor-block-disk-pool-k5oa", "cstor-block-disk-pool-mk0a", "cstor-block-disk-pool-wc3k"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /experiments/functional/snapshot-creation/test.yml:66
2020-07-17T06:46:53.358321 (delta: 0.874713)         elapsed: 7.73925 ********* 
changed: [127.0.0.1] => (item=cstor-block-disk-pool-k5oa) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa\")].metadata.name}'", "delta": "0:00:00.692633", "end": "2020-07-17 06:46:54.255179", "item": "cstor-block-disk-pool-k5oa", "rc": 0, "start": "2020-07-17 06:46:53.562546", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-k5oa-684f7bcb8b", "stdout_lines": ["cstor-block-disk-pool-k5oa-684f7bcb8b"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-mk0a) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a\")].metadata.name}'", "delta": "0:00:00.687224", "end": "2020-07-17 06:46:55.064218", "item": "cstor-block-disk-pool-mk0a", "rc": 0, "start": "2020-07-17 06:46:54.376994", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-mk0a-7db74d6c5d", "stdout_lines": ["cstor-block-disk-pool-mk0a-7db74d6c5d"]}
changed: [127.0.0.1] => (item=cstor-block-disk-pool-wc3k) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k\")].metadata.name}'", "delta": "0:00:00.778910", "end": "2020-07-17 06:46:55.985435", "item": "cstor-block-disk-pool-wc3k", "rc": 0, "start": "2020-07-17 06:46:55.206525", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-wc3k-5c98d4b8f6", "stdout_lines": ["cstor-block-disk-pool-wc3k-5c98d4b8f6"]}

TASK [Obtaining the pool pods] *************************************************
task path: /experiments/functional/snapshot-creation/test.yml:76
2020-07-17T06:46:56.016479 (delta: 2.658123)         elapsed: 10.397408 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-k5oa-684f7bcb8b', '_ansible_item_result': True, u'delta': u'0:00:00.692633', 'stdout_lines': [u'cstor-block-disk-pool-k5oa-684f7bcb8b'], '_ansible_item_label': u'cstor-block-disk-pool-k5oa', u'end': u'2020-07-17 06:46:54.255179', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa")].metadata.name}\'', 'item': u'cstor-block-disk-pool-k5oa', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-07-17 06:46:53.562546', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa-684f7bcb8b\")].metadata.name}'", "delta": "0:00:00.670270", "end": "2020-07-17 06:46:56.831922", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa\")].metadata.name}'", "delta": "0:00:00.692633", "end": "2020-07-17 06:46:54.255179", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-k5oa", "rc": 0, "start": "2020-07-17 06:46:53.562546", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-k5oa-684f7bcb8b", "stdout_lines": ["cstor-block-disk-pool-k5oa-684f7bcb8b"]}, "rc": 0, "start": "2020-07-17 06:46:56.161652", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft", "stdout_lines": ["cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-mk0a-7db74d6c5d', '_ansible_item_result': True, u'delta': u'0:00:00.687224', 'stdout_lines': [u'cstor-block-disk-pool-mk0a-7db74d6c5d'], '_ansible_item_label': u'cstor-block-disk-pool-mk0a', u'end': u'2020-07-17 06:46:55.064218', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a")].metadata.name}\'', 'item': u'cstor-block-disk-pool-mk0a', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-07-17 06:46:54.376994', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a-7db74d6c5d\")].metadata.name}'", "delta": "0:00:00.692525", "end": "2020-07-17 06:46:57.660341", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a\")].metadata.name}'", "delta": "0:00:00.687224", "end": "2020-07-17 06:46:55.064218", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-mk0a", "rc": 0, "start": "2020-07-17 06:46:54.376994", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-mk0a-7db74d6c5d", "stdout_lines": ["cstor-block-disk-pool-mk0a-7db74d6c5d"]}, "rc": 0, "start": "2020-07-17 06:46:56.967816", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc", "stdout_lines": ["cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-wc3k-5c98d4b8f6', '_ansible_item_result': True, u'delta': u'0:00:00.778910', 'stdout_lines': [u'cstor-block-disk-pool-wc3k-5c98d4b8f6'], '_ansible_item_label': u'cstor-block-disk-pool-wc3k', u'end': u'2020-07-17 06:46:55.985435', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k")].metadata.name}\'', 'item': u'cstor-block-disk-pool-wc3k', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-07-17 06:46:55.206525', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k-5c98d4b8f6\")].metadata.name}'", "delta": "0:00:00.675000", "end": "2020-07-17 06:46:58.448179", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k\")].metadata.name}'", "delta": "0:00:00.778910", "end": "2020-07-17 06:46:55.985435", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-wc3k", "rc": 0, "start": "2020-07-17 06:46:55.206525", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-wc3k-5c98d4b8f6", "stdout_lines": ["cstor-block-disk-pool-wc3k-5c98d4b8f6"]}, "rc": 0, "start": "2020-07-17 06:46:57.773179", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9", "stdout_lines": ["cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9"]}

TASK [Checking if the snapshot is created in all the pool pods.] ***************
task path: /experiments/functional/snapshot-creation/test.yml:86
2020-07-17T06:46:58.482468 (delta: 2.465954)         elapsed: 12.863397 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft', '_ansible_item_result': True, u'delta': u'0:00:00.670270', 'stdout_lines': [u'cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-k5oa-684f7bcb8b', '_ansible_item_result': True, u'delta': u'0:00:00.692633', 'stdout_lines': [u'cstor-block-disk-pool-k5oa-684f7bcb8b'], '_ansible_item_label': u'cstor-block-disk-pool-k5oa', u'end': u'2020-07-17 06:46:54.255179', '_ansible_no_log': False, u'start': u'2020-07-17 06:46:53.562546', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-k5oa', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2020-07-17 06:46:56.831922', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa-684f7bcb8b")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-k5oa-684f7bcb8b', '_ansible_item_result': True, u'delta': u'0:00:00.692633', 'stdout_lines': [u'cstor-block-disk-pool-k5oa-684f7bcb8b'], '_ansible_item_label': u'cstor-block-disk-pool-k5oa', u'end': u'2020-07-17 06:46:54.255179', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa")].metadata.name}\'', u'start': u'2020-07-17 06:46:53.562546', 'item': u'cstor-block-disk-pool-k5oa', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-k5oa-684f7bcb8b")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-07-17 06:46:56.161652', '_ansible_ignore_errors': None}) => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft -n openebs -- zfs list -t snapshot", "delta": "0:00:01.038351", "end": "2020-07-17 06:46:59.671840", "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa-684f7bcb8b\")].metadata.name}'", "delta": "0:00:00.670270", "end": "2020-07-17 06:46:56.831922", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa-684f7bcb8b\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa\")].metadata.name}'", "delta": "0:00:00.692633", "end": "2020-07-17 06:46:54.255179", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-k5oa\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-k5oa", "rc": 0, "start": "2020-07-17 06:46:53.562546", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-k5oa-684f7bcb8b", "stdout_lines": ["cstor-block-disk-pool-k5oa-684f7bcb8b"]}, "rc": 0, "start": "2020-07-17 06:46:56.161652", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft", "stdout_lines": ["cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft"]}, "rc": 0, "start": "2020-07-17 06:46:58.633489", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-k5oa-684f7bcb8b-w84ft -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT\ncstor-41939f9d-fcce-4b34-b8ed-22b605b8d78d/pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a@pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a_snapshot-busybox_1594968410581233295     0B      -    72K  -", "stdout_lines": ["NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT", "cstor-41939f9d-fcce-4b34-b8ed-22b605b8d78d/pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a@pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a_snapshot-busybox_1594968410581233295     0B      -    72K  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc', '_ansible_item_result': True, u'delta': u'0:00:00.692525', 'stdout_lines': [u'cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-mk0a-7db74d6c5d', '_ansible_item_result': True, u'delta': u'0:00:00.687224', 'stdout_lines': [u'cstor-block-disk-pool-mk0a-7db74d6c5d'], '_ansible_item_label': u'cstor-block-disk-pool-mk0a', u'end': u'2020-07-17 06:46:55.064218', '_ansible_no_log': False, u'start': u'2020-07-17 06:46:54.376994', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-mk0a', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2020-07-17 06:46:57.660341', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a-7db74d6c5d")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-mk0a-7db74d6c5d', '_ansible_item_result': True, u'delta': u'0:00:00.687224', 'stdout_lines': [u'cstor-block-disk-pool-mk0a-7db74d6c5d'], '_ansible_item_label': u'cstor-block-disk-pool-mk0a', u'end': u'2020-07-17 06:46:55.064218', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a")].metadata.name}\'', u'start': u'2020-07-17 06:46:54.376994', 'item': u'cstor-block-disk-pool-mk0a', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-mk0a-7db74d6c5d")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-07-17 06:46:56.967816', '_ansible_ignore_errors': None}) => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc -n openebs -- zfs list -t snapshot", "delta": "0:00:00.895489", "end": "2020-07-17 06:47:00.707059", "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a-7db74d6c5d\")].metadata.name}'", "delta": "0:00:00.692525", "end": "2020-07-17 06:46:57.660341", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a-7db74d6c5d\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a\")].metadata.name}'", "delta": "0:00:00.687224", "end": "2020-07-17 06:46:55.064218", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-mk0a\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-mk0a", "rc": 0, "start": "2020-07-17 06:46:54.376994", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-mk0a-7db74d6c5d", "stdout_lines": ["cstor-block-disk-pool-mk0a-7db74d6c5d"]}, "rc": 0, "start": "2020-07-17 06:46:56.967816", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc", "stdout_lines": ["cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc"]}, "rc": 0, "start": "2020-07-17 06:46:59.811570", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-mk0a-7db74d6c5d-5t9pc -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT\ncstor-8efd1a3a-f469-4cfa-99d6-dd6669209467/pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a@pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a_snapshot-busybox_1594968410581233295     0B      -    72K  -", "stdout_lines": ["NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT", "cstor-8efd1a3a-f469-4cfa-99d6-dd6669209467/pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a@pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a_snapshot-busybox_1594968410581233295     0B      -    72K  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9', '_ansible_item_result': True, u'delta': u'0:00:00.675000', 'stdout_lines': [u'cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-wc3k-5c98d4b8f6', '_ansible_item_result': True, u'delta': u'0:00:00.778910', 'stdout_lines': [u'cstor-block-disk-pool-wc3k-5c98d4b8f6'], '_ansible_item_label': u'cstor-block-disk-pool-wc3k', u'end': u'2020-07-17 06:46:55.985435', '_ansible_no_log': False, u'start': u'2020-07-17 06:46:55.206525', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k")].metadata.name}\'', 'failed': False, 'item': u'cstor-block-disk-pool-wc3k', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2020-07-17 06:46:58.448179', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k-5c98d4b8f6")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-block-disk-pool-wc3k-5c98d4b8f6', '_ansible_item_result': True, u'delta': u'0:00:00.778910', 'stdout_lines': [u'cstor-block-disk-pool-wc3k-5c98d4b8f6'], '_ansible_item_label': u'cstor-block-disk-pool-wc3k', u'end': u'2020-07-17 06:46:55.985435', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k")].metadata.name}\'', u'start': u'2020-07-17 06:46:55.206525', 'item': u'cstor-block-disk-pool-wc3k', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-block-disk-pool-wc3k-5c98d4b8f6")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-07-17 06:46:57.773179', '_ansible_ignore_errors': None}) => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9 -n openebs -- zfs list -t snapshot", "delta": "0:00:00.994396", "end": "2020-07-17 06:47:01.854606", "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k-5c98d4b8f6\")].metadata.name}'", "delta": "0:00:00.675000", "end": "2020-07-17 06:46:58.448179", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k-5c98d4b8f6\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k\")].metadata.name}'", "delta": "0:00:00.778910", "end": "2020-07-17 06:46:55.985435", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-block-disk-pool-wc3k\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-block-disk-pool-wc3k", "rc": 0, "start": "2020-07-17 06:46:55.206525", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-wc3k-5c98d4b8f6", "stdout_lines": ["cstor-block-disk-pool-wc3k-5c98d4b8f6"]}, "rc": 0, "start": "2020-07-17 06:46:57.773179", "stderr": "", "stderr_lines": [], "stdout": "cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9", "stdout_lines": ["cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9"]}, "rc": 0, "start": "2020-07-17 06:47:00.860210", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9 -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-block-disk-pool-wc3k-5c98d4b8f6-qmnt9 -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT\ncstor-a962362e-9c7d-468a-b5be-32feb75cc080/pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a@pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a_snapshot-busybox_1594968410581233295     0B      -    72K  -", "stdout_lines": ["NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT", "cstor-a962362e-9c7d-468a-b5be-32feb75cc080/pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a@pvc-55d0e95e-a73c-4c1d-8b7d-87b57357332a_snapshot-busybox_1594968410581233295     0B      -    72K  -"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/snapshot-creation/test.yml:97
2020-07-17T06:47:01.900098 (delta: 3.417593)         elapsed: 16.281027 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:106
2020-07-17T06:47:01.960199 (delta: 0.060063)         elapsed: 16.341128 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-07-17T06:47:02.008649 (delta: 0.048415)         elapsed: 16.389578 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-07-17T06:47:02.038809 (delta: 0.030121)         elapsed: 16.419738 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-07-17T06:47:02.066444 (delta: 0.027542)         elapsed: 16.447373 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-07-17T06:47:02.102359 (delta: 0.035879)         elapsed: 16.483288 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "0729a880f30ed49523377585f88c84785297782d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "75581027b99e9de1e903ec50005f5822", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1594968422.16-86845162238816/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-07-17T06:47:03.630303 (delta: 1.527902)         elapsed: 18.011232 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.607288", "end": "2020-07-17 06:47:04.387031", "rc": 0, "start": "2020-07-17 06:47:03.779743", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-07-17T06:47:04.419886 (delta: 0.789445)         elapsed: 18.800815 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-07-17T06:46:47Z", "generation": 2, "name": "create-snapshot", "resourceVersion": "24304", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/create-snapshot", "uid": "ed1d3eb5-6c8c-40ed-96e6-0faa52b10e57"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=15   unreachable=0    failed=0   

2020-07-17T06:47:05.109406 (delta: 0.68947)         elapsed: 19.490335 ******** 
=============================================================================== 
```

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
