### PR TITLE
feat[expt-cstor]: Test case to validate the pool creation is failing when the blockdevice has filesystem

### DIFF
--- a/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/README.md
+++ b/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/README.md
@@ -1,0 +1,19 @@
+# Test Case to validate the cspc pool creation is failed when the blockdevice has filesystem already on it.
+
+## Description
+   - This test is capable of validating if the pool creation is failed when the specified blockdevices has filesystem.
+   - This test constitutes the below files.
+     - test_vars.yml - This test_vars file has the list of test specific variables used in this test case.
+     - test.yml - Playbook where the test logic is to validate the blockdevice reusability.
+     - create_filesystem.yml - Util where the test logic is implemented to create or remove the filesystem. 
+     - cspc.yml  - CSPC pool spec which has to be populated with the given variables.
+   - This test case should be provided with the parameters in form of job environmental variables in run_litmus_test.yml.
+
+## Environment Variables
+
+| Parameters              | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| OPERATOR_NS             | Namespace where the openebs is deployed                                           |
+| POOL_NAME               | Name of the cspc pool                                                             |
+| POOL_TYPE               | Type of the pool to create, supported values are striped, mirrored, raidz ,raidz2 |
+| NODE_PASSWORD           | password for the node to ssh                                                      |

--- a/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/create_filesystem.yml
+++ b/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/create_filesystem.yml
@@ -1,0 +1,85 @@
+---
+     ##{{ outer_item }} is name of the list of blockdevices, the values will passed as a loop variable in test.yml    
+  
+    - name: Getting the device path from the blockdevice 
+      shell: kubectl get blockdevice -n {{ operator_ns }} {{ outer_item }} -o custom-columns=:.spec.path --no-headers
+      register: bd_path
+
+    - block: 
+
+        - name: Create the filesystem from the targeted disks
+          shell: sshpass -p {{ password }} ssh -o StrictHostKeyChecking=no {{ user_name }}@{{ node_ip.stdout }} "echo '"{{ password }}"' | sudo -S mkfs.ext4 {{ bd_path.stdout }}"
+          register: fs_create
+          until: "'Writing superblocks and filesystem accounting information' in fs_create.stdout"
+          retries: 12
+          delay: 5
+              
+      when: "file_system == 'create'"
+
+    - block: 
+
+        - name: Remove the filesystem from the targeted disks
+          shell: sshpass -p {{ password }} ssh -o StrictHostKeyChecking=no {{ user_name }}@{{ node_ip.stdout }} "echo '"{{ password }}"' | sudo -S wipefs -a {{ bd_path.stdout }}"
+          register: fs_delete
+          until: "'erased' in fs_delete.stdout"
+          retries: 12
+          delay: 5
+              
+      when: "file_system == 'delete'"
+
+    - name: Obtain the daemonset pod name for the targeted node
+      shell: >
+        kubectl get pods -n {{ operator_ns }} -l name=openebs-ndm 
+        -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]=="{{ target_node }}")].metadata.name}'
+      args:
+        executable: /bin/bash
+      register: ndm_pod_name
+
+    - name: Restart the ndm daemonset pod for the targeted node
+      shell: kubectl delete pods -n {{ operator_ns }} {{ ndm_pod_name.stdout }} 
+      args:
+        executable: /bin/bash
+
+    - name: check if the NDM daemonset pod is deleted
+      shell: kubectl get pods -n {{ operator_ns }} -l name=openebs-ndm
+      args:
+        executable: /bin/bash
+      register: pod_list
+      until: "'{{ ndm_pod_name.stdout }}' not in pod_list.stdout"
+
+    - name: Check the ndm daemonset pod is in running state
+      shell: >
+        kubectl get pods -n {{ operator_ns }} -l name=openebs-ndm 
+        -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]=="{{ target_node }}")].status.phase}'
+      args:
+        executable: /bin/bash
+      register: ndm_pod_status
+      until: "'Running' in ndm_pod_status.stdout"
+      delay: 5
+      retries: 30
+
+    - block:
+
+        - name: Verify if the blockdevice has the filesystem in it
+          shell: kubectl get blockdevice -n {{ operator_ns }} {{ outer_item }} --no-headers -o custom-columns=:.spec.filesystem
+          args:
+            executable: /bin/bash
+          register: fs_status
+          until: "'fsType' in fs_status.stdout"
+          delay: 5
+          retries: 30
+
+      when: "file_system == 'create'"
+
+    - block:
+
+        - name: Verify if the filesystem has been removed
+          shell: kubectl get blockdevice -n {{ operator_ns }} {{ outer_item }} --no-headers -o custom-columns=:.spec.filesystem
+          args:
+            executable: /bin/bash
+          register: fs_status
+          until: "'fsType' not in fs_status.stdout"
+          delay: 5
+          retries: 30
+
+      when: "file_system == 'delete'" 

--- a/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/cspc.yml
+++ b/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/cspc.yml
@@ -1,0 +1,13 @@
+apiVersion: cstor.openebs.io/v1
+kind: CStorPoolCluster
+metadata:
+  name: pool-name
+  namespace: operator_ns
+spec:
+  pools:
+    - nodeSelector:
+        kubernetes.io/hostname: node-name
+      dataRaidGroups:
+      - blockDevices:
+      poolConfig:
+        dataRaidGroupType: pool-type

