### PR TITLE
feat(exp): adding e2e-test for zfspv shared mount support

### DIFF
--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
@@ -22,4 +22,4 @@ Note: For running this experiment above storage-class should be present. This st
 1. First deploy the busybox application using `shared: yes` enabled storage-class
 2. Then we dump some dummy data into the application pod mount point.
 3. Scale the busybox deployment replicas so that multiple pods (here replicas = 2) can share the volume.
-4. After that data consistencty is verified from the scaled application pod in the way that data is accessible from both the pods and after restarting the application pod data consistency should be maintained.
+4. After that data consistency is verified from the scaled application pod in the way that data is accessible from both the pods and after restarting the application pod data consistency should be maintained.

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
@@ -13,16 +13,13 @@ parameters:
   poolname: "< zpool_name >"
 provisioner: zfs.csi.openebs.io
 ```
-- For running this litmus experiment of verification of shared mount support for zfspv, update the needed test specific values in run_litmus_test.yml file and create the kubernetes job.
+- To run this test of verification of shared mount support for zfspv, update the needed test specific values in run_litmus_test.yml file and create the kubernetes job.
 
-Note: For run this experiment above storage-class should be present. This storage will be created as a part of zfs-localpv provisioner experiment. If zfs-localpv components are not deployed using e2e-test script located at `e2e-tests/providers/zfs-localpv-provisioiner` please make sure you create the storage class from above mentioned yaml.
+Note: For running this experiment above storage-class should be present. This storage will be created as a part of zfs-localpv provisioner experiment. If zfs-localpv components are not deployed using e2e-test script located at `e2e-tests/providers/zfs-localpv-provisioiner` please make sure you create the storage class from above mentioned yaml.
 
 ## Steps performed in this experiment:
 
 1. First deploy the busybox application using `shared: yes` enabled storage-class
 2. Then we dump some dummy data into the application pod mount point.
 3. Scale the busybox deployment replicas so that multiple pods (here replicas = 2) can share the volume.
-4. After that data consistencty is verified from the scaled application pod in the way that data is     accessible from both the pods and after restarting the application pod data should not alter/corrupt.
-
-
-
+4. After that data consistencty is verified from the scaled application pod in the way that data is     accessible from both the pods and after restarting the application pod data consistency should be maintained.

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
@@ -1,0 +1,28 @@
+## About the experiment
+
+- This functional test verifies the zfs-localpv shared mount volume support via multiple pods. Applications who wants to share the volume can use the storage-class as below.
+
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-zfspv
+parameters:
+  shared: "yes"
+  fstype: "zfs"
+  poolname: "< zpool_name >"
+provisioner: zfs.csi.openebs.io
+```
+- For running this litmus experiment of verification of shared mount support for zfspv, update the needed test specific values in run_litmus_test.yml file and create the kubernetes job.
+
+Note: For run this experiment above storage-class should be present. This storage will be created as a part of zfs-localpv provisioner experiment. If zfs-localpv components are not deployed using e2e-test script located at `e2e-tests/providers/zfs-localpv-provisioiner` please make sure you create the storage class from above mentioned yaml.
+
+## Steps performed in this experiment:
+
+1. First deploy the busybox application using `shared: yes` enabled storage-class
+2. Then we dump some dummy data into the application pod mount point.
+3. Scale the busybox deployment replicas so that multiple pods (here replicas = 2) can share the volume.
+4. After that data consistencty is verified from the scaled application pod in the way that data is     accessible from both the pods and after restarting the application pod data should not alter/corrupt.
+
+
+

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/README.md
@@ -22,4 +22,4 @@ Note: For running this experiment above storage-class should be present. This st
 1. First deploy the busybox application using `shared: yes` enabled storage-class
 2. Then we dump some dummy data into the application pod mount point.
 3. Scale the busybox deployment replicas so that multiple pods (here replicas = 2) can share the volume.
-4. After that data consistencty is verified from the scaled application pod in the way that data is     accessible from both the pods and after restarting the application pod data consistency should be maintained.
+4. After that data consistencty is verified from the scaled application pod in the way that data is accessible from both the pods and after restarting the application pod data consistency should be maintained.

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/busybox_share.j2
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/busybox_share.j2
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-shared-mount
+  namespace: "{{ app_ns }}"
+  labels:
+    app: shared-mount
+spec:
+  selector:
+    matchLabels:
+      app: shared-mount
+  template:
+    metadata:
+      labels:
+        app: shared-mount
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: "{{ app_pvc }}"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  namespace: "{{ app_ns }}"
+  name: "{{ app_pvc }}"
+spec:
+  storageClassName: "{{ storage_class }}"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/run_litmus_test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/run_litmus_test.yml
@@ -39,8 +39,14 @@ spec:
           - name: STORAGE_CLASS      ## Give the storage class supporting shared volume mount
             value: ''
 
