### PR TITLE
refactor[test]: Modified the blockdevice re-usability test to segregate to deletion of pool

### DIFF
--- a/experiments/functional/cspc-pool/blockdevice-reusability/README.md
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/README.md
@@ -19,5 +19,6 @@
 | OPERATOR_NS             | Namespace where the openebs is deployed                                           |
 | SPC_POOL_NAME           | Name of the spc pool                                                              |
 | CSPC_POOL_NAME          | Name of the cspc Pool                                                             |
-| POOL_TYPE               | Type of the pool to create, supported values are striped, mirror, raidz ,raidz2 |
+| POOL_TYPE               | Type of the pool to create, supported values are striped, mirror, raidz ,raidz2   |
 | STORAGE_CLASS           | Name of the storage class to deploy the application                               |
+| ACTION                  | Value to provision or deprovision the pool                                        |

--- a/experiments/functional/cspc-pool/blockdevice-reusability/run_litmus_test.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/run_litmus_test.yml
@@ -48,5 +48,8 @@ spec:
           - name: OPERATOR_NS
             value: openebs
 
+          - name: ACTION
+            value: provision
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/cspc-pool/blockdevice-reusability/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/cspc-pool/blockdevice-reusability/test.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/test.yml
@@ -17,170 +17,312 @@
           vars:
             status: 'SOT'
 
-        - set_fact:
-              label: openebs.io/storage-pool-claim={{ spc_pool_name }}
-          when: spc_pool_name != "" 
-
-        - set_fact:
-              label: openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
-          when: old_cspc_pool != ""          
-
-        - name: Obtain the node name from the csp
-          shell: >
-            kubectl get csp -l openebs.io/storage-pool-claim={{ spc_pool_name }}
-            -o jsonpath='{range.items[*]}{.metadata.labels.kubernetes\.io\/hostname}{"\n"}{end}'
-          args:
-            executable: /bin/bash
-          register: nodes
-
-        # Creating the blockdevice template from blockdevice.j2 jinja template for each node
-        - name: Add node labels for each nodes and create blockdevice template
-          template:
-            src: ./blockdevice.j2
-            dest: ./blockdevice-{{ item[0] }}.yml
-          with_together:
-            - "{{ nodes.stdout_lines }}"
-
-        - name: Add the block devices for each node's block device template
-          include_tasks: add_blockdevice.yml
-          with_items: "{{ nodes.stdout_lines }}"
-          loop_control:
-            loop_var: outer_item
-
-        # Insert the blockdevice template created for each nodes into cspc spec
-        # blockinfile module will insert the external_files/block.
-        # marker line template will be replaced with the values in marker_begin (default="BEGIN") and marker_end (default="END").
-        - name: Include the blockdevice template in the CSPC spec
-          blockinfile:
-            dest: ./cspc.yml
-            marker_end: "## {{ item }} Ansible Config ##"
-            insertafter: pools
-            state: present
-            block: |
-              {{ lookup('file', './blockdevice-{{ item }}.yml') }}
-          with_items:
-            - "{{ nodes.stdout_lines }}"
-
-        - name: Replacing the pool name in CSPC spec
-          replace:
-            path: ./cspc.yml
-            regexp: "cspc-pool-name"
-            replace: "{{ new_cspc_pool }}"
-
-        - name: Replacing the namespace in CSPC spec
-          replace:
-            path: ./cspc.yml
-            regexp: "operator_ns"
-            replace: "{{ operator_ns }}"
-
-        - name: Replacing the pool type in CSPC spec
-          replace:
-            path: ./cspc.yml
-            regexp: "pool-type"
-            replace: "{{ pool_type }}"
-
-        - name: Replacing the storage class name in CSPC spec
-          replace:
-            path: ./cspc.yml
-            regexp: "sc-name"
-            replace: "{{ sc_name }}"
-
-        - name: Display cspc.yml for verification
-          debug: var=item
-          with_file:
-          - "cspc.yml"
-
         - block:
 
-            - name: Obtain the claimed blockDevice list from bdc
+            - set_fact:
+                  label: openebs.io/storage-pool-claim={{ spc_pool_name }}
+              when: spc_pool_name != "" 
+
+            - set_fact:
+                  label: openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+              when: old_cspc_pool != ""          
+
+            - name: Obtain the node name from the csp
               shell: >
