### PR TITLE
refactor(service_chaos): Modified the test case for kubelet service failure for csi cstor volumes

### DIFF
--- a/chaoslib/service_failure/service_chaos.yml
+++ b/chaoslib/service_failure/service_chaos.yml
@@ -104,7 +104,7 @@
 
          - block:
 
-            - name: Check if the new target pod is scheduled on some other node after {{ svc_type }} failure
+            - name: Check if the new target pod is scheduled after {{ svc_type }} failure
               shell: >
                 kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvol_name }} --no-headers |  wc -l
               args:
@@ -138,7 +138,7 @@
 
          - block:
 
-            - name: Check if the new controller pod is scheduled on some other node after {{ svc_type }} failure
+            - name: Check if the new controller pod is scheduled after {{ svc_type }} failure
               shell: >
                 kubectl get pods -n {{ operator_ns }} 
                 -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pvol_name }} --no-headers  |  wc -l
@@ -175,7 +175,7 @@
  
        - block:
 
-            - name: Check if the new target pod is scheduled on some other node after {{ svc_type }} failure
+            - name: Check if the new target pod is scheduled after {{ svc_type }} failure
               shell: >
                 kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvol_name }} --no-headers |  wc -l
               args:

--- a/chaoslib/service_failure/service_chaos.yml
+++ b/chaoslib/service_failure/service_chaos.yml
@@ -55,6 +55,22 @@
       when: vol_provisioner == 'openebs.io/provisioner-iscsi'
 
     - block:
+
+      - name: Identify the node name on which target pod is scheduled
+        shell: >
+          kubectl get pod {{ csi_target_pod }} -n {{ operator_ns }}
+          --no-headers -o custom-columns=:.spec.nodeName
+        args:
+          executable: /bin/bash
+        register: target_node_name
+
+      - name: Record the node name on which target pod is scheduled
+        set_fact: 
+          csi_target_node: "{{ target_node_name.stdout }}"
+
+      when: vol_provisioner == 'cstor.csi.openebs.io'
+
+    - block:
        
        - name: stop the {{ svc_type }} services
          shell: > 
@@ -100,7 +116,8 @@
 
             - name: Get the new target pod name
               shell: >
-                kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvol_name }} --no-headers | grep -v Terminating | awk '{print $1}'
+                kubectl get pods -n {{ operator_ns }} 
+                -l openebs.io/persistent-volume={{ pvol_name }} --no-headers | grep -v Terminating | awk '{print $1}'
               args:
                 executable: /bin/bash
               register: new_target_pod
@@ -123,7 +140,8 @@
 
             - name: Check if the new controller pod is scheduled on some other node after {{ svc_type }} failure
               shell: >
-                kubectl get pods -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pvol_name }} --no-headers  |  wc -l
+                kubectl get pods -n {{ operator_ns }} 
+                -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pvol_name }} --no-headers  |  wc -l
               args:
                 executable: /bin/bash
               register: ctrl_pod_count
@@ -133,7 +151,8 @@
 
             - name: Get the new controller pod name
               shell: >
-                kubectl get pods -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pvol_name }} --no-headers | grep -v Terminating | awk '{print $1}'
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pvol_name }} 
+                --no-headers | grep -v Terminating | awk '{print $1}'
               args:
                 executable: /bin/bash
               register: new_ctrl_pod
@@ -153,6 +172,38 @@
            - app_node == ctrl_node
 
          when: vol_provisioner == 'openebs.io/provisioner-iscsi'
+ 
+       - block:
+
+            - name: Check if the new target pod is scheduled on some other node after {{ svc_type }} failure
+              shell: >
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvol_name }} --no-headers |  wc -l
+              args:
+                executable: /bin/bash
+              register: target_pod_count
+              until: "'2' in target_pod_count.stdout"
+              delay: 15
+              retries: 30
+
+            - name: Get the new target pod name
+              shell: >
+                kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pvol_name }} --no-headers | grep -v Terminating | awk '{print $1}'
+              args:
+                executable: /bin/bash
+              register: new_target_pod
+
+            - name: Check the newly created target pod status
+              shell: >
+                kubectl get pod {{ new_target_pod.stdout }} -n {{ operator_ns }} --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: new_target_pod_status
+              until: "'Running' in new_target_pod_status.stdout"
+              delay: 15
+              retries: 35
+         when: 
+         - vol_provisioner == 'cstor.csi.openebs.io'
+         - app_node == csi_target_node       
  
        - name: Check if the new application pod is scheduled after {{ svc_type }} failure
          shell: >
@@ -230,5 +281,4 @@
      delay: 10
      retries: 50
 
-  when: action == "svc_start"
-          
+  when: action == "svc_start" 

--- a/experiments/chaos/kubernetes/service_failure/test.yml
+++ b/experiments/chaos/kubernetes/service_failure/test.yml
@@ -31,7 +31,6 @@
           vars:
             status: 'SOT'
 
-
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify that the AUT (Application Under Test) is running
@@ -86,7 +85,8 @@
 
           - name: Get the target pod name associated with this pv
             shell: >
-              kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv_name.stdout }} --no-headers -o custom-columns=:.metadata.name
+              kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv_name.stdout }} 
+              --no-headers -o custom-columns=:.metadata.name
             args:
               executable: /bin/bash
             register: target_pod_name
@@ -94,13 +94,26 @@
 
           - name: Get the controller pod name associated with this pv
             shell: >
-              kubectl get pods -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pv_name.stdout }} --no-headers -o custom-columns=:.metadata.name
+              kubectl get pods -n {{ operator_ns }} -l openebs.io/controller=jiva-controller,openebs.io/persistent-volume={{ pv_name.stdout }} 
+              --no-headers -o custom-columns=:.metadata.name
             args:
               executable: /bin/bash
             register: ctrl_pod_name
             when: stg_engine == 'jiva'
         
           when: vol_provisioner == 'openebs.io/provisioner-iscsi'
+
+        - block:
+
+          - name: Get the target pod name associated with this pv
+            shell: >
+              kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv_name.stdout }} 
+              --no-headers -o custom-columns=:.metadata.name
+            args:
+              executable: /bin/bash
+            register: csi_target_pod_name
+        
+          when: vol_provisioner == 'cstor.csi.openebs.io'          
 
         - name: Create some test data
           include: "{{ data_consistency_util_path }}"
@@ -118,6 +131,7 @@
             app_label: "{{ label }}"
             action: "svc_stop"
             target_pod: "{{ target_pod_name.stdout }}"
+            csi_target_pod: "{{ csi_target_pod_name.stdout }}"
             ctrl_pod: "{{ ctrl_pod_name.stdout }}"
             app_pod: "{{ app_pod_name.stdout }}"
             pvol_name: "{{ pv_name.stdout }}"
@@ -129,8 +143,8 @@
             action: "svc_start"
             target_pod: "{{ target_pod_name.stdout }}"
             ctrl_pod: "{{ ctrl_pod_name }}"
+            csi_target_pod: "{{ csi_target_pod_name.stdout }}"
             app_pod: "{{ app_pod_name.stdout }}"
-
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the kubelet service failure scenario test scenario is applicable for csto csi based volume

**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
