### PR TITLE
refactor the task to include the maxpool count in spc spec

### DIFF
--- a/providers/cstor/cstor-block-device-pool/spc.yml
+++ b/providers/cstor/cstor-block-device-pool/spc.yml
@@ -5,7 +5,6 @@ metadata:
 spec:
   name: pool-name
   type: disk
-  maxPools: maxpool-count
   poolSpec:
     poolType: pool-type
     thickProvisioning: false

--- a/providers/cstor/cstor-block-device-pool/test.yml
+++ b/providers/cstor/cstor-block-device-pool/test.yml
@@ -150,11 +150,20 @@
                 regexp: "pool-name"
                 replace: "{{ pool_name }}"
 
-            - name: Replacing the maxPool count in SPC spec
-              replace:
-                path: ./spc.yml
-                regexp: "maxpool-count"
-                replace: "{{ maxpool_count }}"
+            - block: 
+
+                - name: Inserting the maxpool count in spc spec
+                  lineinfile:
+                    path: ./spc.yml
+                    insertafter: 'type: disk'
+                    line: "  maxPools: maxpool-count"
+
+                - name: Replacing the maxPool count value in SPC spec
+                  replace:
+                    path: ./spc.yml
+                    regexp: "maxpool-count"
+                    replace: "{{ maxpool_count }}"
+
               when: "maxpool_count != '0'"
 
             - name: Replacing the storage class name in SPC spec


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>
- Updated the tasks to include the maxpool count in spc pool spec

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
