### PR TITLE
refactor[sc-policies]: Included the storage policy for csi xfs filesystem

### DIFF
--- a/providers/cstor-storage-policies/csi-cstor-xfs-sc.j2
+++ b/providers/cstor-storage-policies/csi-cstor-xfs-sc.j2
@@ -15,7 +15,7 @@ parameters:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: openebs-cstor-csi-xfs
+  name: openebs-cstor-csi-xfs-single-replica
 provisioner: cstor.csi.openebs.io
 allowVolumeExpansion: true
 parameters:

--- a/providers/cstor-storage-policies/csi-cstor-xfs-sc.j2
+++ b/providers/cstor-storage-policies/csi-cstor-xfs-sc.j2
@@ -10,3 +10,17 @@ parameters:
   replicaCount: "3"
   cstorPoolCluster: "{{ pool_name }}"
   fsType: xfs
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-xfs
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  cas-type: cstor
+  replicaCount: "1"
+  cstorPoolCluster: "{{ pool_name }}"
+  fsType: xfs
+

--- a/providers/cstor-storage-policies/run_litmus_test.yml
+++ b/providers/cstor-storage-policies/run_litmus_test.yml
@@ -24,7 +24,7 @@ spec:
             #value: log_plays, actionable, default
             value: default
 
-            # Provide name POOL_NAME for the cstor-pool [SPC NAME]
+            # Provide name POOL_NAME for the cstor-pool 
           - name: POOL_NAME
             value: cstor-sparse-pool
 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan sathyaseelan.n@mayadata.io

- Included a storage class with single replica in storage policies for xfs filesytem

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
