### PR TITLE
refactor[node-failure]: Modified the node shut down test case as applicable for cstor csi volumes

### DIFF
--- a/experiments/chaos/node_failure/prerequisites.yml
+++ b/experiments/chaos/node_failure/prerequisites.yml
@@ -23,6 +23,11 @@
   set_fact:
     stg_prov: "{{ provisioner.stdout }}"
 
+- name: Record the storage engine name
+  set_fact:
+    stg_engine: "cstor"
+  when: stg_prov == "cstor.csi.openebs.io"
+
 - block:
     - name: Derive PV name from PVC to query storage engine type (openebs)
       shell: >


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- In this test case checking the compatible of node failure for cstor csi based volumes.
- Power off or shutdown the node where the application pod is scheduled and wait until the application pod got evicted and scheduled on another node.
- At this time volume may not mount on the application pod due to multi-attach error.
- Deleting node CR may mount the volume. Checking if the volume is able to mount after deleting node CR and verify the data persistence of the application.

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
d2iq@rack2:~/sathya/e2e-tests/apps/percona/deployers$ kubectl logs -f node-failure-fdprm-66c4g -n litmus
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Apr 15 2020, 17:20:14) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/node_failure/prerequisites.yml

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/node_failure/test.yml

PLAY [localhost] ***************************************************************
2020-07-30T08:31:06.126359 (delta: 0.042895)         elapsed: 0.042895 ******** 
=============================================================================== 
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:14
2020-07-30T08:31:06.137266 (delta: 0.010871)         elapsed: 0.053802 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-07-30T08:31:06.196286 (delta: 0.059005)         elapsed: 0.112822 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-07-30T08:31:06.230259 (delta: 0.033948)         elapsed: 0.146795 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:16
2020-07-30T08:31:06.264099 (delta: 0.033809)         elapsed: 0.180635 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-07-30T08:31:06.315613 (delta: 0.05148)         elapsed: 0.232149 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "984ebc2882d067cf86b84134c02b29af128a0539", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "68fccee348c495fd9ac54ccd51afd692", "mode": "0644", "owner": "root", "size": 425, "src": "/root/.ansible/tmp/ansible-tmp-1596097866.36-46612407176581/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-07-30T08:31:06.825898 (delta: 0.510244)         elapsed: 0.742434 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.831449", "end": "2020-07-30 08:31:07.892550", "rc": 0, "start": "2020-07-30 08:31:07.061101", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-07-30T08:31:07.924310 (delta: 1.09837)         elapsed: 1.840846 ********* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-07-30T05:20:23Z", "generation": 8, "name": "node-failure", "resourceVersion": "3652199", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/node-failure", "uid": "b0d05a71-23b4-482f-b030-a0b7859f4e85"}, "spec": {"testMetadata": {"chaostype": "node-failure"}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-07-30T08:31:08.754338 (delta: 0.82999)         elapsed: 2.670874 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-07-30T08:31:08.778163 (delta: 0.023793)         elapsed: 2.694699 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-07-30T08:31:08.803514 (delta: 0.02532)         elapsed: 2.72005 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/node_failure/test.yml:23
2020-07-30T08:31:08.827477 (delta: 0.023919)         elapsed: 2.744013 ******** 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : test-sathya", 
        "Label        : lkey=lvalue"
    ]
}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/node_failure/prerequisites.yml:2
2020-07-30T08:31:08.892605 (delta: 0.065067)         elapsed: 2.809141 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc testclaim -n test-sathya --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.043940", "end": "2020-07-30 08:31:10.086783", "rc": 0, "start": "2020-07-30 08:31:09.042843", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-pool-new", "stdout_lines": ["openebs-cstor-pool-new"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/node_failure/prerequisites.yml:10
2020-07-30T08:31:10.118736 (delta: 1.226095)         elapsed: 4.035272 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-pool-new --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.882152", "end": "2020-07-30 08:31:11.146286", "rc": 0, "start": "2020-07-30 08:31:10.264134", "stderr": "", "stderr_lines": [], "stdout": "cstor.csi.openebs.io", "stdout_lines": ["cstor.csi.openebs.io"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:18
2020-07-30T08:31:11.227703 (delta: 1.108932)         elapsed: 5.144239 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-pool-new"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:22
2020-07-30T08:31:11.274488 (delta: 0.04675)         elapsed: 5.191024 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "cstor.csi.openebs.io"}, "changed": false}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:26
2020-07-30T08:31:11.318661 (delta: 0.044126)         elapsed: 5.235197 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/node_failure/prerequisites.yml:32
2020-07-30T08:31:11.372886 (delta: 0.054191)         elapsed: 5.289422 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /experiments/chaos/node_failure/prerequisites.yml:40
2020-07-30T08:31:11.403188 (delta: 0.030267)         elapsed: 5.319724 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/node_failure/prerequisites.yml:48
2020-07-30T08:31:11.431544 (delta: 0.028322)         elapsed: 5.34808 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/node_failure/test.yml:32
2020-07-30T08:31:11.459957 (delta: 0.02838)         elapsed: 5.376493 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "c3d158e37e6690e06d2df05aaab730ac04f28e26", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "bf958392dd91677ad0cb84dfd8db23cf", "mode": "0644", "owner": "root", "size": 59, "src": "/root/.ansible/tmp/ansible-tmp-1596097871.49-97615159781726/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/node_failure/test.yml:37
2020-07-30T08:31:11.746231 (delta: 0.286235)         elapsed: 5.662767 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "chaoslib/vmware_chaos/vm_power_operations.yml"}, "ansible_included_var_files": ["/experiments/chaos/node_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/node_failure/test.yml:40
2020-07-30T08:31:11.793193 (delta: 0.046925)         elapsed: 5.709729 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/vmware_chaos/vm_power_operations.yml"}, "changed": false}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/node_failure/test.yml:44
2020-07-30T08:31:11.843318 (delta: 0.050092)         elapsed: 5.759854 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "27b2c80542dfd9d56af54d21d71d2fba0cd55966", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "5ae89030910c1e5130291aa8223b27c0", "mode": "0644", "owner": "root", "size": 80, "src": "/root/.ansible/tmp/ansible-tmp-1596097871.88-64861213174312/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/node_failure/test.yml:49
2020-07-30T08:31:12.142465 (delta: 0.299087)         elapsed: 6.059001 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/chaos/node_failure/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/node_failure/test.yml:52
2020-07-30T08:31:12.192155 (delta: 0.049656)         elapsed: 6.108691 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [Verify if the application is running.] ***********************************
task path: /experiments/chaos/node_failure/test.yml:58
2020-07-30T08:31:12.252747 (delta: 0.060558)         elapsed: 6.169283 ******** 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-07-30T08:31:12.293262 (delta: 0.040481)         elapsed: 6.209798 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n test-sathya -l lkey=\"lvalue\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.712183", "end": "2020-07-30 08:31:13.161018", "rc": 0, "start": "2020-07-30 08:31:12.448835", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-07-30T08:22:25Z]]", "stdout_lines": ["map[running:map[startedAt:2020-07-30T08:22:25Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-07-30T08:31:13.195389 (delta: 0.902094)         elapsed: 7.111925 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n test-sathya -o jsonpath='{.items[?(@.metadata.labels.lkey==\"lvalue\")].status.phase}'", "delta": "0:00:00.758555", "end": "2020-07-30 08:31:14.110042", "rc": 0, "start": "2020-07-30 08:31:13.351487", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/node_failure/test.yml:68
2020-07-30T08:31:14.148049 (delta: 0.952625)         elapsed: 8.064585 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n test-sathya -l lkey=lvalue --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.730687", "end": "2020-07-30 08:31:15.027882", "rc": 0, "start": "2020-07-30 08:31:14.297195", "stderr": "", "stderr_lines": [], "stdout": "percona-f445994bd-jd99l", "stdout_lines": ["percona-f445994bd-jd99l"]}

TASK [Obtain PVC name from the application mount] ******************************
task path: /experiments/chaos/node_failure/test.yml:75
2020-07-30T08:31:15.064896 (delta: 0.916813)         elapsed: 8.981432 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods \"percona-f445994bd-jd99l\" -n \"test-sathya\" -o yaml | grep claimName | awk '{print $2}'", "delta": "0:00:00.959486", "end": "2020-07-30 08:31:16.184563", "rc": 0, "start": "2020-07-30 08:31:15.225077", "stderr": "", "stderr_lines": [], "stdout": "testclaim", "stdout_lines": ["testclaim"]}

TASK [Obtain the Persistent Volume name] ***************************************
task path: /experiments/chaos/node_failure/test.yml:83
2020-07-30T08:31:16.213574 (delta: 1.148643)         elapsed: 10.13011 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc \"testclaim\" -n \"test-sathya\" --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.720885", "end": "2020-07-30 08:31:17.070356", "failed_when_result": false, "rc": 0, "start": "2020-07-30 08:31:16.349471", "stderr": "", "stderr_lines": [], "stdout": "pvc-5950d828-b87b-44f3-abc5-1d9f5807d688", "stdout_lines": ["pvc-5950d828-b87b-44f3-abc5-1d9f5807d688"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/node_failure/test.yml:93
2020-07-30T08:31:17.103709 (delta: 0.8901)         elapsed: 11.020245 ********* 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-07-30T08:31:17.193044 (delta: 0.089294)         elapsed: 11.10958 ******** 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database nodefailurenew;') => {"changed": true, "cmd": "kubectl exec percona-f445994bd-jd99l -n test-sathya -- mysql -uroot -pk8sDem0 -e 'create database nodefailurenew;'", "delta": "0:00:00.816422", "end": "2020-07-30 08:31:18.165936", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database nodefailurenew;'", "rc": 0, "start": "2020-07-30 08:31:17.349514", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' nodefailurenew) => {"changed": true, "cmd": "kubectl exec percona-f445994bd-jd99l -n test-sathya -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' nodefailurenew", "delta": "0:00:01.093861", "end": "2020-07-30 08:31:19.406025", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' nodefailurenew", "rc": 0, "start": "2020-07-30 08:31:18.312164", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' nodefailurenew) => {"changed": true, "cmd": "kubectl exec percona-f445994bd-jd99l -n test-sathya -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' nodefailurenew", "delta": "0:00:01.029849", "end": "2020-07-30 08:31:20.572639", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' nodefailurenew", "rc": 0, "start": "2020-07-30 08:31:19.542790", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-07-30T08:31:20.611836 (delta: 3.418758)         elapsed: 14.528372 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-07-30T08:31:20.637570 (delta: 0.025695)         elapsed: 14.554106 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-07-30T08:31:20.665871 (delta: 0.028271)         elapsed: 14.582407 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-07-30T08:31:20.694631 (delta: 0.028728)         elapsed: 14.611167 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-07-30T08:31:20.721357 (delta: 0.026694)         elapsed: 14.637893 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-07-30T08:31:20.746745 (delta: 0.025356)         elapsed: 14.663281 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-07-30T08:31:20.772823 (delta: 0.026047)         elapsed: 14.689359 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-07-30T08:31:20.797734 (delta: 0.024872)         elapsed: 14.71427 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-07-30T08:31:20.822372 (delta: 0.024609)         elapsed: 14.738908 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-07-30T08:31:20.847046 (delta: 0.024644)         elapsed: 14.763582 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get Application pod Node to perform chaos] *******************************
task path: /experiments/chaos/node_failure/test.yml:102
2020-07-30T08:31:20.872541 (delta: 0.025461)         elapsed: 14.789077 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-f445994bd-jd99l -n test-sathya --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.708206", "end": "2020-07-30 08:31:21.716752", "rc": 0, "start": "2020-07-30 08:31:21.008546", "stderr": "", "stderr_lines": [], "stdout": "konvoy-node2.mayalabs.io", "stdout_lines": ["konvoy-node2.mayalabs.io"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:111
2020-07-30T08:31:21.745141 (delta: 0.872562)         elapsed: 15.661677 ******* 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2020-07-30T08:31:21.801626 (delta: 0.056453)         elapsed: 15.718162 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.33.1.1 vim-cmd vmsvc/getallvms | grep konvoy-node2.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.371706", "end": "2020-07-30 08:31:23.323904", "rc": 0, "start": "2020-07-30 08:31:21.952198", "stderr": "Warning: Permanently added '10.33.1.1' (RSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '10.33.1.1' (RSA) to the list of known hosts."], "stdout": "31", "stdout_lines": ["31"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2020-07-30T08:31:23.356286 (delta: 1.554626)         elapsed: 17.272822 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.33.1.1 vim-cmd vmsvc/power.off 31", "delta": "0:00:04.411393", "end": "2020-07-30 08:31:27.916789", "failed_when_result": false, "rc": 0, "start": "2020-07-30 08:31:23.505396", "stderr": "", "stderr_lines": [], "stdout": "Powering off VM:", "stdout_lines": ["Powering off VM:"]}

TASK [Check the node status] ***************************************************
task path: /experiments/chaos/node_failure/test.yml:118
2020-07-30T08:31:27.951999 (delta: 4.59568)         elapsed: 21.868535 ******** 
FAILED - RETRYING: Check the node status (15 retries left).
FAILED - RETRYING: Check the node status (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get nodes konvoy-node2.mayalabs.io --no-headers", "delta": "0:00:00.763201", "end": "2020-07-30 08:32:30.891630", "rc": 0, "start": "2020-07-30 08:32:30.128429", "stderr": "", "stderr_lines": [], "stdout": "konvoy-node2.mayalabs.io   NotReady   <none>   92m   v1.17.7", "stdout_lines": ["konvoy-node2.mayalabs.io   NotReady   <none>   92m   v1.17.7"]}

TASK [Wait for the application pod to get evicted] *****************************
task path: /experiments/chaos/node_failure/test.yml:128
2020-07-30T08:32:30.927285 (delta: 62.975249)         elapsed: 84.843821 ****** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 300, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [check the application status] ********************************************
task path: /experiments/chaos/node_failure/test.yml:133
2020-07-30T08:37:31.319505 (delta: 300.392185)         elapsed: 385.236041 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n test-sathya -l lkey=lvalue --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.767642", "end": "2020-07-30 08:37:32.247054", "rc": 0, "start": "2020-07-30 08:37:31.479412", "stderr": "", "stderr_lines": [], "stdout": "Pending\nRunning", "stdout_lines": ["Pending", "Running"]}

TASK [Check if the CVRs are in healthy state] **********************************
task path: /experiments/chaos/node_failure/test.yml:143
2020-07-30T08:37:32.298303 (delta: 0.978726)         elapsed: 386.214839 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-5950d828-b87b-44f3-abc5-1d9f5807d688 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.003235", "end": "2020-07-30 08:37:33.473667", "rc": 0, "start": "2020-07-30 08:37:32.470432", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Delete the node CR] ******************************************************
task path: /experiments/chaos/node_failure/test.yml:158
2020-07-30T08:37:33.510114 (delta: 1.211776)         elapsed: 387.42665 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete node konvoy-node2.mayalabs.io", "delta": "0:00:00.727315", "end": "2020-07-30 08:37:34.371586", "failed_when_result": false, "rc": 0, "start": "2020-07-30 08:37:33.644271", "stderr": "", "stderr_lines": [], "stdout": "node \"konvoy-node2.mayalabs.io\" deleted", "stdout_lines": ["node \"konvoy-node2.mayalabs.io\" deleted"]}

TASK [wait for the application pod to start] ***********************************
task path: /experiments/chaos/node_failure/test.yml:166
2020-07-30T08:37:34.406774 (delta: 0.896626)         elapsed: 388.32331 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 360, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Check if the application pod is rescheduled] *****************************
task path: /experiments/chaos/node_failure/test.yml:170
2020-07-30T08:43:34.645144 (delta: 360.238333)         elapsed: 748.56168 ***** 
FAILED - RETRYING: Check if the application pod is rescheduled (45 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (44 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (43 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (42 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (41 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (40 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (39 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (38 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (37 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (36 retries left).
FAILED - RETRYING: Check if the application pod is rescheduled (35 retries left).
changed: [127.0.0.1] => {"attempts": 12, "changed": true, "cmd": "kubectl get pods -n test-sathya -l lkey=lvalue --no-headers -o wide | grep -v konvoy-node2.mayalabs.io | awk '{print $3}'", "delta": "0:00:00.752765", "end": "2020-07-30 08:45:36.460901", "rc": 0, "start": "2020-07-30 08:45:35.708136", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the rescheduled pod name] *****************************************
task path: /experiments/chaos/node_failure/test.yml:183
2020-07-30T08:45:36.497422 (delta: 121.852252)         elapsed: 870.413958 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n test-sathya -l lkey=lvalue --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.756678", "end": "2020-07-30 08:45:37.407953", "rc": 0, "start": "2020-07-30 08:45:36.651275", "stderr": "", "stderr_lines": [], "stdout": "percona-f445994bd-554x4", "stdout_lines": ["percona-f445994bd-554x4"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/node_failure/test.yml:191
2020-07-30T08:45:37.445425 (delta: 0.947958)         elapsed: 871.361961 ****** 
included: /utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:4
2020-07-30T08:45:37.509234 (delta: 0.063765)         elapsed: 871.42577 ******* 
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database nodefailurenew;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database nodefailurenew;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' nodefailurenew)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' nodefailurenew", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' nodefailurenew)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' nodefailurenew", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:21
2020-07-30T08:45:37.573179 (delta: 0.06391)         elapsed: 871.489715 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-f445994bd-554x4 -n test-sathya", "delta": "0:00:04.840662", "end": "2020-07-30 08:45:42.560694", "rc": 0, "start": "2020-07-30 08:45:37.720032", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-f445994bd-554x4\" deleted", "stdout_lines": ["pod \"percona-f445994bd-554x4\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:27
2020-07-30T08:45:42.590278 (delta: 5.01705)         elapsed: 876.506814 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n test-sathya", "delta": "0:00:01.908349", "end": "2020-07-30 08:45:44.654641", "rc": 0, "start": "2020-07-30 08:45:42.746292", "stderr": "", "stderr_lines": [], "stdout": "NAME                      READY   STATUS              RESTARTS   AGE\npercona-f445994bd-pgnhj   0/1     ContainerCreating   0          5s", "stdout_lines": ["NAME                      READY   STATUS              RESTARTS   AGE", "percona-f445994bd-pgnhj   0/1     ContainerCreating   0          5s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:37
2020-07-30T08:45:44.695167 (delta: 2.104853)         elapsed: 878.611703 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n test-sathya -l lkey=lvalue -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:01.762402", "end": "2020-07-30 08:45:46.610536", "rc": 0, "start": "2020-07-30 08:45:44.848134", "stderr": "", "stderr_lines": [], "stdout": "percona-f445994bd-pgnhj", "stdout_lines": ["percona-f445994bd-pgnhj"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:44
2020-07-30T08:45:46.639990 (delta: 1.944783)         elapsed: 880.556526 ****** 
FAILED - RETRYING: Checking application pod is in running state (150 retries left).
FAILED - RETRYING: Checking application pod is in running state (149 retries left).
FAILED - RETRYING: Checking application pod is in running state (148 retries left).
FAILED - RETRYING: Checking application pod is in running state (147 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n test-sathya -o jsonpath='{.items[?(@.metadata.name==\"percona-f445994bd-pgnhj\")].status.phase}'", "delta": "0:00:00.991225", "end": "2020-07-30 08:45:59.750229", "rc": 0, "start": "2020-07-30 08:45:58.759004", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:51
2020-07-30T08:45:59.784006 (delta: 13.143982)         elapsed: 893.700542 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n test-sathya -o jsonpath='{.items[?(@.metadata.name==\"percona-f445994bd-pgnhj\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.884423", "end": "2020-07-30 08:46:00.831248", "rc": 0, "start": "2020-07-30 08:45:59.946825", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-07-30T08:45:58Z]]", "stdout_lines": ["map[running:map[startedAt:2020-07-30T08:45:58Z]]"]}

TASK [Check if db is ready for connections] ************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:61
2020-07-30T08:46:00.873696 (delta: 1.089656)         elapsed: 894.790232 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-f445994bd-pgnhj -n test-sathya | grep 'ready for connections'", "delta": "0:00:00.749224", "end": "2020-07-30 08:46:01.778090", "rc": 0, "start": "2020-07-30 08:46:01.028866", "stderr": "", "stderr_lines": [], "stdout": "2020-07-30T08:45:59.361590Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2020-07-30T08:45:59.361590Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:68
2020-07-30T08:46:01.814605 (delta: 0.940864)         elapsed: 895.731141 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-f445994bd-pgnhj -n test-sathya -- mysqlcheck -c nodefailurenew -uroot -pk8sDem0", "delta": "0:00:01.037407", "end": "2020-07-30 08:46:02.997214", "failed_when_result": false, "rc": 0, "start": "2020-07-30 08:46:01.959807", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "nodefailurenew.ttbl                                OK", "stdout_lines": ["nodefailurenew.ttbl                                OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:77
2020-07-30T08:46:03.031503 (delta: 1.216863)         elapsed: 896.948039 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-f445994bd-pgnhj -n test-sathya -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' nodefailurenew;", "delta": "0:00:00.981341", "end": "2020-07-30 08:46:04.168506", "failed_when_result": false, "rc": 0, "start": "2020-07-30 08:46:03.187165", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Delete/drop MySQL database] **********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:90
2020-07-30T08:46:04.206894 (delta: 1.175348)         elapsed: 898.12343 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /utils/scm/applications/mysql/mysql_data_persistence.yml:98
2020-07-30T08:46:04.245610 (delta: 0.038685)         elapsed: 898.162146 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/node_failure/test.yml:200
2020-07-30T08:46:04.284932 (delta: 0.039291)         elapsed: 898.201468 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:210
2020-07-30T08:46:04.329289 (delta: 0.044324)         elapsed: 898.245825 ****** 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2020-07-30T08:46:04.381392 (delta: 0.052067)         elapsed: 898.297928 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.33.1.1 vim-cmd vmsvc/getallvms | grep konvoy-node2.mayalabs.io | awk '{print $1}'", "delta": "0:00:01.474855", "end": "2020-07-30 08:46:06.008488", "rc": 0, "start": "2020-07-30 08:46:04.533633", "stderr": "", "stderr_lines": [], "stdout": "31", "stdout_lines": ["31"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2020-07-30T08:46:06.046399 (delta: 1.664978)         elapsed: 899.962935 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.33.1.1 vim-cmd vmsvc/power.on 31", "delta": "0:00:01.935726", "end": "2020-07-30 08:46:08.129414", "failed_when_result": false, "rc": 0, "start": "2020-07-30 08:46:06.193688", "stderr": "", "stderr_lines": [], "stdout": "Powering on VM:", "stdout_lines": ["Powering on VM:"]}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/node_failure/test.yml:217
2020-07-30T08:46:08.164676 (delta: 2.118237)         elapsed: 902.081212 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-07-30T08:46:08.214178 (delta: 0.049469)         elapsed: 902.130714 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-07-30T08:46:08.243013 (delta: 0.028798)         elapsed: 902.159549 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-07-30T08:46:08.272248 (delta: 0.029189)         elapsed: 902.188784 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-07-30T08:46:08.299360 (delta: 0.027076)         elapsed: 902.215896 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "cad674606733d8b7d866b5f49971647a70c2b6c0", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "159ae1f9ce03ff4606f1339d21689e05", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1596098768.34-169347363530923/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-07-30T08:46:09.955470 (delta: 1.656075)         elapsed: 903.872006 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.828832", "end": "2020-07-30 08:46:10.930256", "rc": 0, "start": "2020-07-30 08:46:10.101424", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-07-30T08:46:10.963304 (delta: 1.007798)         elapsed: 904.87984 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-07-30T05:20:23Z", "generation": 9, "name": "node-failure", "resourceVersion": "3657915", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/node-failure", "uid": "b0d05a71-23b4-482f-b030-a0b7859f4e85"}, "spec": {"testMetadata": {"chaostype": "node-failure"}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=54   changed=35   unreachable=0    failed=0   

2020-07-30T08:46:11.645471 (delta: 0.682134)         elapsed: 905.562007 ****** 
=============================================================================== 

```