+          - name: OPERATOR_NAMESPACE ## Namespace in which all the resources created by zfs driver will be present
+            value: ''                ## for e.g. zfsvolume (zv) will be in this namespace
+
           - name: DATA_PERSISTENCE   ## Give values according to the application
             value: ''                ## For `Busybox` : `busybox`
+
+          - name: ACTION             ## `provision` OR `deprovision`
+            value: ''
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/run_litmus_test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/run_litmus_test.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zfspv-shared-mount
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: zfspv-shared-mount-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: shared-mount-volume
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays  #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE      ## Namespace in which application is deployed
+            value: '' 
+          
+          - name: APP_PVC            ## PVC name of the application
+            value: ''
+
+          - name: STORAGE_CLASS      ## Give the storage class supporting shared volume mount
+            value: ''
+
+          - name: DATA_PERSISTENCE   ## Give values according to the application
+            value: ''                ## For `Busybox` : `busybox`
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: zfspv-shared-mount

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
@@ -1,0 +1,142 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+    
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+        - block: 
+           
+            - name: Create application namespace
+              shell: >
+                kubectl create ns {{ app_ns }}
+              args:
+                executable: /bin/bash
+
+            - name: Update the busybox application template with test specific values
+              template:
+                src: busybox_share.j2
+                dest: busybox_share.yml
+
+            - name: Deploy the busybox application using above storage-class
+              shell: >
+                kubectl apply -f busybox_share.yml
+              args:
+                executable: /bin/bash
+
+            - name: Check the pvc status
+              shell: >
+                kubectl get pvc -n {{ app_ns }} --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: pvc_status
+              until: pvc_status.stdout == 'Bound'
+              delay: 2
+              retries: 20
+
+            - name: Get the application deployment name
+              shell: >
+                kubectl get deploy -n {{ app_ns }} --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: app_deploy_name
+
+            - name: Get the application pod name
+              shell: >
+                kubectl get pod -n {{ app_ns }} -l app=shared-mount --no-headers -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: app_pod_name
+
+            - name: Check if the application pod is running
+              shell: >
+                kubectl get pod {{ app_pod_name.stdout }} -n {{ app_ns }} --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: app_pod_status
+              until: "app_pod_status.stdout == 'Running'"
+              delay: 3
+              retries: 30
+
+            - name: Create some test data into the application pod
+              include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+              vars:
+                status: 'LOAD'
+                ns: "{{ app_ns }}"
+                pod_name: "{{ app_pod_name.stdout }}"
+
+            - name: Scale the deployment replicas to use shared mount volume by multiple pods
+              shell: >
+                kubectl scale deploy/{{ app_deploy_name.stdout }} -n {{ app_ns }} --replicas=2
+              args:
+                executable: /bin/bash
+
+            - name: Check the no of replicas in deployment spec
+              shell: >
+                kubectl get deploy/{{ app_deploy_name.stdout }} -n {{ app_ns }} --no-headers
+                -o custom-columns=:.status.readyReplicas
+              args: 
+                executable: /bin/bash
+              register: replica_count
+              until: "replica_count.stdout == '2'"
+
+            - name: Get the new application pod name after scaling the deployment replicas
+              shell: >
+                kubectl get pod -n {{ app_ns }} -l app=shared-mount --no-headers
+                -o custom-columns=:.metadata.name | grep -v {{ app_pod_name.stdout }}
+              args:
+                executable: /bin/bash
+              register: scaled_app_pod_name
+
+            - name: Check the container-status of the new application pod
+              shell: >
+                kubectl get pod {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} --no-headers
+                -o jsonpath='{.status.containerStatuses[].state}' | grep running
+              args:
+                executable: /bin/bash
+              register: containerStatus
+              until: "'running' in containerStatus.stdout"
+              delay: 2
+              retries: 50
+
+            - name: Label the scaled application pod
+              shell: >
+                kubectl label pod {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} share=mount
+              args:
+                executable: /bin/bash
+
+            - name: Verify if the shared volume data is accessible from both the application pods
+              include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+              vars:
+                status: 'VERIFY'
+                ns: "{{ app_ns }}"
+                label: share=mount
+                pod_name: "{{ app_pod_name.stdout }}"
+
+        - set_fact:
+            flag: "Pass"
+      
+      rescue:
+        - set_fact:
+            flag: "Fail"
+      
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+
+              

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
@@ -133,7 +133,7 @@
             - name: Delete the dumped data files from scaled application pod
               shell: >
                 kubectl exec -ti {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} -- sh -c