--- a/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/run_litmus_test.yml
+++ b/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/run_litmus_test.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cstor-pool-creation-bd-with-filesystem-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cstor-pool-creation-bd-with-filesystem
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+            # Provide name POOL_NAME for the cstor-pool
+          - name: POOL_NAME
+            value: cspc-pool-bd-filesystem
+
+           # Provide the value for POOL_TYPE 
+           # stripe, mirror, raidz, raidz2
+          - name: POOL_TYPE
+            value: stripe
+
+           # Namespace where the OpenEBS components are deployed
+          - name: OPERATOR_NS
+            value: openebs
+
+          - name: NODE_PASSWORD
+            value: ""
+
+          - name: USER_NAME
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/test.yml
+++ b/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/test.yml
@@ -1,0 +1,119 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+         ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Getting the compute node name
+          shell: kubectl get nodes --no-headers | grep -v master | awk {'print $1'}
+          register: nodes
+
+        - name: Select random node from the list of nodes as target node
+          set_fact:
+            target_node: "{{ item }}"
+          with_random_choice: "{{ nodes.stdout_lines }}"
+
+        - name: set the value for the disk count to fetch the unclaimed blockDevice from each node
+          set_fact:
+            disk_count: "{{ item.value.count }}"
+          loop: "{{ lookup('dict', bd_count) }}"
+          when: "'{{ pool_type }}' in item.key"
+
+        - name: Obtain the target node ip
+          shell: >
+            kubectl get nodes {{ target_node }} --no-headers 
+            -o custom-columns=:.status.addresses[*].address | cut -f1 -d  ","
+          args:
+            executable: /bin/bash
+          register: node_ip
+
+        - name: Getting the Claimed block-device from targeted node to create the filesystem
+          shell: >
+            kubectl get blockdevice -n {{ operator_ns }} 
+            -l kubernetes.io/hostname={{ target_node }} -o json | jq '.items[] | select(.status.claimState=="Unclaimed") | select(.status.state=="Active") | .metadata.name' | tr "\"" " " | grep -v sparse | head -n "{{ disk_count }}"
+          register: blockdevice
+
+        - name: Create the filesystem in each blockdevices
+          include_tasks: create_filesystem.yml
+          with_items: "{{ blockdevice.stdout_lines }}"
+          vars:
+            file_system: 'create'
+          loop_control:
+            loop_var: outer_item
+
+        - name: Add the block devices in cspc spec
+          lineinfile:
+            path: ./cspc.yml
+            insertafter: ' blockDevices:'
+            line: '        - blockDeviceName: {{ item }}'
+          with_items:
+              - "{{ blockdevice.stdout_lines }}"
+
+        - name: Replacing the pool name in CSPC spec
+          replace:
+            path: ./cspc.yml
+            regexp: "pool-name"
+            replace: "{{ pool_name }}"
+
+        - name: Replacing the namespace in CSPC spec
+          replace:
+            path: ./cspc.yml
+            regexp: "operator_ns"
+            replace: "{{ operator_ns }}"
+
+        - name: Replacing the pool type in CSPC spec
+          replace:
+            path: ./cspc.yml
+            regexp: "pool-type"
+            replace: "{{ pool_type }}"
+
+        - name: Replacing the node name in CSPC spec
+          replace:
+            path: ./cspc.yml
+            regexp: "node-name"
+            replace: "{{ target_node }}"
+
+        - name: Display cspc.yml for verification
+          debug: var=item
+          with_file:
+          - "cspc.yml"
+
+        - name: Create cstor cspc pool
+          shell: kubectl apply -f cspc.yml
+          args:
+            executable: /bin/bash
+          register: cspc_status
+          failed_when: "'block device has file system' not in cspc_status.stderr and cspc_status.rc == 0"
+ 
+        - name: Remove the filesystem from blockdevices
+          include_tasks: create_filesystem.yml
+          with_items: "{{ blockdevice.stdout_lines }}"
+          vars:
+            file_system: 'delete'
+          loop_control:
+            loop_var: outer_item
+        
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+          - set_fact:
+              flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+          - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+            vars:
+              status: 'EOT'

