### PR TITLE
refactor[cspc-pool-delete]: Included a task to verify the existence of replica status before deleting the pool

### DIFF
--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -178,6 +178,24 @@
 
         - block:
 
+            - name: Obtain the CSPI list to verify the existence of replicas
+              shell: 
+                 kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ pool_name }} 
+                 -o custom-columns=:.metadata.name --no-headers
+              args:
+                executable: /bin/bash
+              register: cspi_list
+               
+            - name: Verify if the replicas are removed
+              shell: >
+                 kubectl get cspi -n {{ operator_ns }} {{ item }}
+                 -o custom-columns=:.status.provisionedReplicas --no-headers
+              args:
+                executable: /bin/bash
+              register: cspi_rep_status
+              with_items: "{{ cspi_list.stdout_lines }}"
+              failed_when: "cspi_rep_status.stdout != '0'"
+               
             - name: Remove the CStor Pool Cluster
               shell: >
                 kubectl delete cspc {{ pool_name }} -n {{ operator_ns }}


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included a condition to verify the existence of replica status before deleting a cspc pool

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
k8s@e2e1-master:~/e2e-tests/providers/cstor/cstor-cspc-pool$ kubectl logs -f cstor-cspc-pool-provision-wk9rq-ds4dd -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-07-21T08:48:54.379443 (delta: 0.042816)         elapsed: 0.042816 ******** 
=============================================================================== 