-                'rm -f /busybox/*'
+                'rm -rf /busybox/*'
               args:
                 executable: /bin/bash
               register: status
@@ -157,6 +157,16 @@
               shell: >
                 kubectl label pod {{ app_pod_name.stdout }} -n {{ app_ns }} name=previous-pod
               args: 
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+             
+              ## To keep the application pod label and deployment label same we label the deployment as well
+              ## This will help in filtering while running volume-snapshot test.
+            - name: Label the application deployment
+              shell: >
+                kubectl label deploy/{{ app_deploy_name.stdout }} -n {{ app_ns }} name=previous-pod
+              args:
                 executable: /bin/bash
               register: status
               failed_when: "status.rc != 0"

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
@@ -2,7 +2,6 @@
   connection: local
   gather_facts: False
 
-
   vars_files:
     - test_vars.yml
     - /mnt/parameters.yml

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
@@ -92,6 +92,8 @@
                 executable: /bin/bash
               register: replica_count
               until: "replica_count.stdout == '2'"
+              delay: 2
+              retries: 20
 
             - name: Get the new application pod name after scaling the deployment replicas
               shell: >
@@ -101,7 +103,7 @@
                 executable: /bin/bash
               register: scaled_app_pod_name
 
-            - name: Check the container-status of the new application pod
+            - name: Check the container status of the new application pod
               shell: >
                 kubectl get pod {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} --no-headers
                 -o jsonpath='{.status.containerStatuses[].state}' | grep running
@@ -114,18 +116,59 @@
 
             - name: Label the scaled application pod
               shell: >
-                kubectl label pod {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} share=mount
+                kubectl label pod {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} name=share-pod
               args:
                 executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
 
             - name: Verify if the shared volume data is accessible from both the application pods
               include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
               vars:
                 status: 'VERIFY'
                 ns: "{{ app_ns }}"
-                label: share=mount
+                label: name=share-pod
                 pod_name: "{{ app_pod_name.stdout }}"
 
+            - name: Delete the dumped data files from scaled application pod
+              shell: >
+                kubectl exec -ti {{ scaled_app_pod_name.stdout }} -n {{ app_ns }} -- sh -c
+                'rm -f /busybox/*'
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - name: Again dumping some dummy data, this time from scaled application pod
+              include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+              vars:
+                status: 'LOAD'
+                ns: "{{ app_ns }}"
+                pod_name: "{{ scaled_app_pod_name.stdout }}"
+
+            - name: Get the application pod name
+              shell: >
+                kubectl get pod -n {{ app_ns }} --no-headers -o custom-columns=:.metadata.name | grep -v {{ scaled_app_pod_name.stdout }}
+              args:
+                executable: /bin/bash
+              register: app_pod_name
+              
+            - name: Label the application pod
+              shell: >
+                kubectl label pod {{ app_pod_name.stdout }} -n {{ app_ns }} name=previous-pod
+              args: 
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - name: Verify the data consistency from the previous pod
+              include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+              vars:
+                status: 'VERIFY'
+                ns: "{{ app_ns }}"
+                label: name=previous-pod
+                pod_name: "{{ scaled_app_pod_name.stdout }}"
+                
         - set_fact:
             flag: "Pass"
       

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test.yml
@@ -178,6 +178,57 @@
                 ns: "{{ app_ns }}"
                 label: name=previous-pod
                 pod_name: "{{ scaled_app_pod_name.stdout }}"