--- a/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/test_vars.yml
+++ b/experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/test_vars.yml
@@ -1,0 +1,16 @@
+# Test-specific parameters
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+test_name: block-pool-creation-bd-with-filesystem
+pool_name: "{{ lookup('env','POOL_NAME') }}"
+pool_type: "{{ lookup('env','POOL_TYPE') }}"
+password: "{{ lookup('env','NODE_PASSWORD') }}"
+
+bd_count:
+   stripe:
+      count: 1
+   mirror:
+      count: 2
+   raidz:
+      count: 3
+   raidz2:
+      count: 6


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Test case to validate the pool creation is blocked when the blockdevice has filesystem on it.
- In this test case obtaining the blockdevice from the random node and obatined the device path for the blockdevice.
- Then ssh into the targeted node and created the filesystemms on the disks.
- Restarted the targeted pods and verify the bd has file system.
- Create the pool check if it blocked. and wipe the filesystem from the disks.
- validated this test case against stripe,mirror,raidz1,raidz2 pools
**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [x] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [x] Do the artifacts follow the appropriate directory structure? 
* [x] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [x] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
d2iq@rack2:~$ kubectl logs -f cstor-pool-creation-bd-with-filesystem-m9f4g-km5d9 -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-08-10T10:22:08.808300 (delta: 0.041061)         elapsed: 0.041061 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2020-08-10T10:22:08.818945 (delta: 0.01061)         elapsed: 0.051706 ********* 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2020-08-10T10:22:15.978235 (delta: 7.159275)         elapsed: 7.210996 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-08-10T10:22:16.049757 (delta: 0.071494)         elapsed: 7.282518 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-08-10T10:22:16.101128 (delta: 0.051338)         elapsed: 7.333889 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-08-10T10:22:16.151143 (delta: 0.049984)         elapsed: 7.383904 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-08-10T10:22:16.228573 (delta: 0.077397)         elapsed: 7.461334 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "dead282f58b9477b3ffbf829ccf259f83848600b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "de8985d70b146957345d81b4a02c1d86", "mode": "0644", "owner": "root", "size": 439, "src": "/root/.ansible/tmp/ansible-tmp-1597054936.27-153057273473772/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-08-10T10:22:16.775128 (delta: 0.546522)         elapsed: 8.007889 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.621219", "end": "2020-08-10 10:22:17.650731", "rc": 0, "start": "2020-08-10 10:22:17.029512", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: block-pool-creation-bd-with-filesystem \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: block-pool-creation-bd-with-filesystem ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-08-10T10:22:17.703435 (delta: 0.928275)         elapsed: 8.936196 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-08-10T09:28:38Z", "generation": 19, "name": "block-pool-creation-bd-with-filesystem", "resourceVersion": "3342029", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/block-pool-creation-bd-with-filesystem", "uid": "dad2bbc6-42ef-44f6-bc15-23c14ea59c2b"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-08-10T10:22:18.526169 (delta: 0.822697)         elapsed: 9.75893 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-08-10T10:22:18.578331 (delta: 0.052132)         elapsed: 9.811092 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-08-10T10:22:18.626260 (delta: 0.047892)         elapsed: 9.859021 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-08-10T10:22:18.676615 (delta: 0.050291)         elapsed: 9.909376 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'}", "delta": "0:00:00.868595", "end": "2020-08-10 10:22:19.712418", "rc": 0, "start": "2020-08-10 10:22:18.843823", "stderr": "", "stderr_lines": [], "stdout": "konvoy-node1.mayalabs.io\nkonvoy-node2.mayalabs.io\nkonvoy-node3.mayalabs.io\nkonvoy-node4.mayalabs.io\nkonvoy-node5.mayalabs.io", "stdout_lines": ["konvoy-node1.mayalabs.io", "konvoy-node2.mayalabs.io", "konvoy-node3.mayalabs.io", "konvoy-node4.mayalabs.io", "konvoy-node5.mayalabs.io"]}

TASK [Select random node from the list of nodes as target node] ****************
2020-08-10T10:22:19.772282 (delta: 1.095624)         elapsed: 11.005043 ******* 
ok: [127.0.0.1] => (item=konvoy-node3.mayalabs.io) => {"ansible_facts": {"target_node": "konvoy-node3.mayalabs.io"}, "changed": false, "item": "konvoy-node3.mayalabs.io"}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-08-10T10:22:19.848809 (delta: 0.076493)         elapsed: 11.08157 ******** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ pool_type }}' in item.key
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
ok: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}}) => {"ansible_facts": {"disk_count": "2"}, "changed": false, "item": {"key": "mirror", "value": {"count": 2}}}
skipping: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}})  => {"changed": false, "item": {"key": "stripe", "value": {"count": 1}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Obtain the target node ip] ***********************************************
2020-08-10T10:22:19.957928 (delta: 0.109071)         elapsed: 11.190689 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes -l kubernetes.io/hostname=konvoy-node3.mayalabs.io -o=jsonpath='{range .items[*]}{.metadata.labels.konvoy\\.mesosphere\\.com\\/inventory_hostname}{\"\\n\"}{end}'", "delta": "0:00:00.728796", "end": "2020-08-10 10:22:20.843997", "rc": 0, "start": "2020-08-10 10:22:20.115201", "stderr": "", "stderr_lines": [], "stdout": "10.34.1.54", "stdout_lines": ["10.34.1.54"]}

TASK [Getting the Claimed block-device from targeted node to create the filesystem] ***
2020-08-10T10:22:20.905683 (delta: 0.947723)         elapsed: 12.138444 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs -l kubernetes.io/hostname=konvoy-node3.mayalabs.io -o json | jq '.items[] | select(.status.claimState==\"Unclaimed\") | select(.status.state==\"Active\") | .metadata.name' | tr \"\\\"\" \" \" | grep -v sparse | head -n \"2\"", "delta": "0:00:00.730878", "end": "2020-08-10 10:22:21.796387", "rc": 0, "start": "2020-08-10 10:22:21.065509", "stderr": "", "stderr_lines": [], "stdout": " blockdevice-09350ef6b7f3e8375cde6863a1709523 \n blockdevice-0ba81506ded5c68678cede76d705a64f ", "stdout_lines": [" blockdevice-09350ef6b7f3e8375cde6863a1709523 ", " blockdevice-0ba81506ded5c68678cede76d705a64f "]}

TASK [Create the filesystem in each blockdevices] ******************************
2020-08-10T10:22:21.856835 (delta: 0.951121)         elapsed: 13.089596 ******* 
included: /experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/create_filesystem.yml for 127.0.0.1
included: /experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/create_filesystem.yml for 127.0.0.1