TASK [include_tasks] ***********************************************************
2020-07-21T08:48:54.389195 (delta: 0.009607)         elapsed: 0.052568 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-07-21T08:48:54.460160 (delta: 0.070834)         elapsed: 0.123533 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-07-21T08:48:54.494430 (delta: 0.034243)         elapsed: 0.157803 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-07-21T08:48:54.530536 (delta: 0.035961)         elapsed: 0.193909 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-07-21T08:48:54.581147 (delta: 0.050573)         elapsed: 0.24452 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "035bacdb4b1fd8992a7683879a3fea2b885ee8ef", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "723a8fdf57f6efa3378c103e9eb54b09", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1595321334.62-12392340051806/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-07-21T08:48:55.202052 (delta: 0.620873)         elapsed: 0.865425 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.544750", "end": "2020-07-21 08:48:56.000673", "rc": 0, "start": "2020-07-21 08:48:55.455923", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-07-21T08:48:56.051324 (delta: 0.849242)         elapsed: 1.714697 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-07-21T08:15:43Z", "generation": 3, "name": "cstor-pool-provision", "resourceVersion": "27526", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "82b8557a-a5e9-4c02-8088-cb910d2642ee"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-07-21T08:48:57.029064 (delta: 0.977712)         elapsed: 2.692437 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-07-21T08:48:57.052631 (delta: 0.023535)         elapsed: 2.716004 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-07-21T08:48:57.076554 (delta: 0.023874)         elapsed: 2.739927 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-07-21T08:48:57.099843 (delta: 0.023257)         elapsed: 2.763216 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -3", "delta": "0:00:00.786478", "end": "2020-07-21 08:48:58.043314", "failed_when_result": false, "rc": 0, "start": "2020-07-21 08:48:57.256836", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1\ne2e1-node2\ne2e1-node3", "stdout_lines": ["e2e1-node1", "e2e1-node2", "e2e1-node3"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2020-07-21T08:48:58.082015 (delta: 0.98214)         elapsed: 3.745388 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:00.865761", "end": "2020-07-21 08:48:59.088753", "failed_when_result": false, "rc": 0, "start": "2020-07-21 08:48:58.222992", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-07-21T08:48:59.117046 (delta: 1.034983)         elapsed: 4.780419 ******** 
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}})  => {"changed": false, "item": {"key": "stripe", "value": {"count": 1}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Add node labels for each nodes and create blockdevice template] **********
2020-07-21T08:48:59.180364 (delta: 0.061425)         elapsed: 4.843737 ******** 
skipping: [127.0.0.1] => (item=[u'e2e1-node1'])  => {"changed": false, "item": ["e2e1-node1"], "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=[u'e2e1-node2'])  => {"changed": false, "item": ["e2e1-node2"], "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=[u'e2e1-node3'])  => {"changed": false, "item": ["e2e1-node3"], "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device count] ********************************
2020-07-21T08:48:59.252414 (delta: 0.071206)         elapsed: 4.915787 ******** 
skipping: [127.0.0.1] => (item=e2e1-node1)  => {"changed": false, "item": "e2e1-node1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node2)  => {"changed": false, "item": "e2e1-node2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node3)  => {"changed": false, "item": "e2e1-node3", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-07-21T08:48:59.303851 (delta: 0.0514)         elapsed: 4.967224 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Add the block devices for each node's block device template] *************
2020-07-21T08:48:59.340463 (delta: 0.036424)         elapsed: 5.003836 ******** 
skipping: [127.0.0.1] => (item=e2e1-node1)  => {"changed": false, "outer_item": "e2e1-node1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node2)  => {"changed": false, "outer_item": "e2e1-node2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node3)  => {"changed": false, "outer_item": "e2e1-node3", "skip_reason": "Conditional result was False"}

TASK [Include the blockdevice template in the CSPC spec] ***********************
2020-07-21T08:48:59.397450 (delta: 0.056956)         elapsed: 5.060823 ******** 
skipping: [127.0.0.1] => (item=e2e1-node1)  => {"changed": false, "item": "e2e1-node1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node2)  => {"changed": false, "item": "e2e1-node2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node3)  => {"changed": false, "item": "e2e1-node3", "skip_reason": "Conditional result was False"}

TASK [Replacing the pool name in CSPC spec] ************************************
2020-07-21T08:48:59.452181 (delta: 0.054693)         elapsed: 5.115554 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the namespace in CSPC spec] ************************************
2020-07-21T08:48:59.484938 (delta: 0.032722)         elapsed: 5.148311 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the pool type in CSPC spec] ************************************
2020-07-21T08:48:59.516474 (delta: 0.031502)         elapsed: 5.179847 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the storage class name in CSPC spec] ***************************
2020-07-21T08:48:59.547863 (delta: 0.031354)         elapsed: 5.211236 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display cspc.yml for verification] ***************************************
2020-07-21T08:48:59.584096 (delta: 0.036191)         elapsed: 5.247469 ******** 
skipping: [127.0.0.1] => (item=apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: pool-name
  namespace: operator_ns
spec:
  pools:


---
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: sc-name
  annotations:
    openebs.io/cas-type: cstor
provisioner: cstor.csi.openebs.io
allowVolumeExpansion: true
parameters:
  replicaCount: "3"
  cas-type: cstor
  cstorPoolCluster: pool-name)  => {"item": "apiVersion: cstor.openebs.io/v1\nkind: CStorPoolCluster\nmetadata:\n  name: pool-name\n  namespace: operator_ns\nspec:\n  pools:\n\n\n---\nkind: StorageClass\napiVersion: storage.k8s.io/v1\nmetadata:\n  name: sc-name\n  annotations:\n    openebs.io/cas-type: cstor\nprovisioner: cstor.csi.openebs.io\nallowVolumeExpansion: true\nparameters:\n  replicaCount: \"3\"\n  cas-type: cstor\n  cstorPoolCluster: pool-name"}
skipping: [127.0.0.1] => {"msg": "All items completed"}