-                kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ spc_pool_name }}
-                -o custom-columns=:.spec.blockDeviceName --no-headers
+                kubectl get csp -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+                -o jsonpath='{range.items[*]}{.metadata.labels.kubernetes\.io\/hostname}{"\n"}{end}'
               args:
                 executable: /bin/bash
-              register: blockdevice_name
+              register: nodes
 
-            - name: Remove the SPC
-              shell: kubectl delete spc {{ spc_pool_name }}
-              args:
-                executable: /bin/bash
-              
-            - name: Verify if the SPC is deleted
-              shell: kubectl get spc
-              args:
-                executable: /bin/bash
-              register: spc_status
-              until: '"{{ spc_pool_name }}" not in spc_status.stdout'
-              retries: 30
-              delay: 10
+            # Creating the blockdevice template from blockdevice.j2 jinja template for each node
+            - name: Add node labels for each nodes and create blockdevice template
+              template:
+                src: ./blockdevice.j2
+                dest: ./blockdevice-{{ item[0] }}.yml
+              with_together:
+                - "{{ nodes.stdout_lines }}"
 
-            - name: Verify if the CSP is getting removed
-              shell: kubectl get csp -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+            - name: Add the block devices for each node's block device template
+              include_tasks: add_blockdevice.yml
+              with_items: "{{ nodes.stdout_lines }}"
+              loop_control:
+                loop_var: outer_item
+
+            # Insert the blockdevice template created for each nodes into cspc spec
+            # blockinfile module will insert the external_files/block.
+            # marker line template will be replaced with the values in marker_begin (default="BEGIN") and marker_end (default="END").
+            - name: Include the blockdevice template in the CSPC spec
+              blockinfile:
+                dest: ./cspc.yml
+                marker_end: "## {{ item }} Ansible Config ##"
+                insertafter: pools
+                state: present
+                block: |
+                  {{ lookup('file', './blockdevice-{{ item }}.yml') }}
+              with_items:
+                - "{{ nodes.stdout_lines }}"
+
+            - name: Replacing the pool name in CSPC spec
+              replace:
+                path: ./cspc.yml
+                regexp: "cspc-pool-name"
+                replace: "{{ new_cspc_pool }}"
+
+            - name: Replacing the namespace in CSPC spec
+              replace:
+                path: ./cspc.yml
+                regexp: "operator_ns"
+                replace: "{{ operator_ns }}"
+
+            - name: Replacing the pool type in CSPC spec
+              replace:
+                path: ./cspc.yml
+                regexp: "pool-type"
+                replace: "{{ pool_type }}"
+
+            - name: Replacing the storage class name in CSPC spec
+              replace:
+                path: ./cspc.yml
+                regexp: "sc-name"
+                replace: "{{ sc_name }}"
+
+            - name: Display cspc.yml for verification
+              debug: var=item
+              with_file:
+              - "cspc.yml"
+
+            - block:
+
+                - name: Obtain the claimed blockDevice list from bdc
+                  shell: >
+                    kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+                    -o custom-columns=:.spec.blockDeviceName --no-headers
+                  args:
+                    executable: /bin/bash
+                  register: blockdevice_name
+
+                - name: Remove the SPC
+                  shell: kubectl delete spc {{ spc_pool_name }}
+                  args:
+                    executable: /bin/bash
+                  
+                - name: Verify if the SPC is deleted
+                  shell: kubectl get spc
+                  args:
+                    executable: /bin/bash
+                  register: spc_status
+                  until: '"{{ spc_pool_name }}" not in spc_status.stdout'
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the CSP is getting removed
+                  shell: kubectl get csp -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+                  args:
+                    executable: /bin/bash
+                  register: csp_status
+                  until: "'No resources found.' in csp_status.stderr"
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the cStor pool pods are deleted
+                  shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+                  args:
+                    executable: /bin/bash
+                  register: pool_status
+                  until: "'No resources found.' in pool_status.stderr"
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the BDC are deleted
+                  shell: kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ spc_pool_name }}
+                  args:
+                    executable: /bin/bash
+                  register: bdc_status
+                  until: "'No resources found.' in bdc_status.stderr"
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the blockDevices are unclaimed
+                  shell: >
+                    kubectl get blockdevices -n {{ operator_ns }} 
+                    -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.claimState}'
+                  args:
+                    executable: /bin/bash
+                  register: bd_status
+                  with_items: "{{ blockdevice_name.stdout_lines }}"
+                  until: "'Unclaimed' in bd_status.stdout"
+                  retries: 30
+                  delay: 10
+
+              when: spc_pool_name != ""
+
+            - block:
+
+                - name: Obtain the claimed blockDevice list from bdc
+                  shell: >
+                    kubectl get bdc -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+                    -o custom-columns=:.spec.blockDeviceName --no-headers
+                  args:
+                    executable: /bin/bash
+                  register: blockdevice_name
+
+                - name: Remove the CSPC pool
+                  shell: kubectl delete cspc {{ old_cspc_pool }} -n  {{ operator_ns }}
+                  args:
+                    executable: /bin/bash
+                  
+                - name: Verify if the CSPC is deleted
+                  shell: kubectl get cspc -n {{ operator_ns }}
+                  args:
+                    executable: /bin/bash
+                  register: cspc_status
+                  until: '"{{ old_cspc_pool }}" not in cspc_status.stdout'
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the CSPI is getting removed
+                  shell: kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+                  args:
+                    executable: /bin/bash
+                  register: cspi_status
+                  until: "'No resources found.' in cspi_status.stderr"
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the cStor pool pods are deleted
+                  shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+                  args:
+                    executable: /bin/bash
+                  register: pool_status
+                  until: "'No resources found.' in pool_status.stderr"
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the BDC are deleted
+                  shell: kubectl get bdc -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+                  args:
+                    executable: /bin/bash
+                  register: bdc_status
+                  until: "'No resources found.' in bdc_status.stderr"
+                  retries: 30
+                  delay: 10
+
+                - name: Verify if the blockDevices are unclaimed
+                  shell: >
+                    kubectl get blockdevices -n {{ operator_ns }} 
+                    -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.claimState}'
+                  args:
+                    executable: /bin/bash
+                  register: bd_status
+                  with_items: "{{ blockdevice_name.stdout_lines }}"
+                  until: "'Unclaimed' in bd_status.stdout"
+                  retries: 30
+                  delay: 10        
+            
+              when: old_cspc_pool != ""
+
+            - name: Create cstor cspc disk pool
+              shell: kubectl apply -f cspc.yml
               args:
                 executable: /bin/bash