TASK [Getting the claimed block-device from each node] *************************
2020-08-10T10:22:21.995023 (delta: 0.138155)         elapsed: 13.227784 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-09350ef6b7f3e8375cde6863a1709523  -o custom-columns=:.spec.path --no-headers", "delta": "0:00:00.698662", "end": "2020-08-10 10:22:22.853631", "rc": 0, "start": "2020-08-10 10:22:22.154969", "stderr": "", "stderr_lines": [], "stdout": "/dev/sde1", "stdout_lines": ["/dev/sde1"]}

TASK [Create the filesystem from the targeted inside the node] *****************
2020-08-10T10:22:22.914791 (delta: 0.919718)         elapsed: 14.147552 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "sshpass -p Test@123 ssh -o StrictHostKeyChecking=no root@10.34.1.54 \"mkfs.ext4 /dev/sde1\"", "delta": "0:00:02.582245", "end": "2020-08-10 10:22:25.654065", "rc": 0, "start": "2020-08-10 10:22:23.071820", "stderr": "Warning: Permanently added '10.34.1.54' (ECDSA) to the list of known hosts.\r\nmke2fs 1.42.9 (28-Dec-2013)", "stderr_lines": ["Warning: Permanently added '10.34.1.54' (ECDSA) to the list of known hosts.", "mke2fs 1.42.9 (28-Dec-2013)"], "stdout": "Filesystem label=\nOS type: Linux\nBlock size=4096 (log=2)\nFragment size=4096 (log=2)\nStride=0 blocks, Stripe width=0 blocks\n3276800 inodes, 13106939 blocks\n655346 blocks (5.00%) reserved for the super user\nFirst data block=0\nMaximum filesystem blocks=2162163712\n400 block groups\n32768 blocks per group, 32768 fragments per group\n8192 inodes per group\nSuperblock backups stored on blocks: \n\t32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208, \n\t4096000, 7962624, 11239424\n\nAllocating group tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            \nWriting inode tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            \nCreating journal (32768 blocks): done\nWriting superblocks and filesystem accounting information:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone", "stdout_lines": ["Filesystem label=", "OS type: Linux", "Block size=4096 (log=2)", "Fragment size=4096 (log=2)", "Stride=0 blocks, Stripe width=0 blocks", "3276800 inodes, 13106939 blocks", "655346 blocks (5.00%) reserved for the super user", "First data block=0", "Maximum filesystem blocks=2162163712", "400 block groups", "32768 blocks per group, 32768 fragments per group", "8192 inodes per group", "Superblock backups stored on blocks: ", "\t32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208, ", "\t4096000, 7962624, 11239424", "", "Allocating group tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            ", "Writing inode tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            ", "Creating journal (32768 blocks): done", "Writing superblocks and filesystem accounting information:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone"]}

TASK [Remove the filesystem from the targeted inside the node] *****************
2020-08-10T10:22:25.717181 (delta: 2.802354)         elapsed: 16.949942 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the daemonset pod name for the targeted node] *********************
2020-08-10T10:22:25.769530 (delta: 0.052313)         elapsed: 17.002291 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].metadata.name}'", "delta": "0:00:00.726636", "end": "2020-08-10 10:22:26.650746", "rc": 0, "start": "2020-08-10 10:22:25.924110", "stderr": "", "stderr_lines": [], "stdout": "openebs-ndm-4792d", "stdout_lines": ["openebs-ndm-4792d"]}

TASK [Restart the ndm daemonset pod for the targeted node] *********************
2020-08-10T10:22:26.700666 (delta: 0.931101)         elapsed: 17.933427 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n openebs openebs-ndm-4792d", "delta": "0:00:03.377424", "end": "2020-08-10 10:22:30.227753", "rc": 0, "start": "2020-08-10 10:22:26.850329", "stderr": "", "stderr_lines": [], "stdout": "pod \"openebs-ndm-4792d\" deleted", "stdout_lines": ["pod \"openebs-ndm-4792d\" deleted"]}

TASK [check if the NDM daemonset pod is deleted] *******************************
2020-08-10T10:22:30.283445 (delta: 3.582742)         elapsed: 21.516206 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ ndm_pod_name.stdout }}' not in
pod_list.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm", "delta": "0:00:00.746633", "end": "2020-08-10 10:22:31.193798", "rc": 0, "start": "2020-08-10 10:22:30.447165", "stderr": "", "stderr_lines": [], "stdout": "NAME                READY   STATUS              RESTARTS   AGE\nopenebs-ndm-drfzp   1/1     Running             0          13m\nopenebs-ndm-gnm7f   0/1     ContainerCreating   0          1s\nopenebs-ndm-r85mn   1/1     Running             0          8m46s\nopenebs-ndm-t5hlk   1/1     Running             0          59m", "stdout_lines": ["NAME                READY   STATUS              RESTARTS   AGE", "openebs-ndm-drfzp   1/1     Running             0          13m", "openebs-ndm-gnm7f   0/1     ContainerCreating   0          1s", "openebs-ndm-r85mn   1/1     Running             0          8m46s", "openebs-ndm-t5hlk   1/1     Running             0          59m"]}

