### PR TITLE
refactor(Jiva-snapshot-delete): Enable experiment to restart replica in different modes

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/run_litmus_test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/run_litmus_test.yml
@@ -35,5 +35,8 @@ spec:
           - name: DATA_CHECK #data_integrity for jiva  #data_accesibility for cstor
             value: "data_integrity"
 
+          - name: REPLICA_RESTART
+            value: "LEADER" #Supported values are {RANDOM, LEADER}
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/snapshot_deletion/jiva/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
@@ -11,6 +11,6 @@
   args:
     executable: /bin/bash
   register: snapshot_number
-  until: "((snapshot_number.stdout)|int) <= 11"
+  until: "((snapshot_number.stdout)|int) <= 13"
   delay: 5
   retries: 50

--- a/experiments/functional/snapshot_deletion/jiva/test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test.yml
@@ -123,6 +123,7 @@
          include: "{{ replica_restart_yml }}"
          vars:
            controller_service: "{{ controller_svc.stdout }}"
+           action: "{{ lookup('env','REPLICA_RESTART') }}"
          with_items: "{{ iterator.stdout_lines }}"
 
        - name: Include replica count test

--- a/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
@@ -1,46 +1,66 @@
-# - name: Get the name of replica pods
-#   shell: >
-#     kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}'
-#   args:
-#     executable: /bin/bash
-#   register: replica_pod
+- block:
 
-# - name: Set the replica pod name to variable based on latest creation timestamp
-#   set_fact:
-#     replica_name: "{{ replica_pod.stdout_lines[2].split()[0] }}"
+   - name: Get the name of replica pods
+     shell: >
+       kubectl get pods -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}}'
+     args:
+       executable: /bin/bash
+     register: replica_pod_name
 
-- name: Get replica json response from controller
-  vars:
-    replicas_endpoint: "9501/v1/replicas"
-  uri:
-    url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
-    method: GET
-    return_content: yes
-    status_code: 200
-    headers:
-      Content-Type: "application/json"
-    body_format: json
-  register: json_response
+   - name: Set the replica pod name to variable based on latest creation timestamp
+     set_fact:
+       replica_pod: "{{ replica_pod_name.stdout_lines[2].split()[0] }}"
 
-- name: Set master replica ip
-  set_fact:
-          replica_ip: "{{ json_response.json.data[0].address | regex_replace('tcp://') | regex_replace(':9502') }}"
+   - name: Delete random replica
+     shell: >
+       kubectl delete pod {{ replica_pod.stdout }} -n {{ operator_ns }}
+     args:
+       executable: /bin/bash
 
-- debug:
-    var: "replica_ip"
+   # Pausing replica to distribute the data among the new snapshots
+   # created after the restarts
+   - name: Pause for some time for a new replica to come up
+     pause:
+       minutes: 1
 
-- name: Getting the master replica pod name corresponding to the IP
-  shell: kubectl get pod -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP=="{{ replica_ip }}")].metadata.name}'
-  register: replica_name
+  when: action == "RANDOM"
 
-- name: Delete master replica
-  shell: >
-    kubectl delete pod {{ replica_name.stdout }} -n {{ operator_ns }}
-  args:
-    executable: /bin/bash
+- block:
 
-# Pausing replica to distribute the data among the new snapshots
-# created after the restarts
-- name: Pause for some time for a new replica to come up
-  pause:
-    minutes: 1
+   - name: Get replica json response from controller
+     vars:
+       replicas_endpoint: "9501/v1/replicas"
+     uri:
+       url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+       method: GET
+       return_content: yes
+       status_code: 200
+       headers:
+         Content-Type: "application/json"
+       body_format: json
+     register: json_response
+
+   - name: Set master replica ip
+     set_fact:
+             replica_ip: "{{ json_response.json.data[0].address | regex_replace('tcp://') | regex_replace(':9502') }}"
+
+   - debug:
+       var: "replica_ip"
+
+   - name: Getting the master replica pod name corresponding to the IP
+     shell: kubectl get pod -l openebs.io/replica=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP=="{{ replica_ip }}")].metadata.name}'
+     register: replica_name
+
+   - name: Delete master replica
+     shell: >
+       kubectl delete pod {{ replica_name.stdout }} -n {{ operator_ns }}
+     args:
+       executable: /bin/bash
+
+   # Pausing replica to distribute the data among the new snapshots
+   # created after the restarts
+   - name: Pause for some time for a new replica to come up
+     pause:
+       minutes: 1
+
+  when: action == "LEADER"


### PR DESCRIPTION


Signed-off-by:  <ranjanshashank855@gmail.com>

**What this PR does / why we need it**:
- Add a env `REPLICA_RESTART` whose supported values are {LEADER, RANDOM}.
- In `LEADER` mode experiment always pick the master replica and restarts it.
- In `RANDOM` mode experiment pick random replica pod and restarts it.

**Which issue this PR fixes** 
- https://github.com/openebs/e2e-tests/issues/468

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