-              register: csp_status
-              until: "'No resources found.' in csp_status.stderr"
-              retries: 30
-              delay: 10
 
-            - name: Verify if the cStor pool pods are deleted
-              shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ spc_pool_name }}
-              args:
-                executable: /bin/bash
-              register: pool_status
-              until: "'No resources found.' in pool_status.stderr"
-              retries: 30
-              delay: 10
-
-            - name: Verify if the BDC are deleted
-              shell: kubectl get bdc -n {{ operator_ns }} -l openebs.io/storage-pool-claim={{ spc_pool_name }}
-              args:
-                executable: /bin/bash
-              register: bdc_status
-              until: "'No resources found.' in bdc_status.stderr"
-              retries: 30
-              delay: 10
-
-            - name: Verify if the blockDevices are unclaimed
+            - name: Check whether cspc is created
               shell: >
-                kubectl get blockdevices -n {{ operator_ns }} 
-                -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.claimState}'
+                kubectl get cspc -n {{ operator_ns }} -o custom-columns=:.metadata.name --no-headers
               args:
                 executable: /bin/bash
-              register: bd_status
-              with_items: "{{ blockdevice_name.stdout_lines }}"
-              until: "'Unclaimed' in bd_status.stdout"
+              register: cspc_name
+              until: "new_cspc_pool in cspc_name.stdout"
+              delay: 30
+              retries: 10
+
+            - name: Verify the status of CSPI
+              shell: >
+                kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
+                -o custom-columns=:.status.phase --no-headers
+              args:
+                executable: /bin/bash
+              register: cspi_status
+              until: "((cspi_status.stdout_lines|unique)|length) == 1 and 'ONLINE' in cspi_status.stdout"
+              delay: 5
+              retries: 60
+
+            - name: Obtain the CSPI name to verify the status
+              shell: >
+                kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
+                -o custom-columns=:.metadata.name --no-headers
+              args:
+                executable: /bin/bash
+              register: cspi_name
+
+            - name: Verify if the cStor Pool pods are Running
+              shell: >
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item }}
+                --no-headers -o custom-columns=:status.phase
+              args:
+                executable: /bin/bash
+              register: poolcount
+              with_items: "{{ cspi_name.stdout_lines }}"
+              until: "((poolcount.stdout_lines|unique)|length) == 1 and 'Running' in poolcount.stdout"
               retries: 30
               delay: 10
 