TASK [Check the ndm daemonset pod is in running state] *************************
2020-08-10T10:22:31.260743 (delta: 0.977264)         elapsed: 22.493504 ******* 
FAILED - RETRYING: Check the ndm daemonset pod is in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].status.phase}'", "delta": "0:00:00.736195", "end": "2020-08-10 10:22:38.049009", "rc": 0, "start": "2020-08-10 10:22:37.312814", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:22:38.097755 (delta: 6.836976)         elapsed: 29.330516 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-09350ef6b7f3e8375cde6863a1709523  --no-headers -o custom-columns=:.spec.filesystem", "delta": "0:00:00.895008", "end": "2020-08-10 10:22:39.139155", "rc": 0, "start": "2020-08-10 10:22:38.244147", "stderr": "", "stderr_lines": [], "stdout": "map[fsType:ext4]", "stdout_lines": ["map[fsType:ext4]"]}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:22:39.208067 (delta: 1.110269)         elapsed: 30.440828 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the claimed block-device from each node] *************************
2020-08-10T10:22:39.262087 (delta: 0.053989)         elapsed: 30.494848 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-0ba81506ded5c68678cede76d705a64f  -o custom-columns=:.spec.path --no-headers", "delta": "0:00:00.729099", "end": "2020-08-10 10:22:40.147527", "rc": 0, "start": "2020-08-10 10:22:39.418428", "stderr": "", "stderr_lines": [], "stdout": "/dev/sdo1", "stdout_lines": ["/dev/sdo1"]}

TASK [Create the filesystem from the targeted inside the node] *****************
2020-08-10T10:22:40.202691 (delta: 0.940567)         elapsed: 31.435452 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "sshpass -p Test@123 ssh -o StrictHostKeyChecking=no root@10.34.1.54 \"mkfs.ext4 /dev/sdo1\"", "delta": "0:00:02.464403", "end": "2020-08-10 10:22:42.824834", "rc": 0, "start": "2020-08-10 10:22:40.360431", "stderr": "mke2fs 1.42.9 (28-Dec-2013)", "stderr_lines": ["mke2fs 1.42.9 (28-Dec-2013)"], "stdout": "Filesystem label=\nOS type: Linux\nBlock size=4096 (log=2)\nFragment size=4096 (log=2)\nStride=0 blocks, Stripe width=0 blocks\n3276800 inodes, 13106939 blocks\n655346 blocks (5.00%) reserved for the super user\nFirst data block=0\nMaximum filesystem blocks=2162163712\n400 block groups\n32768 blocks per group, 32768 fragments per group\n8192 inodes per group\nSuperblock backups stored on blocks: \n\t32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208, \n\t4096000, 7962624, 11239424\n\nAllocating group tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            \nWriting inode tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            \nCreating journal (32768 blocks): done\nWriting superblocks and filesystem accounting information:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone", "stdout_lines": ["Filesystem label=", "OS type: Linux", "Block size=4096 (log=2)", "Fragment size=4096 (log=2)", "Stride=0 blocks, Stripe width=0 blocks", "3276800 inodes, 13106939 blocks", "655346 blocks (5.00%) reserved for the super user", "First data block=0", "Maximum filesystem blocks=2162163712", "400 block groups", "32768 blocks per group, 32768 fragments per group", "8192 inodes per group", "Superblock backups stored on blocks: ", "\t32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208, ", "\t4096000, 7962624, 11239424", "", "Allocating group tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            ", "Writing inode tables:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone                            ", "Creating journal (32768 blocks): done", "Writing superblocks and filesystem accounting information:   0/400\b\b\b\b\b\b\b       \b\b\b\b\b\b\bdone"]}

TASK [Remove the filesystem from the targeted inside the node] *****************
2020-08-10T10:22:42.889559 (delta: 2.686832)         elapsed: 34.12232 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the daemonset pod name for the targeted node] *********************
2020-08-10T10:22:42.937967 (delta: 0.048374)         elapsed: 34.170728 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].metadata.name}'", "delta": "0:00:00.725196", "end": "2020-08-10 10:22:43.801619", "rc": 0, "start": "2020-08-10 10:22:43.076423", "stderr": "", "stderr_lines": [], "stdout": "openebs-ndm-gnm7f", "stdout_lines": ["openebs-ndm-gnm7f"]}

TASK [Restart the ndm daemonset pod for the targeted node] *********************
2020-08-10T10:22:43.855552 (delta: 0.917536)         elapsed: 35.088313 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n openebs openebs-ndm-gnm7f", "delta": "0:00:08.378847", "end": "2020-08-10 10:22:52.384395", "rc": 0, "start": "2020-08-10 10:22:44.005548", "stderr": "", "stderr_lines": [], "stdout": "pod \"openebs-ndm-gnm7f\" deleted", "stdout_lines": ["pod \"openebs-ndm-gnm7f\" deleted"]}

TASK [check if the NDM daemonset pod is deleted] *******************************
2020-08-10T10:22:52.437049 (delta: 8.581464)         elapsed: 43.66981 ******** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ ndm_pod_name.stdout }}' not in
pod_list.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm", "delta": "0:00:00.740976", "end": "2020-08-10 10:22:53.345309", "rc": 0, "start": "2020-08-10 10:22:52.604333", "stderr": "", "stderr_lines": [], "stdout": "NAME                READY   STATUS              RESTARTS   AGE\nopenebs-ndm-drfzp   1/1     Running             0          13m\nopenebs-ndm-m59gv   0/1     ContainerCreating   0          1s\nopenebs-ndm-r85mn   1/1     Running             0          9m8s\nopenebs-ndm-t5hlk   1/1     Running             0          59m", "stdout_lines": ["NAME                READY   STATUS              RESTARTS   AGE", "openebs-ndm-drfzp   1/1     Running             0          13m", "openebs-ndm-m59gv   0/1     ContainerCreating   0          1s", "openebs-ndm-r85mn   1/1     Running             0          9m8s", "openebs-ndm-t5hlk   1/1     Running             0          59m"]}

