### PR TITLE
refactor[script]: Increase retried and delay for getting total replicas in RW mode

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
+++ b/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
@@ -12,8 +12,8 @@
     body_format: json
   register: json_response
   until: json_response.json.data[0].replicaCount == 3
-  retries: 15
-  delay: 10
+  retries: 20
+  delay: 15
 
 - name: Get rw replica status from controller
   vars:

--- a/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
+++ b/experiments/functional/snapshot_deletion/jiva/check_replica_count.yml
@@ -12,8 +12,8 @@
     body_format: json
   register: json_response
   until: json_response.json.data[0].replicaCount == 3
-  retries: 20
-  delay: 15
+  retries: 30
+  delay: 20
 
 - name: Get rw replica status from controller
   vars:
@@ -29,4 +29,4 @@
   register: json_response
   until: json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "RW"
   retries: 20
-  delay: 30
+  delay: 60

--- a/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
+++ b/experiments/functional/snapshot_deletion/jiva/snapshot_delete_verify_test.yml
@@ -12,5 +12,5 @@
     executable: /bin/bash
   register: snapshot_number
   until: "((snapshot_number.stdout)|int) <= 13"
-  delay: 10
+  delay: 20
   retries: 50

--- a/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
@@ -50,8 +50,8 @@
      shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[0].address' | sed -e 's/^"//' -e 's/"$//'
      register: json_response
      until: "'tcp' in json_response.stdout" 
-     delay: 10
-     retries: 12
+     delay: 15
+     retries: 24
 
    - name: Set master replica ip
      set_fact:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Increase reties & delay for getting the number of replica in RW mode. 

**Following is log of ansible test container:**

- https://gist.github.com/shashank855/259c4c4a3f0aea6290a7dff4852e4d76

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
