### PR TITLE
refactor[volume-scaledown]: Modified the sed operation with patch commands to perform the scaledown

### DIFF
--- a/experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml
+++ b/experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml
@@ -66,14 +66,6 @@
           set_fact:
             cvc_name: "{{ pv.stdout }}"
 
-        - name: Obtain the CVC manifest into two files
-          shell: >
-            kubectl get cvc "{{ cvc_name }}" -n "{{ openebs_ns }}" -o yaml | tee cvc1.yml cvc2.yml
-          args:
-            executable: /bin/bash
-          register: result
-          failed_when: "result.rc != 0"
-
         - name: Get the current replica count
           shell: >
             kubectl get cvc "{{ cvc_name }}" -n "{{ openebs_ns }}" --no-headers
@@ -82,31 +74,25 @@
             executable: /bin/bash
           register: current_replica
 
-        - name: Remove couple of pool instances from cvc manifest
-          shell: sed -i '/replicaPoolInfo\:/{n;N;N;d}' cvc2.yml
+        ## openebs admission server should block the scale down process because only one replica should be allowed to delete.
+
+        - name: Try to scale down couple of replicas
+          shell: >
+             kubectl patch cvc {{ cvc_name }} 
+             -n {{ openebs_ns }} --type='json' -p='[{"op": "remove", "path": "/spec/policy/replicaPoolInfo"}]'
           args:
             executable: /bin/bash
+          register: multiple_rep
+          failed_when: "'more than one replica scale down requested' not in multiple_rep.stderr"
 
-        ## openebs admission server should block the scale down process because only one replica should be aloowed to delete.
-
-        - name: Try to scale down couple of replicas by applying above manifest
-          shell: kubectl apply -f cvc2.yml
+        - name: Try to scale down only one of replica
+          shell: >
+            kubectl patch cvc {{ cvc_name }} 
+            -n {{ openebs_ns }} --type='json' -p='[{"op": "remove", "path": "/spec/policy/replicaPoolInfo/1"}]'
           args:
             executable: /bin/bash
-          register: state
-          failed_when: state.rc == 0
-
-        - name: Remove one pool instance info from cvc manifest
-          shell: sed -i '/replicaPoolInfo:/{N;s/\n.*//;}' cvc1.yml
-          args:
-            executable: /bin/bash
-
-        - name: Scale down the replicas by configuring cvc
-          shell: kubectl apply -f cvc1.yml
-          args:
-            executable: /bin/bash
-          register: result
-          failed_when: result.rc != 0
+          register: single_rep
+          failed_when: "'patched' not in single_rep.stdout"
 
         - name: Check the replica count in cvc
           shell: >
@@ -129,38 +115,13 @@
           until: "current_replica.stdout > rep_count.stdout"
           delay: 10
           retries: 20
-        
-        - name: Delete the application pod
-          shell: kubectl delete pod "{{ app_pod_name.stdout }}" -n "{{ namespace }}"
-          args:
-            executable: /bin/bash
-          register: result
-          failed_when: "result.rc != 0"
-
-        - name: Get the application pod name
-          shell: >
-            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o custom-columns=:.metadata.name
-          args:
-            executable: /bin/bash
-          register: rescheduled_pod_name
-
-        - name: Check if the application pod is in running state
-          shell: >
-            kubectl get pods "{{ rescheduled_pod_name.stdout }}" -n "{{ namespace }}"
-            --no-headers -o custom-columns=:.status.phase
-          args:
-            executable: /bin/bash
-          register: pod_status
-          until: "'Running' in pod_status.stdout"
-          delay: 10
-          retries: 30
 
         - name: Verify application data persistence
           include: "{{ data_consistency_util_path }}"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
-            pod_name: "{{ rescheduled_pod_name.stdout }}"
+            pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''
 
         - set_fact:


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the task to perform the scale down of csi cstor volume scaledown.
- trying to patch removing the multiple volume it has to fail
- And scaledown the volume one at a time webhook will allow to scaledown,.
- And removed the tasks to restart the application pod it has been already as part of the data consistency check util


**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [x] Can you suggest the minimal resource requirements for the litmusbook execution?
* [x] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:

```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Apr 15 2020, 17:20:14) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml

PLAY [localhost] ***************************************************************
2020-08-09T15:02:35.289000 (delta: 0.042159)         elapsed: 0.042159 ******** 
=============================================================================== 
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:14
2020-08-09T15:02:35.298211 (delta: 0.009187)         elapsed: 0.05137 ********* 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /utils/fcm/create_testname.yml:3
2020-08-09T15:02:35.327357 (delta: 0.029131)         elapsed: 0.080516 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /utils/fcm/create_testname.yml:7
2020-08-09T15:02:35.382904 (delta: 0.055517)         elapsed: 0.136063 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:17
2020-08-09T15:02:35.454816 (delta: 0.071882)         elapsed: 0.207975 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-08-09T15:02:35.493945 (delta: 0.039086)         elapsed: 0.247104 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "580e43b6f78c753c0000237dd6284990dcc75163", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "366829f396de1d70ecec0aee4bdad3b4", "mode": "0644", "owner": "root", "size": 428, "src": "/root/.ansible/tmp/ansible-tmp-1596985355.53-121958043759181/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-08-09T15:02:35.954037 (delta: 0.460063)         elapsed: 0.707196 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.498707", "end": "2020-08-09 15:02:36.697625", "rc": 0, "start": "2020-08-09 15:02:36.198918", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-replica-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-replica-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-08-09T15:02:36.723935 (delta: 0.769855)         elapsed: 1.477094 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-08-09T14:58:19Z", "generation": 3, "name": "cstor-csi-replica-scaledown", "resourceVersion": "364742", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-replica-scaledown", "uid": "65f08559-b86e-4b51-9377-828f3fc97c1a"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-08-09T15:02:37.512384 (delta: 0.788416)         elapsed: 2.265543 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-08-09T15:02:37.542002 (delta: 0.029588)         elapsed: 2.295161 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-08-09T15:02:37.571244 (delta: 0.029212)         elapsed: 2.324403 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:21
2020-08-09T15:02:37.604483 (delta: 0.03316)         elapsed: 2.357642 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "9624e812f35f056e3d1fbe816cdffe51ca61b8d0", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "ad91f65363cc3de694549b37be953585", "mode": "0644", "owner": "root", "size": 81, "src": "/root/.ansible/tmp/ansible-tmp-1596985357.64-20819264134260/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:26
2020-08-09T15:02:37.886321 (delta: 0.281806)         elapsed: 2.63948 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "ansible_included_var_files": ["/experiments/functional/cStor/cstor-csi-volume-scaledown/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:29
2020-08-09T15:02:37.932838 (delta: 0.046463)         elapsed: 2.685997 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/utils/scm/applications/busybox/busybox_data_persistence.yml"}, "changed": false}

TASK [Get the application pod name] ********************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:34
2020-08-09T15:02:37.994962 (delta: 0.062071)         elapsed: 2.748121 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n csi-vol-scaled -l app=busybox-sts --no-headers -o custom-columns=:.metadata.name", "delta": "0:00:00.763706", "end": "2020-08-09 15:02:38.907138", "rc": 0, "start": "2020-08-09 15:02:38.143432", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-875df", "stdout_lines": ["app-busybox-85d45b855f-875df"]}

TASK [Check if the application pod is in running state] ************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:41
2020-08-09T15:02:38.948659 (delta: 0.953644)         elapsed: 3.701818 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n csi-vol-scaled -l app=busybox-sts --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.611135", "end": "2020-08-09 15:02:39.737738", "failed_when_result": false, "rc": 0, "start": "2020-08-09 15:02:39.126603", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:49
2020-08-09T15:02:39.770844 (delta: 0.822153)         elapsed: 4.524003 ******** 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2020-08-09T15:02:39.851627 (delta: 0.080749)         elapsed: 4.604786 ******** 
changed: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/scaledown bs=4k count=1024) => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-875df -n csi-vol-scaled -- sh -c \"dd if=/dev/urandom of=/busybox/scaledown bs=4k count=1024\"", "delta": "0:00:01.013885", "end": "2020-08-09 15:02:41.039908", "failed_when_result": false, "item": "dd if=/dev/urandom of=/busybox/scaledown bs=4k count=1024", "rc": 0, "start": "2020-08-09 15:02:40.026023", "stderr": "1024+0 records in\n1024+0 records out\n4194304 bytes (4.0MB) copied, 0.023759 seconds, 168.4MB/s", "stderr_lines": ["1024+0 records in", "1024+0 records out", "4194304 bytes (4.0MB) copied, 0.023759 seconds, 168.4MB/s"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=md5sum /busybox/scaledown > /busybox/scaledown-pre-chaos-md5) => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-875df -n csi-vol-scaled -- sh -c \"md5sum /busybox/scaledown > /busybox/scaledown-pre-chaos-md5\"", "delta": "0:00:00.932677", "end": "2020-08-09 15:02:42.116767", "failed_when_result": false, "item": "md5sum /busybox/scaledown > /busybox/scaledown-pre-chaos-md5", "rc": 0, "start": "2020-08-09 15:02:41.184090", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=sync;sync;sync) => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-875df -n csi-vol-scaled -- sh -c \"sync;sync;sync\"", "delta": "0:00:00.875970", "end": "2020-08-09 15:02:43.130684", "failed_when_result": false, "item": "sync;sync;sync", "rc": 0, "start": "2020-08-09 15:02:42.254714", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:21
2020-08-09T15:02:43.167783 (delta: 3.31613)         elapsed: 7.920942 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:27
2020-08-09T15:02:43.204190 (delta: 0.036364)         elapsed: 7.957349 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:37
2020-08-09T15:02:43.233061 (delta: 0.028833)         elapsed: 7.98622 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:44
2020-08-09T15:02:43.257993 (delta: 0.024889)         elapsed: 8.011152 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:51
2020-08-09T15:02:43.285361 (delta: 0.0273)         elapsed: 8.03852 *********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:61
2020-08-09T15:02:43.320688 (delta: 0.035289)         elapsed: 8.073847 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:70
2020-08-09T15:02:43.343411 (delta: 0.022657)         elapsed: 8.09657 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the current pod name for application] *****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:83
2020-08-09T15:02:43.369883 (delta: 0.026434)         elapsed: 8.123042 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:90
2020-08-09T15:02:43.401852 (delta: 0.031929)         elapsed: 8.155011 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:98
2020-08-09T15:02:43.428718 (delta: 0.026815)         elapsed: 8.181877 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC.] ************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:57
2020-08-09T15:02:43.455361 (delta: 0.026549)         elapsed: 8.20852 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc \"openebs-busybox\" -n \"csi-vol-scaled\" --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.684984", "end": "2020-08-09 15:02:44.258887", "rc": 0, "start": "2020-08-09 15:02:43.573903", "stderr": "", "stderr_lines": [], "stdout": "pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4", "stdout_lines": ["pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4"]}

TASK [Get CVC name, note that CVC name is same as PV.] *************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:65
2020-08-09T15:02:44.285486 (delta: 0.830072)         elapsed: 9.038645 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"cvc_name": "pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4"}, "changed": false}

TASK [Get the current replica count] *******************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:69
2020-08-09T15:02:44.339703 (delta: 0.054168)         elapsed: 9.092862 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvc \"pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4\" -n \"openebs\" --no-headers -o custom-columns=:status.poolInfo | awk '{print NF}'", "delta": "0:00:00.617223", "end": "2020-08-09 15:02:45.074833", "rc": 0, "start": "2020-08-09 15:02:44.457610", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Try to scale down couple of replicas by applying above manifest] *********
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:79
2020-08-09T15:02:45.107569 (delta: 0.767827)         elapsed: 9.860728 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cvc pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4 -n openebs --type='json' -p='[{\"op\": \"remove\", \"path\": \"/spec/policy/replicaPoolInfo\"}]'", "delta": "0:00:00.648313", "end": "2020-08-09 15:02:45.912033", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2020-08-09 15:02:45.263720", "stderr": "Error from server (BadRequest): admission webhook \"admission-webhook.cstor.openebs.io\" denied the request: Can't perform more than one replica scale down requested scale down count 3", "stderr_lines": ["Error from server (BadRequest): admission webhook \"admission-webhook.cstor.openebs.io\" denied the request: Can't perform more than one replica scale down requested scale down count 3"], "stdout": "", "stdout_lines": []}

TASK [Try to scale down couple of replicas by applying above manifest] *********
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:88
2020-08-09T15:02:45.950408 (delta: 0.842802)         elapsed: 10.703567 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch cvc pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4 -n openebs --type='json' -p='[{\"op\": \"remove\", \"path\": \"/spec/policy/replicaPoolInfo/1\"}]'", "delta": "0:00:00.602542", "end": "2020-08-09 15:02:46.678606", "failed_when_result": false, "rc": 0, "start": "2020-08-09 15:02:46.076064", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumeconfig.cstor.openebs.io/pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4 patched", "stdout_lines": ["cstorvolumeconfig.cstor.openebs.io/pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4 patched"]}

TASK [Check the replica count in cvc] ******************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:97
2020-08-09T15:02:46.712044 (delta: 0.761605)         elapsed: 11.465203 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvc \"pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4\" -n \"openebs\" --no-headers -o custom-columns=:status.poolInfo | awk '{print NF}'", "delta": "0:00:00.771604", "end": "2020-08-09 15:02:47.658781", "rc": 0, "start": "2020-08-09 15:02:46.887177", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [check the replica count in cStorvolume] **********************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:108
2020-08-09T15:02:47.692998 (delta: 0.980921)         elapsed: 12.446157 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cstorvolume \"pvc-a1df0d83-dc18-412d-bc9a-5dd4772700b4\" -n \"openebs\" --no-headers -o custom-columns=:spec.replicationFactor", "delta": "0:00:00.647032", "end": "2020-08-09 15:02:48.496142", "rc": 0, "start": "2020-08-09 15:02:47.849110", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:119
2020-08-09T15:02:48.533428 (delta: 0.840395)         elapsed: 13.286587 ******* 
included: /utils/scm/applications/busybox/busybox_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the busybox app] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:4
2020-08-09T15:02:48.592493 (delta: 0.059034)         elapsed: 13.345652 ******* 
skipping: [127.0.0.1] => (item=dd if=/dev/urandom of=/busybox/scaledown bs=4k count=1024)  => {"changed": false, "item": "dd if=/dev/urandom of=/busybox/scaledown bs=4k count=1024", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=md5sum /busybox/scaledown > /busybox/scaledown-pre-chaos-md5)  => {"changed": false, "item": "md5sum /busybox/scaledown > /busybox/scaledown-pre-chaos-md5", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=sync;sync;sync)  => {"changed": false, "item": "sync;sync;sync", "skip_reason": "Conditional result was False"}

TASK [Kill the application pod] ************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:21
2020-08-09T15:02:48.651770 (delta: 0.059243)         elapsed: 13.404929 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod app-busybox-85d45b855f-875df -n csi-vol-scaled", "delta": "0:00:41.012599", "end": "2020-08-09 15:03:29.799136", "rc": 0, "start": "2020-08-09 15:02:48.786537", "stderr": "", "stderr_lines": [], "stdout": "pod \"app-busybox-85d45b855f-875df\" deleted", "stdout_lines": ["pod \"app-busybox-85d45b855f-875df\" deleted"]}

TASK [Verify if the application pod is deleted] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:27
2020-08-09T15:03:29.825946 (delta: 41.17413)         elapsed: 54.579105 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pod_name }}" not in podstatus.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n csi-vol-scaled", "delta": "0:00:00.651568", "end": "2020-08-09 15:03:30.615433", "rc": 0, "start": "2020-08-09 15:03:29.963865", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS    RESTARTS   AGE\napp-busybox-85d45b855f-kr6kt   1/1     Running   0          41s", "stdout_lines": ["NAME                           READY   STATUS    RESTARTS   AGE", "app-busybox-85d45b855f-kr6kt   1/1     Running   0          41s"]}

TASK [Obtain the newly created pod name for application] ***********************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:37
2020-08-09T15:03:30.659676 (delta: 0.833456)         elapsed: 55.412835 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n csi-vol-scaled -l app=busybox-sts -o jsonpath='{.items[].metadata.name}'", "delta": "0:00:00.588125", "end": "2020-08-09 15:03:31.406241", "rc": 0, "start": "2020-08-09 15:03:30.818116", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-85d45b855f-kr6kt", "stdout_lines": ["app-busybox-85d45b855f-kr6kt"]}

TASK [Checking application pod is in running state] ****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:44
2020-08-09T15:03:31.435745 (delta: 0.776023)         elapsed: 56.188904 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n csi-vol-scaled -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-85d45b855f-kr6kt\")].status.phase}'", "delta": "0:00:00.595758", "end": "2020-08-09 15:03:32.156708", "rc": 0, "start": "2020-08-09 15:03:31.560950", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:51
2020-08-09T15:03:32.201438 (delta: 0.76566)         elapsed: 56.954597 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n csi-vol-scaled -o jsonpath='{.items[?(@.metadata.name==\"app-busybox-85d45b855f-kr6kt\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.638091", "end": "2020-08-09 15:03:32.982244", "rc": 0, "start": "2020-08-09 15:03:32.344153", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-08-09T15:02:50Z]]", "stdout_lines": ["map[running:map[startedAt:2020-08-09T15:02:50Z]]"]}

TASK [Check the md5sum of stored data file] ************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:61
2020-08-09T15:03:33.023259 (delta: 0.821782)         elapsed: 57.776418 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-kr6kt -n csi-vol-scaled -- sh -c \"md5sum /busybox/scaledown > /busybox/scaledown-post-chaos-md5\"", "delta": "0:00:00.840384", "end": "2020-08-09 15:03:33.993990", "failed_when_result": false, "rc": 0, "start": "2020-08-09 15:03:33.153606", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify whether data is consistent] ***************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:70
2020-08-09T15:03:34.055189 (delta: 1.031893)         elapsed: 58.808348 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-85d45b855f-kr6kt -n csi-vol-scaled -- sh -c \"diff /busybox/scaledown-pre-chaos-md5 /busybox/scaledown-post-chaos-md5\"", "delta": "0:00:00.805806", "end": "2020-08-09 15:03:35.006780", "failed_when_result": false, "rc": 0, "start": "2020-08-09 15:03:34.200974", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Obtain the current pod name for application] *****************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:83
2020-08-09T15:03:35.052919 (delta: 0.997676)         elapsed: 59.806078 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop the files] ***************************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:90
2020-08-09T15:03:35.085716 (delta: 0.032753)         elapsed: 59.838875 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful file delete] *******************************************
task path: /utils/scm/applications/busybox/busybox_data_persistence.yml:98
2020-08-09T15:03:35.126063 (delta: 0.04026)         elapsed: 59.879222 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:127
2020-08-09T15:03:35.164511 (delta: 0.037923)         elapsed: 59.91767 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/cStor/cstor-csi-volume-scaledown/test.yml:136
2020-08-09T15:03:35.209436 (delta: 0.044886)         elapsed: 59.962595 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /utils/fcm/update_litmus_result_resource.yml:3
2020-08-09T15:03:35.263241 (delta: 0.053742)         elapsed: 60.0164 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:14
2020-08-09T15:03:35.296365 (delta: 0.033073)         elapsed: 60.049524 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:17
2020-08-09T15:03:35.326544 (delta: 0.030112)         elapsed: 60.079703 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /utils/fcm/update_litmus_result_resource.yml:27
2020-08-09T15:03:35.357143 (delta: 0.030562)         elapsed: 60.110302 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "edef4929c2aeb0b4080b53449e71fdd2989816ca", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b21152f8341923b57281ccf4a5984def", "mode": "0644", "owner": "root", "size": 426, "src": "/root/.ansible/tmp/ansible-tmp-1596985415.4-261703943914583/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /utils/fcm/update_litmus_result_resource.yml:38
2020-08-09T15:03:36.714973 (delta: 1.357792)         elapsed: 61.468132 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.503865", "end": "2020-08-09 15:03:37.354504", "rc": 0, "start": "2020-08-09 15:03:36.850639", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-csi-replica-scaledown \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-csi-replica-scaledown ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /utils/fcm/update_litmus_result_resource.yml:41
2020-08-09T15:03:37.387873 (delta: 0.672866)         elapsed: 62.141032 ******* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-08-09T14:58:19Z", "generation": 4, "name": "cstor-csi-replica-scaledown", "resourceVersion": "365064", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-csi-replica-scaledown", "uid": "65f08559-b86e-4b51-9377-828f3fc97c1a"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=32   changed=23   unreachable=0    failed=0   

2020-08-09T15:03:37.965400 (delta: 0.577494)         elapsed: 62.718559 ******* 
=============================================================================== 
```