TASK [Check the ndm daemonset pod is in running state] *************************
2020-08-10T10:22:53.414617 (delta: 0.977519)         elapsed: 44.647378 ******* 
FAILED - RETRYING: Check the ndm daemonset pod is in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].status.phase}'", "delta": "0:00:00.793854", "end": "2020-08-10 10:23:00.448865", "rc": 0, "start": "2020-08-10 10:22:59.655011", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:23:00.518305 (delta: 7.103629)         elapsed: 51.751066 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-0ba81506ded5c68678cede76d705a64f  --no-headers -o custom-columns=:.spec.filesystem", "delta": "0:00:00.692490", "end": "2020-08-10 10:23:01.372047", "rc": 0, "start": "2020-08-10 10:23:00.679557", "stderr": "", "stderr_lines": [], "stdout": "map[fsType:ext4]", "stdout_lines": ["map[fsType:ext4]"]}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:23:01.435437 (delta: 0.917096)         elapsed: 52.668198 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Add the block devices in cspc spec] **************************************
2020-08-10T10:23:01.484590 (delta: 0.04909)         elapsed: 52.717351 ******** 
changed: [127.0.0.1] => (item= blockdevice-09350ef6b7f3e8375cde6863a1709523 ) => {"backup": "", "changed": true, "item": " blockdevice-09350ef6b7f3e8375cde6863a1709523 ", "msg": "line added"}
changed: [127.0.0.1] => (item= blockdevice-0ba81506ded5c68678cede76d705a64f ) => {"backup": "", "changed": true, "item": " blockdevice-0ba81506ded5c68678cede76d705a64f ", "msg": "line added"}

TASK [Replacing the pool name in CSPC spec] ************************************
2020-08-10T10:23:01.948582 (delta: 0.463931)         elapsed: 53.181343 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the namespace in CSPC spec] ************************************
2020-08-10T10:23:02.269883 (delta: 0.321262)         elapsed: 53.502644 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the pool type in CSPC spec] ************************************
2020-08-10T10:23:02.476191 (delta: 0.206275)         elapsed: 53.708952 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the node name in CSPC spec] ************************************
2020-08-10T10:23:02.676912 (delta: 0.200689)         elapsed: 53.909673 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2020-08-10T10:23:02.876475 (delta: 0.199514)         elapsed: 54.109236 ******* 
ok: [127.0.0.1] => (item=apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: cstor-cspc-disk-pool
  namespace: openebs
spec:
  pools:
    - nodeSelector:
        kubernetes.io/hostname: konvoy-node3.mayalabs.io
      dataRaidGroups:
      - blockDevices:
        - blockDeviceName:  blockdevice-0ba81506ded5c68678cede76d705a64f 
        - blockDeviceName:  blockdevice-09350ef6b7f3e8375cde6863a1709523 
      poolConfig:
        dataRaidGroupType: mirror) => {
    "item": "apiVersion: cstor.openebs.io/v1\nkind: CStorPoolCluster\nmetadata:\n  name: cstor-cspc-disk-pool\n  namespace: openebs\nspec:\n  pools:\n    - nodeSelector:\n        kubernetes.io/hostname: konvoy-node3.mayalabs.io\n      dataRaidGroups:\n      - blockDevices:\n        - blockDeviceName:  blockdevice-0ba81506ded5c68678cede76d705a64f \n        - blockDeviceName:  blockdevice-09350ef6b7f3e8375cde6863a1709523 \n      poolConfig:\n        dataRaidGroupType: mirror"
}

TASK [Create cstor disk pool] **************************************************
2020-08-10T10:23:02.956992 (delta: 0.080486)         elapsed: 54.189753 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc.yml", "delta": "0:00:01.214099", "end": "2020-08-10 10:23:04.319199", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2020-08-10 10:23:03.105100", "stderr": "Error from server (BadRequest): error when creating \"cspc.yml\": admission webhook \"admission-webhook.cstor.openebs.io\" denied the request: invalid cspc specification: invalid pool spec: block device has file system {ext4}", "stderr_lines": ["Error from server (BadRequest): error when creating \"cspc.yml\": admission webhook \"admission-webhook.cstor.openebs.io\" denied the request: invalid cspc specification: invalid pool spec: block device has file system {ext4}"], "stdout": "", "stdout_lines": []}

TASK [Remove the filesystem in each blockdevices] ******************************
2020-08-10T10:23:04.387974 (delta: 1.430951)         elapsed: 55.620735 ******* 
included: /experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/create_filesystem.yml for 127.0.0.1
included: /experiments/functional/cspc-pool/block-pool-creation-bd-with-filesystem/create_filesystem.yml for 127.0.0.1

TASK [Getting the claimed block-device from each node] *************************
2020-08-10T10:23:04.519282 (delta: 0.131277)         elapsed: 55.752043 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-09350ef6b7f3e8375cde6863a1709523  -o custom-columns=:.spec.path --no-headers", "delta": "0:00:00.739873", "end": "2020-08-10 10:23:05.424043", "rc": 0, "start": "2020-08-10 10:23:04.684170", "stderr": "", "stderr_lines": [], "stdout": "/dev/sde1", "stdout_lines": ["/dev/sde1"]}

