### PR TITLE
refactor[bd-reusability]: Modified the task to obtain the node name for blockdevice reusability test

### DIFF
--- a/experiments/functional/cspc-pool/blockdevice-reusability/test.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/test.yml
@@ -25,13 +25,13 @@
               label: openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
           when: old_cspc_pool != ""          
 
-        - name: Obtain the node name from the BDC of SPC pool
+        - name: Obtain the node name from the csp
           shell: >
-            kubectl get bdc -n {{ operator_ns }} -l {{ label }} 
-            -o custom-columns=:.spec.blockDeviceNodeAttributes.hostName --no-headers
+            kubectl get csp -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+            -o jsonpath='{range.items[*]}{.metadata.labels.kubernetes\.io\/hostname}{"\n"}{end}'
           args:
             executable: /bin/bash
-          register: nodes    
+          register: nodes
 
         # Creating the blockdevice template from blockdevice.j2 jinja template for each node
         - name: Add node labels for each nodes and create blockdevice template


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the task to get the node name for blockdevice reusability.
- Changed the tasks to get the node instead of getting node name from BDC obtained from csp. 

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
