### PR TITLE
refact(exp): adding reconciliation test case for provision localpv on selected blockdevice

### DIFF
--- a/experiments/functional/localpv/localpv-provisioning-selected-device/README.md
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/README.md
@@ -16,13 +16,15 @@
 
 ## Procedure
 
-- This functional test checks if the local pv can be provisioned on the selected block device.
+- This functional test checks if the local pv can be provisioned on the selected block device. 
 
-- This litmusbook accepts the parameters in form of job environmental variables.
+- This litmusbook accepts the parameters in form of job environmental variables and accordingly this test case can be run for two different test case type i.e. positive test case and negative test case.
 
-- Certain block device will be labelled with `openebs.io/block-device-tag=< tag-value >`
+For positive test case first we label the block devices and then provision the volume and verify the successful provisioning of the volume. For the negative test case first we provision the volume but claim for the persistent volume should be in pending state, and then we label the block device and verify the successful reconcilation of provisioning the volume is done. And later in both the cases we verify that block device is selected from only the list of tagged block devices.
 
-- The `< tag-value >` can be passed to Local PV storage class via cas annotations. If the value is present, then Local PV device provisioner will set the following additional selector on the BDC:
+1. Certain block device will be labelled with `openebs.io/block-device-tag=< tag-value >`
+
+2. The `< tag-value >` can be passed to Local PV storage class via cas annotations. If the value is present, then Local PV device provisioner will set the following additional selector on the BDC:
   `openebs.io/block-device-tag=< tag-value >`
 
 - The storage class spec will be built as follows:
