### PR TITLE
fix(typo): Remove json from jq query in jiva autogen snapshot experiment

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
@@ -47,7 +47,7 @@
    - name: Getting master replica IP
      vars:
        replicas_endpoint: "9501/v1/replicas"
-     shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.json.data[0].address'
+     shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[0].address'
      register: json_response
      until: "'tcp' in json_response.stdout" 
      delay: 15


### PR DESCRIPTION
Signed-off-by: <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Remove .json form jquery in getting the leader replicaIP task.

**Following is the log from litmus test container**
```
root@node-failure-lwm7p-qmlpf:/# curl http://12.0.6.96:9501/v1/replicas | jq '.data[0].address'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1466  100  1466    0     0  1431k      0 --:--:-- --:--:-- --:--:-- 1431k
"tcp://172.168.205.73:9502"
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