+          
+          when: action == 'provision'
+
+        - block: 
+
+          - name: Get the zvolume name from the pvc name
+            shell: >
+              kubectl get pvc {{ app_pvc }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
+            args:
+              executable: /bin/bash
+            register: zvol_name
+
+          - name: Update the busybox deployment template with test specific values
+            template:
+              src: busybox_share.j2
+              dest: busybox_share.yml
+
+          - name: Delete the application deployment
+            shell: >
+              kubectl delete -f busybox_share.yml
+            args:
+              executable: /bin/bash
+            register: status
+            
+          - name: Verify that application pods have been deleted successfully
+            shell: >
+              kubectl get pods -n {{ app_ns }}
+            args:
+              executable: /bin/bash
+            register: app_pod_status
+            failed_when: "'No resources found' in app_pod_status.stdout"
+          
+          - name: Verify the successful deletion of pvc in {{ app_ns }} namespaces
+            shell: >
+              kubectl get pvc -n {{ app_ns }}
+            args: 
+              executable: /bin/bash
+            register: pvc_status
+            failed_when: "app_pvc in pvc_status.stdout"
+
+          - name: Verify the successful deletion of zvolume
+            shell: >
+              kubectl get zv -n {{ operator_ns }}
+            args:
+              executable: /bin/bash
+            register: zv_status
+            until: "zvol_name.stdout not in zv_status.stdout"
+            delay: 3
+            retries: 30
+
+          when: action == 'deprovision'
                 
         - set_fact:
             flag: "Pass"

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test_vars.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test_vars.yml
@@ -7,3 +7,7 @@ app_pvc: "{{ lookup('env','APP_PVC') }}"
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 
 storage_class: "{{ lookup('env','STORAGE_CLASS') }}"
+
+action: "{{ lookup('env','ACTION') }}"
+
+operator_ns: "{{ lookup('env', 'OPERATOR_NAMESPACE') }}"

--- a/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test_vars.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-shared-mount/test_vars.yml
@@ -1,0 +1,9 @@
+test_name: zfspv-shared-mount
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
+storage_class: "{{ lookup('env','STORAGE_CLASS') }}"

--- a/experiments/functional/zfs-LocalPV/zfspv-snapshot/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-snapshot/test.yml
@@ -106,7 +106,7 @@
               args:
                 executable: /bin/bash
               register: app_pod_status
-              until: "app_pod_name.stdout not in app_pod_status.stdout"
+              until: "'No resources found' in app_pod_status.stdout"
               delay: 2
               retries: 20
 

--- a/experiments/functional/zfs-LocalPV/zfspv-snapshot/test.yml
+++ b/experiments/functional/zfs-LocalPV/zfspv-snapshot/test.yml
@@ -106,9 +106,15 @@
               args:
                 executable: /bin/bash
               register: app_pod_status
-              until: "'No resources found' in app_pod_status.stdout"
+              until: "app_pod_name.stdout not in app_pod_status.stdout"
               delay: 2
               retries: 20
+
+              ## As we are checking the status of only one pod if is terminated successfully
+              ## but in case of shared mount support other pods may not be terminate at the same time
+              ## to avoid such condition here we have manual wait for 30 seconds.
+            - name: Manual wait for some time
+              shell: sleep 30
 
             - name: create snapshot   
               shell: >

--- a/providers/zfs-localpv-provisioner/openebs-zfspv-sc.j2
+++ b/providers/zfs-localpv-provisioner/openebs-zfspv-sc.j2
@@ -89,3 +89,36 @@ allowVolumeExpansion: true
 parameters:
   poolname: "{{ pool_name }}"
 provisioner: zfs.csi.openebs.io
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}-zfs-shared"
+parameters:
+  shared: "yes"
+  fstype: "zfs"
+  poolname: "{{ pool_name }}"
+provisioner: zfs.csi.openebs.io
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}-xfs-shared"
+parameters:
+  shared: "yes"
+  fstype: "xfs"
+  poolname: "{{ pool_name }}"
+provisioner: zfs.csi.openebs.io
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}-ext4-shared"
+parameters:
+  shared: "yes"
+  fstype: "ext4"
+  poolname: "{{ pool_name }}"
+provisioner: zfs.csi.openebs.io


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**

- This PR adds e2e-test for zfspv shared mount support.
- Applications who wants to share a volume can use below storageclass to make their volumes shared by multiple pods
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-zfspv
parameters:
  shared: "yes"
  fstype: "zfs"
  poolname: "zfspv-pool"
provisioner: zfs.csi.openebs.io
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #436 


**Ansible playboook logs for the test:**
[shared_mount_logs.txt](https://github.com/openebs/e2e-tests/files/4951705/shared_mount_logs.txt)