TASK [Create the filesystem from the targeted inside the node] *****************
2020-08-10T10:23:05.477658 (delta: 0.958343)         elapsed: 56.710419 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove the filesystem from the targeted inside the node] *****************
2020-08-10T10:23:05.530419 (delta: 0.052724)         elapsed: 56.76318 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "sshpass -p Test@123 ssh -o StrictHostKeyChecking=no root@10.34.1.54 \"wipefs -a /dev/sde1\"", "delta": "0:00:01.069263", "end": "2020-08-10 10:23:06.755233", "rc": 0, "start": "2020-08-10 10:23:05.685970", "stderr": "", "stderr_lines": [], "stdout": "/dev/sde1: 2 bytes were erased at offset 0x00000438 (ext4): 53 ef", "stdout_lines": ["/dev/sde1: 2 bytes were erased at offset 0x00000438 (ext4): 53 ef"]}

TASK [Obtain the daemonset pod name for the targeted node] *********************
2020-08-10T10:23:06.817944 (delta: 1.287491)         elapsed: 58.050705 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].metadata.name}'", "delta": "0:00:00.753079", "end": "2020-08-10 10:23:07.726366", "rc": 0, "start": "2020-08-10 10:23:06.973287", "stderr": "", "stderr_lines": [], "stdout": "openebs-ndm-m59gv", "stdout_lines": ["openebs-ndm-m59gv"]}

TASK [Restart the ndm daemonset pod for the targeted node] *********************
2020-08-10T10:23:07.787268 (delta: 0.969244)         elapsed: 59.020029 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n openebs openebs-ndm-m59gv", "delta": "0:00:06.084622", "end": "2020-08-10 10:23:14.020943", "rc": 0, "start": "2020-08-10 10:23:07.936321", "stderr": "", "stderr_lines": [], "stdout": "pod \"openebs-ndm-m59gv\" deleted", "stdout_lines": ["pod \"openebs-ndm-m59gv\" deleted"]}

TASK [check if the NDM daemonset pod is deleted] *******************************
2020-08-10T10:23:14.076752 (delta: 6.289453)         elapsed: 65.309513 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ ndm_pod_name.stdout }}' not in
pod_list.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm", "delta": "0:00:00.765121", "end": "2020-08-10 10:23:15.005208", "rc": 0, "start": "2020-08-10 10:23:14.240087", "stderr": "", "stderr_lines": [], "stdout": "NAME                READY   STATUS              RESTARTS   AGE\nopenebs-ndm-drfzp   1/1     Running             0          13m\nopenebs-ndm-nlxbn   0/1     ContainerCreating   0          1s\nopenebs-ndm-r85mn   1/1     Running             0          9m30s\nopenebs-ndm-t5hlk   1/1     Running             0          60m", "stdout_lines": ["NAME                READY   STATUS              RESTARTS   AGE", "openebs-ndm-drfzp   1/1     Running             0          13m", "openebs-ndm-nlxbn   0/1     ContainerCreating   0          1s", "openebs-ndm-r85mn   1/1     Running             0          9m30s", "openebs-ndm-t5hlk   1/1     Running             0          60m"]}

TASK [Check the ndm daemonset pod is in running state] *************************
2020-08-10T10:23:15.079465 (delta: 1.002649)         elapsed: 66.312226 ******* 
FAILED - RETRYING: Check the ndm daemonset pod is in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].status.phase}'", "delta": "0:00:00.905346", "end": "2020-08-10 10:23:22.155520", "rc": 0, "start": "2020-08-10 10:23:21.250174", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:23:22.213518 (delta: 7.134009)         elapsed: 73.446279 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:23:22.258409 (delta: 0.044864)         elapsed: 73.49117 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-09350ef6b7f3e8375cde6863a1709523  --no-headers -o custom-columns=:.spec.filesystem", "delta": "0:00:00.723558", "end": "2020-08-10 10:23:23.140547", "rc": 0, "start": "2020-08-10 10:23:22.416989", "stderr": "", "stderr_lines": [], "stdout": "map[]", "stdout_lines": ["map[]"]}

TASK [Getting the claimed block-device from each node] *************************
2020-08-10T10:23:23.194497 (delta: 0.936039)         elapsed: 74.427258 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-0ba81506ded5c68678cede76d705a64f  -o custom-columns=:.spec.path --no-headers", "delta": "0:00:00.756939", "end": "2020-08-10 10:23:24.090756", "rc": 0, "start": "2020-08-10 10:23:23.333817", "stderr": "", "stderr_lines": [], "stdout": "/dev/sdo1", "stdout_lines": ["/dev/sdo1"]}

TASK [Create the filesystem from the targeted inside the node] *****************
2020-08-10T10:23:24.154733 (delta: 0.9602)         elapsed: 75.387494 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove the filesystem from the targeted inside the node] *****************
2020-08-10T10:23:24.205836 (delta: 0.051072)         elapsed: 75.438597 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "sshpass -p Test@123 ssh -o StrictHostKeyChecking=no root@10.34.1.54 \"wipefs -a /dev/sdo1\"", "delta": "0:00:01.061355", "end": "2020-08-10 10:23:25.438954", "rc": 0, "start": "2020-08-10 10:23:24.377599", "stderr": "", "stderr_lines": [], "stdout": "/dev/sdo1: 2 bytes were erased at offset 0x00000438 (ext4): 53 ef", "stdout_lines": ["/dev/sdo1: 2 bytes were erased at offset 0x00000438 (ext4): 53 ef"]}