@@ -44,8 +46,6 @@
   reclaimPolicy: Delete
   ```
 
-  
-
 - Upon using the above storage class, the PV should be provisioned on the tagged block device
 
 - Finally, checking if the tagged BD alone is used by BDC being part of the volume.
@@ -58,3 +58,4 @@
 | PVC           | Name of PVC to be created                                    |
 | OPERATOR_NS   | Namespace where OpenEBS is running                           |
 | BD_TAG        | The label value to be used by the key `openebs.io/block-device-tag=< tag-value >` |
+| TEST_CASE_TYPE| Run the test for `positive` or `negative` cases              |

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml
@@ -36,5 +36,11 @@ spec:
           - name: PVC
             value: ''
 
+            ## In positive case type first blockdevice is labeled and then pv is created
+            ## In negative case type first pv creation is done, pvc remains in pending state
+            ## and then we label the blockdevice. In this way successful reconcilation is verified.
+          - name: TEST_CASE_TYPE      ## `positive` OR `negative`
+            value: ''
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/localpv/localpv-provisioning-selected-device/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
@@ -17,29 +17,6 @@
           vars:
             status: 'SOT'
 
-        - name: Obtain the list of nodes
-          shell: kubectl get nodes --no-headers | grep -v master | awk '{print $1}'
-          args:
-            executable: /bin/bash
-          register: nodes
-
-        - name: Getting the Unclaimed block-device from each node
-          shell: >
-            kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ item }}
-            -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | head -n 1
-          register: blockDevice
-          with_items:
-            - "{{ nodes.stdout_lines }}"
-
-        - name: Label the selected block devices
-          shell: >
-            kubectl label bd -n "{{ operator_ns }}" "{{ item.stdout }}" openebs.io/block-device-tag="{{ device_tag }}"
-          args:
-            executable: /bin/bash
-          register: bd_result
-          with_items:
-            - "{{ blockDevice.results }}"
-
         - name: Forming storage class manifest from template
           template:
             src: storage_class.j2
@@ -64,34 +41,126 @@
           register: ns_status
           failed_when: ns_status.rc != 0
 
-        - name: Deploying application
-          shell: kubectl apply -f percona.yml -n "{{ namespace }}"
-          args:
-            executable: /bin/bash
-          register: app_status
-          failed_when: "app_status.rc != 0"
+        - block:
 
-        - name: Check if the PVC is bound
-          shell: >
-            kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: pvc_status
-          until: "'Bound' in pvc_status.stdout"
-          delay: 10
-          retries: 20
+          - name: Obtain the list of nodes
+            shell: kubectl get nodes --no-headers | grep -v master | awk '{print $1}'
+            args:
+              executable: /bin/bash
+            register: nodes
 
-        - name: Check if the application is running
-          shell: >
-            kubectl get pods -n {{ namespace }} -l name=percona 
-            --no-headers -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_state
-          until: "'Running' in app_state.stdout"
-          delay: 5
-          retries: 50
+          - name: Getting the Unclaimed block-device from each node
+            shell: >
+              kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ item }},openebs\.io/block-device-tag!={{ device_tag }}
+              -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | head -n 1
+            register: blockDevice
+            with_items:
+              - "{{ nodes.stdout_lines }}"
+
+          - name: Label the selected block devices
+            shell: >
+              kubectl label bd -n "{{ operator_ns }}" "{{ item.stdout }}" openebs.io/block-device-tag="{{ device_tag }}"
+            args:
+              executable: /bin/bash
+            register: bd_result
+            with_items:
+              - "{{ blockDevice.results }}"
+
+          - name: Deploying application
+            shell: kubectl apply -f percona.yml -n "{{ namespace }}"
+            args:
+              executable: /bin/bash
+            register: app_status
+            failed_when: "app_status.rc != 0"
+
+          - name: Check if the PVC is bound
+            shell: >
+              kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
+              -o custom-columns=:status.phase
+            args:
+              executable: /bin/bash
+            register: pvc_status
+            until: "'Bound' in pvc_status.stdout"
+            delay: 2
+            retries: 30
+
+          - name: Check if the application is running
+            shell: >
+              kubectl get pods -n {{ namespace }} -l name=percona 
+              --no-headers -o custom-columns=:status.phase
+            args:
+              executable: /bin/bash
+            register: app_state
+            until: "'Running' in app_state.stdout"
+            delay: 5
+            retries: 50
+          
+          when: test_case_type == 'positive'
+
+        - block:
+
+          - name: Obtain the list of nodes
+            shell: kubectl get nodes --no-headers | grep -v master | awk '{print $1}'
+            args:
+              executable: /bin/bash
+            register: nodes
+
+          - name: Getting the Unclaimed block-device from each node
+            shell: >
+              kubectl get blockdevice -n {{ operator_ns }} -l kubernetes.io/hostname={{ item }},openebs\.io/block-device-tag!={{ device_tag }}
+              -o jsonpath='{.items[?(@.status.claimState=="Unclaimed")].metadata.name}' | tr " " "\n" | head -n 1
+            register: blockDevice
+            with_items:
+              - "{{ nodes.stdout_lines }}"
+
+          - name: Deploying application
+            shell: kubectl apply -f percona.yml -n "{{ namespace }}"
+            args:
+              executable: /bin/bash
+            register: app_status
+            failed_when: "app_status.rc != 0"
+
+          - name: Check if the PVC is in pending state
+            shell: >
+              kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
+              -o custom-columns=:status.phase
+            args:
+              executable: /bin/bash
+            register: pvc_status
+            failed_when: "'Pending' not in pvc_status.stdout"
+
+          - name: Label the selected block devices
+            shell: >
+              kubectl label bd -n "{{ operator_ns }}" "{{ item.stdout }}" openebs.io/block-device-tag="{{ device_tag }}"
+            args:
+              executable: /bin/bash
+            register: bd_result
+            with_items:
+              - "{{ blockDevice.results }}"
+
+          - name: Check if the PVC is in Bound
+            shell: >
+              kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
+              -o custom-columns=:status.phase
+            args:
+              executable: /bin/bash
+            register: pvc_status
+            until: "'Bound' in pvc_status.stdout"
+            delay: 2
+            retries: 30
+
+          - name: Check if the application is running
+            shell: >
+              kubectl get pods -n {{ namespace }} -l name=percona 
+              --no-headers -o custom-columns=:status.phase
+            args:
+              executable: /bin/bash
+            register: app_state
+            until: "'Running' in app_state.stdout"
+            delay: 5
+            retries: 50
+          
+          when: test_case_type == 'negative'
 
         - name: Getting PV name from PVC
           shell: >

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/test.yml
@@ -120,6 +120,19 @@
             register: app_status
             failed_when: "app_status.rc != 0"
 
+          - name: Get the application pod name
+            shell: kubectl get pod -n {{ namespace }} -l name=percona --no-headers -o custom-columns=:.metadata.name
+            args:
+              executable: /bin/bash
+            register: app_pod_name
+
+          - name: Check the application pod status
+            shell: kubectl get pod -n {{ namespace }} -l name=percona --no-headers -o custom-columns=:.status.phase
+            args: 
+              executable: /bin/bash
+            register: app_pod_status
+            failed_when: "'Pending' not in app_pod_status.stdout"
+
           - name: Check if the PVC is in pending state
             shell: >
               kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
@@ -138,7 +151,7 @@
             with_items:
               - "{{ blockDevice.results }}"
 
-          - name: Check if the PVC is in Bound
+          - name: Check if the PVC is in Bound state
             shell: >
               kubectl get pvc -n {{ namespace }} {{ pvc_name }} --no-headers
               -o custom-columns=:status.phase

--- a/experiments/functional/localpv/localpv-provisioning-selected-device/test_vars.yml
+++ b/experiments/functional/localpv/localpv-provisioning-selected-device/test_vars.yml
@@ -11,3 +11,5 @@ pvc_name: "{{ lookup('env','PVC') }}"
 namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 
 sc_name: openebs-device-test
+
+test_case_type: "{{ lookup('env','TEST_CASE_TYPE') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR adds negative test case for provisioning of localpv on selected device.
- Here for negative testing first we create the storage class where we specify the block device tag
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: {{ sc_name }}
  annotations:
    openebs.io/cas-type: local
    cas.openebs.io/config: |
      - name: StorageType
        value: "device"
      - name: BlockDeviceTag
        value: "{{ device_tag }}"
provisioner: openebs.io/local
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
```
Now we deploy the application but its pvc will remain in pending state. And then we tag the blockdevice with the same label as provided in the storage class. Now pvc should coming in bound state. In this way we can verify the succesful reconcilation of labeling the blockdevice after provisioning the volume.

**Ansible-playbook logs**
1. _positive test case_
[positive_test_case.txt](https://github.com/openebs/e2e-tests/files/4959182/positive_test_case.txt)
2. _negative test case_
[negative_test_case.txt](https://github.com/openebs/e2e-tests/files/4959184/negative_test_case.txt)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #301 