TASK [Create cstor disk pool] **************************************************
2020-07-21T08:48:59.626696 (delta: 0.042544)         elapsed: 5.290069 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether cspc is created] *******************************************
2020-07-21T08:48:59.654902 (delta: 0.028169)         elapsed: 5.318275 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the status of CSPI] ***********************************************
2020-07-21T08:48:59.686867 (delta: 0.029976)         elapsed: 5.35024 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-07-21T08:48:59.714543 (delta: 0.027639)         elapsed: 5.377916 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor Pool pods are Running] *******************************
2020-07-21T08:48:59.742077 (delta: 0.027505)         elapsed: 5.40545 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get cStor Pool pod names to verify the container statuses and check the required number of pools created.] ***
2020-07-21T08:48:59.772760 (delta: 0.029611)         elapsed: 5.436133 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the runningStatus of pool pod] ***************************************
2020-07-21T08:48:59.805196 (delta: 0.032401)         elapsed: 5.468569 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the storage class is created] ***********************************
2020-07-21T08:48:59.843272 (delta: 0.038031)         elapsed: 5.506645 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the CSPI list to verify the existence of replicas] ****************
2020-07-21T08:48:59.876035 (delta: 0.03273)         elapsed: 5.539408 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.705489", "end": "2020-07-21 08:49:00.727138", "rc": 0, "start": "2020-07-21 08:49:00.021649", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-gdt5\ncstor-cspc-disk-pool-nxck\ncstor-cspc-disk-pool-sshw", "stdout_lines": ["cstor-cspc-disk-pool-gdt5", "cstor-cspc-disk-pool-nxck", "cstor-cspc-disk-pool-sshw"]}

TASK [Verify if the replicas are removed] **************************************
2020-07-21T08:49:00.757273 (delta: 0.881189)         elapsed: 6.420646 ******** 
failed: [127.0.0.1] (item=cstor-cspc-disk-pool-gdt5) => {"changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-gdt5 -o custom-columns=:.status.provisionedReplicas --no-headers", "delta": "0:00:00.712277", "end": "2020-07-21 08:49:01.627563", "failed_when_result": true, "item": "cstor-cspc-disk-pool-gdt5", "rc": 0, "start": "2020-07-21 08:49:00.915286", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
failed: [127.0.0.1] (item=cstor-cspc-disk-pool-nxck) => {"changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-nxck -o custom-columns=:.status.provisionedReplicas --no-headers", "delta": "0:00:00.659114", "end": "2020-07-21 08:49:02.414125", "failed_when_result": true, "item": "cstor-cspc-disk-pool-nxck", "rc": 0, "start": "2020-07-21 08:49:01.755011", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
failed: [127.0.0.1] (item=cstor-cspc-disk-pool-sshw) => {"changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-sshw -o custom-columns=:.status.provisionedReplicas --no-headers", "delta": "0:00:00.630711", "end": "2020-07-21 08:49:03.174973", "failed_when_result": true, "item": "cstor-cspc-disk-pool-sshw", "rc": 0, "start": "2020-07-21 08:49:02.544262", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [set_fact] ****************************************************************
2020-07-21T08:49:03.206196 (delta: 2.448887)         elapsed: 8.869569 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-07-21T08:49:03.254154 (delta: 0.047928)         elapsed: 8.917527 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-07-21T08:49:03.293674 (delta: 0.039487)         elapsed: 8.957047 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-07-21T08:49:03.320606 (delta: 0.026879)         elapsed: 8.983979 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-07-21T08:49:03.347100 (delta: 0.026458)         elapsed: 9.010473 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-07-21T08:49:03.374382 (delta: 0.025665)         elapsed: 9.037755 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2ea408c6947aa19d6cabef9d2abfb7f92da4e61f", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b68fcbae0dc9cb3438a655120f3550be", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1595321343.41-81245255225084/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-07-21T08:49:04.718453 (delta: 1.344035)         elapsed: 10.381826 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.616766", "end": "2020-07-21 08:49:05.480050", "rc": 0, "start": "2020-07-21 08:49:04.863284", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
2020-07-21T08:49:05.508070 (delta: 0.789584)         elapsed: 11.171443 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-07-21T08:15:43Z", "generation": 4, "name": "cstor-pool-provision", "resourceVersion": "27573", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "82b8557a-a5e9-4c02-8088-cb910d2642ee"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Fail"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=13   changed=9    unreachable=0    failed=1   

2020-07-21T08:49:06.323785 (delta: 0.815667)         elapsed: 11.987158 ******* 
=============================================================================== 
```