TASK [Obtain the daemonset pod name for the targeted node] *********************
2020-08-10T10:23:25.509076 (delta: 1.303209)         elapsed: 76.741837 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].metadata.name}'", "delta": "0:00:00.873040", "end": "2020-08-10 10:23:26.526587", "rc": 0, "start": "2020-08-10 10:23:25.653547", "stderr": "", "stderr_lines": [], "stdout": "openebs-ndm-nlxbn", "stdout_lines": ["openebs-ndm-nlxbn"]}

TASK [Restart the ndm daemonset pod for the targeted node] *********************
2020-08-10T10:23:26.589275 (delta: 1.080164)         elapsed: 77.822036 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n openebs openebs-ndm-nlxbn", "delta": "0:00:03.624051", "end": "2020-08-10 10:23:30.372002", "rc": 0, "start": "2020-08-10 10:23:26.747951", "stderr": "", "stderr_lines": [], "stdout": "pod \"openebs-ndm-nlxbn\" deleted", "stdout_lines": ["pod \"openebs-ndm-nlxbn\" deleted"]}

TASK [check if the NDM daemonset pod is deleted] *******************************
2020-08-10T10:23:30.430177 (delta: 3.840866)         elapsed: 81.662938 ******* 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: '{{ ndm_pod_name.stdout }}' not in
pod_list.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm", "delta": "0:00:00.729284", "end": "2020-08-10 10:23:31.314058", "rc": 0, "start": "2020-08-10 10:23:30.584774", "stderr": "", "stderr_lines": [], "stdout": "NAME                READY   STATUS              RESTARTS   AGE\nopenebs-ndm-drfzp   1/1     Running             0          14m\nopenebs-ndm-jwj6g   0/1     ContainerCreating   0          1s\nopenebs-ndm-r85mn   1/1     Running             0          9m46s\nopenebs-ndm-t5hlk   1/1     Running             0          60m", "stdout_lines": ["NAME                READY   STATUS              RESTARTS   AGE", "openebs-ndm-drfzp   1/1     Running             0          14m", "openebs-ndm-jwj6g   0/1     ContainerCreating   0          1s", "openebs-ndm-r85mn   1/1     Running             0          9m46s", "openebs-ndm-t5hlk   1/1     Running             0          60m"]}

TASK [Check the ndm daemonset pod is in running state] *************************
2020-08-10T10:23:31.372361 (delta: 0.942151)         elapsed: 82.605122 ******* 
FAILED - RETRYING: Check the ndm daemonset pod is in running state (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n openebs -l name=openebs-ndm -o jsonpath='{.items[?(@.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[*].matchFields[*].values[*]==\"konvoy-node3.mayalabs.io\")].status.phase}'", "delta": "0:00:00.921092", "end": "2020-08-10 10:23:38.327572", "rc": 0, "start": "2020-08-10 10:23:37.406480", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:23:38.387030 (delta: 7.014637)         elapsed: 89.619791 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the blockdevice has the filesystem in it] **********************
2020-08-10T10:23:38.436589 (delta: 0.049523)         elapsed: 89.66935 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get blockdevice -n openebs  blockdevice-0ba81506ded5c68678cede76d705a64f  --no-headers -o custom-columns=:.spec.filesystem", "delta": "0:00:00.709274", "end": "2020-08-10 10:23:39.301452", "rc": 0, "start": "2020-08-10 10:23:38.592178", "stderr": "", "stderr_lines": [], "stdout": "map[]", "stdout_lines": ["map[]"]}

TASK [set_fact] ****************************************************************
2020-08-10T10:23:39.356106 (delta: 0.919484)         elapsed: 90.588867 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-08-10T10:23:39.417893 (delta: 0.061753)         elapsed: 90.650654 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-08-10T10:23:39.502607 (delta: 0.084682)         elapsed: 90.735368 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-08-10T10:23:39.555077 (delta: 0.05244)         elapsed: 90.787838 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-08-10T10:23:39.603544 (delta: 0.048436)         elapsed: 90.836305 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-08-10T10:23:39.655772 (delta: 0.052181)         elapsed: 90.888533 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "7e9cf2e33dcc99c9781e4f5bcdd256c0d2ca48b1", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9e5baed404a2b9167cb00a92d1723867", "mode": "0644", "owner": "root", "size": 437, "src": "/root/.ansible/tmp/ansible-tmp-1597055019.7-277375617747199/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-08-10T10:23:41.271948 (delta: 1.616128)         elapsed: 92.504709 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.793118", "end": "2020-08-10 10:23:42.206631", "rc": 0, "start": "2020-08-10 10:23:41.413513", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: block-pool-creation-bd-with-filesystem \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: block-pool-creation-bd-with-filesystem ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-08-10T10:23:42.268289 (delta: 0.996292)         elapsed: 93.50105 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-08-10T09:28:38Z", "generation": 20, "name": "block-pool-creation-bd-with-filesystem", "resourceVersion": "3342894", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/block-pool-creation-bd-with-filesystem", "uid": "dad2bbc6-42ef-44f6-bc15-23c14ea59c2b"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=55   changed=43   unreachable=0    failed=0   

2020-08-10T10:23:42.939794 (delta: 0.671473)         elapsed: 94.172555 ******* 
===============================================================================
```
