### PR TITLE
refactor[cstor-operator]: Included a task to restart the ndm daemonset pods in cstor operator test

### DIFF
--- a/providers/cstor-operator/test.yml
+++ b/providers/cstor-operator/test.yml
@@ -185,6 +185,41 @@
               delay: 5
               retries: 120                       
 
+            - name: Restart the ndm daemonset pods
+              shell: kubectl delete pods -n {{ namespace }} -l name=openebs-ndm
+              args:
+                executable: /bin/bash
+
+            - name: Obtain the desired number of ndm daemonset
+              shell: >
+                kubectl get daemonset -n {{ namespace }} -l name=openebs-ndm 
+                -o custom-columns=:.status.desiredNumberScheduled --no-headers
+              args:
+                executable: /bin/bash
+              register: desired_count
+
+            - name: Verify readily availabe daemonset is equal to desired count
+              shell: >
+                kubectl get daemonset -n {{ namespace }} -l name=openebs-ndm
+                -o custom-columns=:.status.desiredNumberScheduled --no-headers
+              args:
+                executable: /bin/bash
+              register: ready_count
+              until: (ready_count.stdout)|int == (desired_count.stdout)|int
+              delay: 5
+              retries: 120
+
+            - name: Confirm if node-disk-manager is running in all the nodes
+              shell: >
+                kubectl get pods -n {{ namespace }}
+                -o jsonpath='{.items[?(@.metadata.labels.name=="openebs-ndm")].status.phase}' | grep Running | wc -w
+              args:
+                executable: /bin/bash
+              register: ndm_count
+              until: (desired_count.stdout)|int == (ndm_count.stdout)|int
+              delay: 5
+              retries: 60
+              
           when: lookup('env','ACTION') == "provision"
 
         - block:

--- a/providers/cstor-operator/test.yml
+++ b/providers/cstor-operator/test.yml
@@ -198,10 +198,10 @@
                 executable: /bin/bash
               register: desired_count
 
-            - name: Verify readily availabe daemonset is equal to desired count
+            - name: Verify readily available daemonset is equal to desired count
               shell: >
                 kubectl get daemonset -n {{ namespace }} -l name=openebs-ndm
-                -o custom-columns=:.status.desiredNumberScheduled --no-headers
+                -o custom-columns=:.status.numberReady --no-headers
               args:
                 executable: /bin/bash
               register: ready_count


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

 As part of the recent changes in NDM in case of reuse the blockdevice used for SPC pool it is mandatory to reinstall or restart the ndm components  

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