-          when: spc_pool_name != ""
+            - name: Get cStor Pool pod names to verify the container statuses.
+              shell: >
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
+                --no-headers -o=custom-columns=NAME:".metadata.name"
+              args:
+                executable: /bin/bash
+              register: cstor_pool_pod
 
+            - name: Get the runningStatus of pool pod containers
+              shell: >
+                kubectl get pod {{ item }} -n {{ operator_ns }}
+                -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+                grep -w running | wc -l
+              args:
+                executable: /bin/bash
+              register: runningStatusCount
+              with_items: "{{ cstor_pool_pod.stdout_lines }}"
+              until: "runningStatusCount.stdout == '3'"
+              delay: 30
+              retries: 10
+
+          when: action == 'provision'
+            
         - block:
-
-            - name: Obtain the claimed blockDevice list from bdc
+            - name: Remove the cStor Pool Cluster
               shell: >
-                kubectl get bdc -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
-                -o custom-columns=:.spec.blockDeviceName --no-headers
+                kubectl delete cspc {{ new_cspc_pool }} -n {{ operator_ns }}
               args:
                 executable: /bin/bash
-              register: blockdevice_name
 
-            - name: Remove the CSPC pool
-              shell: kubectl delete cspc {{ old_cspc_pool }} -n  {{ operator_ns }}
+            - name: Remove the Storage class created as part of the test
+              shell: kubectl delete sc {{ sc_name }}
               args:
                 executable: /bin/bash
-              
-            - name: Verify if the CSPC is deleted
-              shell: kubectl get cspc -n {{ operator_ns }}
+
+            - name: Remove the Storage class created as part of the test
+              shell: kubectl get sc
               args:
                 executable: /bin/bash
+              register: sc_status
+              until: '"{{ sc_name }}" not in sc_status.stdout'
+              retries: 3
+              delay: 5
+
+            - name: Verify if the cStor Pool Cluster is deleted
+              shell: >
+                kubectl get cspc -n {{ operator_ns }}
               register: cspc_status
-              until: '"{{ old_cspc_pool }}" not in cspc_status.stdout'
+              until: '"{{ new_cspc_pool }}" not in cspc_status.stdout'
               retries: 30
               delay: 10
 
             - name: Verify if the CSPI is getting removed
-              shell: kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+              shell: >
+                kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
               args:
                 executable: /bin/bash
               register: cspi_status
@@ -189,137 +331,15 @@
               delay: 10
 
             - name: Verify if the cStor pool pods are deleted
-              shell: kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
+              shell:
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
               args:
                 executable: /bin/bash
               register: pool_status
               until: "'No resources found.' in pool_status.stderr"
               retries: 30
               delay: 10
