### PR TITLE
refactor[bd-reusability]: Included the storage class template in cspc  spec

### DIFF
--- a/experiments/functional/cspc-pool/blockdevice-reusability/README.md
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/README.md
@@ -19,4 +19,5 @@
 | OPERATOR_NS             | Namespace where the openebs is deployed                                           |
 | SPC_POOL_NAME           | Name of the spc pool                                                              |
 | CSPC_POOL_NAME          | Name of the cspc Pool                                                             |
-| POOL_TYPE               | Type of the pool to create, supported values are striped, mirrored, raidz ,raidz2 |
+| POOL_TYPE               | Type of the pool to create, supported values are striped, mirror, raidz ,raidz2 |
+| STORAGE_CLASS           | Name of the storage class to deploy the application                               |

--- a/experiments/functional/cspc-pool/blockdevice-reusability/cspc.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/cspc.yml
@@ -6,3 +6,17 @@ metadata:
 spec:
   pools:
 
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: sc-name
+  annotations:
+    openebs.io/cas-type: cstor
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+parameters:
+  replicaCount: "3"
+  cas-type: cstor
+  cstorPoolCluster: cspc-pool-name

--- a/experiments/functional/cspc-pool/blockdevice-reusability/run_litmus_test.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/run_litmus_test.yml
@@ -40,6 +40,10 @@ spec:
           - name: POOL_TYPE
             value: ""
 
+           # Provide the name of STORAGE_CLASS 	
+          - name: STORAGE_CLASS	
+            value: openebs-bd-reusability-sc
+
            # Namespace where the OpenEBS components are deployed
           - name: OPERATOR_NS
             value: openebs

--- a/experiments/functional/cspc-pool/blockdevice-reusability/test.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/test.yml
@@ -79,6 +79,12 @@
             regexp: "pool-type"
             replace: "{{ pool_type }}"
 
+        - name: Replacing the storage class name in CSPC spec
+          replace:
+            path: ./cspc.yml
+            regexp: "sc-name"
+            replace: "{{ sc_name }}"
+
         - name: Display cspc.yml for verification
           debug: var=item
           with_file:

--- a/experiments/functional/cspc-pool/blockdevice-reusability/test_vars.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/test_vars.yml
@@ -5,3 +5,5 @@ old_cspc_pool: "{{ lookup('env','OLD_CSPC_POOL_NAME') }}"
 new_cspc_pool: "{{ lookup('env','NEW_CSPC_POOL_NAME') }}"
 spc_pool_name: "{{ lookup('env','SPC_POOL_NAME') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
+sc_name: "{{ lookup('env', 'STORAGE_CLASS') }}"
+


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included the storage class spec into block device re-usability spec
-  After created the pool create the storage class to provision the application
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