-
-            - name: Verify if the BDC are deleted
-              shell: kubectl get bdc -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ old_cspc_pool }}
-              args:
-                executable: /bin/bash
-              register: bdc_status
-              until: "'No resources found.' in bdc_status.stderr"
-              retries: 30
-              delay: 10
-
-            - name: Verify if the blockDevices are unclaimed
-              shell: >
-                kubectl get blockdevices -n {{ operator_ns }} 
-                -o jsonpath='{.items[?(@.metadata.name=="{{ item }}")].status.claimState}'
-              args:
-                executable: /bin/bash
-              register: bd_status
-              with_items: "{{ blockdevice_name.stdout_lines }}"
-              until: "'Unclaimed' in bd_status.stdout"
-              retries: 30
-              delay: 10        
-         
-          when: old_cspc_pool != ""
-
-        - name: Create cstor cspc disk pool
-          shell: kubectl apply -f cspc.yml
-          args:
-            executable: /bin/bash
-
-        - name: Check whether cspc is created
-          shell: >
-            kubectl get cspc -n {{ operator_ns }} -o custom-columns=:.metadata.name --no-headers
-          args:
-            executable: /bin/bash
-          register: cspc_name
-          until: "new_cspc_pool in cspc_name.stdout"
-          delay: 30
-          retries: 10
-
-        - name: Verify the status of CSPI
-          shell: >
-            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
-            -o custom-columns=:.status.phase --no-headers
-          args:
-            executable: /bin/bash
-          register: cspi_status
-          until: "((cspi_status.stdout_lines|unique)|length) == 1 and 'ONLINE' in cspi_status.stdout"
-          delay: 5
-          retries: 60
-
-        - name: Obtain the CSPI name to verify the status
-          shell: >
-            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
-            -o custom-columns=:.metadata.name --no-headers
-          args:
-            executable: /bin/bash
-          register: cspi_name
-
-        - name: Verify if the cStor Pool pods are Running
-          shell: >
-            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-instance={{ item }}
-            --no-headers -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: poolcount
-          with_items: "{{ cspi_name.stdout_lines }}"
-          until: "((poolcount.stdout_lines|unique)|length) == 1 and 'Running' in poolcount.stdout"
-          retries: 30
-          delay: 10
-
-        - name: Get cStor Pool pod names to verify the container statuses.
-          shell: >
-            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
-            --no-headers -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: cstor_pool_pod
-
-        - name: Get the runningStatus of pool pod containers
-          shell: >
-            kubectl get pod {{ item }} -n {{ operator_ns }}
-            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
-            grep -w running | wc -l
-          args:
-            executable: /bin/bash
-          register: runningStatusCount
-          with_items: "{{ cstor_pool_pod.stdout_lines }}"
-          until: "runningStatusCount.stdout == '3'"
-          delay: 30
-          retries: 10
-            
-        - name: Remove the cStor Pool Cluster
-          shell: >
-            kubectl delete cspc {{ new_cspc_pool }} -n {{ operator_ns }}
-          args:
-            executable: /bin/bash
-
-        - name: Verify if the cStor Pool Cluster is deleted
-          shell: >
-            kubectl get cspc -n {{ operator_ns }}
-          register: cspc_status
-          until: '"{{ new_cspc_pool }}" not in cspc_status.stdout'
-          retries: 30
-          delay: 10
-
-        - name: Verify if the CSPI is getting removed
-          shell: >
-            kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
-          args:
-            executable: /bin/bash
-          register: cspi_status
-          until: "'No resources found.' in cspi_status.stderr"
-          retries: 30
-          delay: 10
-
-        - name: Verify if the cStor pool pods are deleted
-          shell:
-            kubectl get pods -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ new_cspc_pool }}
-          args:
-            executable: /bin/bash
-          register: pool_status
-          until: "'No resources found.' in pool_status.stderr"
-          retries: 30
-          delay: 10
+          when: action == 'deprovision'
 
         - set_fact:
             flag: "Pass"

--- a/experiments/functional/cspc-pool/blockdevice-reusability/test_vars.yml
+++ b/experiments/functional/cspc-pool/blockdevice-reusability/test_vars.yml
@@ -6,4 +6,4 @@ new_cspc_pool: "{{ lookup('env','NEW_CSPC_POOL_NAME') }}"
 spc_pool_name: "{{ lookup('env','SPC_POOL_NAME') }}"
 pool_type: "{{ lookup('env','POOL_TYPE') }}"
 sc_name: "{{ lookup('env', 'STORAGE_CLASS') }}"
-
+action: "{{ lookup('env', 'ACTION') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Segregated the tasks to create and delete the pool based on the env.
- After reused the blockdevice created pool and sc. And using the SC to provision the application 
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
