### PR TITLE
feat(exp): node failure experiment for zfs-localpv

### DIFF
--- a/chaoslib/vmware_chaos/vm_power_operations.yml
+++ b/chaoslib/vmware_chaos/vm_power_operations.yml
@@ -7,7 +7,7 @@
 #    - Operation, either 'on' or 'off'
 #
 - name: Obtain the VM ID
-  shell: sshpass -p {{ esx_pwd }} ssh -o StrictHostKeyChecking=no root@{{ esx_ip }} vim-cmd vmsvc/getallvms | grep {{ target_node }} | awk '{print $1}'
+  shell: sshpass -p {{ esx_pwd }} ssh -o StrictHostKeyChecking=no root@{{ esx_ip }} vim-cmd vmsvc/getallvms | awk '{print $1 " " $2}' | grep {{ target_node }} | awk '{print $1}'
   args:
     executable: /bin/bash
   register: id

--- a/experiments/chaos/node_failure/run_litmus_test.yml
+++ b/experiments/chaos/node_failure/run_litmus_test.yml
@@ -25,7 +25,7 @@ metadata:
   namespace: litmus
 type: Opaque
 data:
-  password:
+  passwordNode:
 
 ---
 apiVersion: batch/v1
@@ -89,7 +89,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: node-password
-                key: password
+                key: passwordNode
 
           - name: USERNAME
             value: ''
@@ -102,7 +102,7 @@ spec:
             value: "" 
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/chaos/node_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ANSIBLE_LOCAL_TEMP=$HOME/.ansible/tmp ANSIBLE_REMOTE_TEMP=$HOME/.ansible/tmp ansible-playbook ./experiments/chaos/node_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:
         - name: parameters
           mountPath: /mnt/

--- a/experiments/chaos/node_failure/run_litmus_test.yml
+++ b/experiments/chaos/node_failure/run_litmus_test.yml
@@ -18,6 +18,16 @@ data:
   password:
 
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: node-password
+  namespace: litmus
+type: Opaque
+data:
+  password:
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,6 +84,18 @@ spec:
               secretKeyRef:
                 name: host-password 
                 key: password
+
+          - name: NODE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: node-password
+                key: password
+
+          - name: USERNAME
+            value: ''
+
+          - name: ZPOOL_NAME
+            value: ''
 
           # Application name to pick the relevant data persistence check util
           - name: DATA_PERSISTENCE

--- a/experiments/chaos/node_failure/test.yml
+++ b/experiments/chaos/node_failure/test.yml
@@ -72,6 +72,10 @@
             executable: /bin/bash
           register: app_pod_name
 
+        - name: Record the application pod name
+          set_fact:
+            application_pod: "{{ app_pod_name.stdout }}"
+
         - name: Obtain PVC name from the application mount
           shell: >
             kubectl get pods "{{ app_pod_name.stdout }}" -n "{{ namespace }}" 
@@ -88,6 +92,10 @@
             executable: /bin/bash
           register: pv
           failed_when: 'pv.stdout == ""'
+
+        - name: Record the pv name
+          set_fact:
+            pv_name: "{{ pv.stdout }}"
 
         ## Generate data on the application
         - name: Generate data on the specified application.
@@ -107,6 +115,10 @@
             executable: /bin/bash
           register: app_node
 
+        - name: Record the application pod node name
+          set_fact:
+            app_node_name: "{{ app_node.stdout }}"
+
         ## Execute the chaos util to turn off the target node
         - include_tasks: "{{ chaos_util_path }}"
           vars:
@@ -121,62 +133,170 @@
             executable: /bin/bash
           register: state
           until: "'NotReady' in state.stdout"
-          delay: 30
-          retries: 15
+          delay: 15
+          retries: 30
 
         # wait 5 minutes
         - name: Wait for the application pod to get evicted
           wait_for:
             timeout: 300
 
-        ## Application verification after injecting chaos
-        - name: check the application status
-          shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "'Running' in app_status.stdout"
-          delay: 5
-          retries: 10
-          ignore_errors: true
+        - block:
+          ## Application verification after injecting chaos
+          - name: check the application status
+            shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
+            args:
+              executable: /bin/bash
+            register: app_status
+            until: "'Running' in app_status.stdout"
+            delay: 5
+            retries: 10
+            ignore_errors: true
 
-        - name: Check if the CVRs are in healthy state
-          shell: >
-            kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
-            -o custom-columns=:.status.phase --no-headers
-          args:
-            executable: /bin/bash
-          register: cvr_status
-          until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
-          retries: 60
-          delay: 10
-          when: stg_engine == 'cstor'
+          - name: Check if the CVRs are in healthy state
+            shell: >
+              kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+              -o custom-columns=:.status.phase --no-headers
+            args:
+              executable: /bin/bash
+            register: cvr_status
+            until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+            retries: 60
+            delay: 10
+            when: stg_engine == 'cstor'
 
-          ### Due to node shutdown, the application pod will be in containercreating state due to multi-attach error.
-          ### As a workaround, the node CR can be deleted which can forcefully remove the terminating pod.
+            ### Due to node shutdown, the application pod will be in containercreating state due to multi-attach error.
+            ### As a workaround, the node CR can be deleted which can forcefully remove the terminating pod.
 
-        - name: Delete the node CR
-          shell: kubectl delete node {{ app_node.stdout }}
-          args:
-            executable: /bin/bash
-          register: node_status
-          failed_when: node_status.rc != 0
+          - name: Delete the node CR
+            shell: kubectl delete node {{ app_node.stdout }}
+            args:
+              executable: /bin/bash
+            register: node_status
+            failed_when: node_status.rc != 0
 
-          ## After deleting node CR, it will take 6 minutes for the volume to be running
-        - name: wait for the application pod to start
-          wait_for:
-            timeout: 360
+            ## After deleting node CR, it will take 6 minutes for the volume to be running
+          - name: wait for the application pod to start
+            wait_for:
+              timeout: 360
 
-        - name: Check if the application pod is rescheduled
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o wide | grep -v {{ app_node.stdout }} | awk '{print $3}'
-          args:
-            executable: /bin/bash
-          register: rescheduled_app_pod_status
-          until: "'Running' in rescheduled_app_pod_status.stdout"
-          delay: 10
-          retries: 45
+          - name: Check if the application pod is rescheduled
+            shell: >
+              kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+              -o wide | grep -v {{ app_node.stdout }} | awk '{print $3}'
+            args:
+              executable: /bin/bash
+            register: rescheduled_app_pod_status
+            until: "'Running' in rescheduled_app_pod_status.stdout"
+            delay: 10
+            retries: 45
+
+          when: stg_prov == "openebs.io/provisioner-iscsi" or stg_prov == "cstor.csi.openebs.io"
+
+        - block:
+
+          - name: Check if the new application pod is scheduled after node failure
+            shell: >
+              kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers | wc -l
+            args:
+              executable: /bin/bash
+            register: app_pod_count
+            until: "'2' in app_pod_count.stdout"
+            delay: 15
+            retries: 30
+  
+          - name: Get the new application pod name
+            shell: > 
+              kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers | grep -v Terminating | awk '{print $1}'
+            args:
+              executable: /bin/bash
+            register: new_app_pod_name
+  
+          - name: Record the new application pod name 
+            set_fact:
+              new_app_pod: "{{ new_app_pod_name.stdout }}"
+           
+          - name: Check for the newly created application pod status 
+            shell: >
+              kubectl get pod {{ new_app_pod }} -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+            args:
+              executable: /bin/bash
+            register: new_app_pod_status
+            failed_when: "'Pending' not in new_app_pod_status.stdout"
+
+          - include_tasks: "{{ chaos_util_path }}"
+            vars:
+              esx_ip: "{{ host_ip }}"
+              target_node: "{{ app_node_name }}"
+              operation: "on"
+            when: platform == 'vmware'
+
+          - name: Check the node status
+            shell: kubectl get node {{ app_node_name }} --no-headers
+            args:
+              executable: /bin/bash
+            register: node_status
+            until: "'NotReady' not in node_status.stdout"
+            delay: 10
+            retries: 30
+
+          - name: verify that previous application pod is successfully deleted
+            shell: kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers
+            args:
+              executable: /bin/bash
+            register: app_pod_status
+            until: "'{{ application_pod }}' not in app_pod_status.stdout"
+            delay: 5
+            retries: 40
+
+          - name: Get the IP Address of the node on which application pod is scheduled
+            shell: >
+              kubectl get nodes {{ app_node_name }} --no-headers -o jsonpath='{.status.addresses[0].address}'
+            args:
+              executable: /bin/bash
+            register: node_ip_address
+      
+          - name: Record the IP Address of the node on which application pod is scheduled
+            set_fact:
+              node_ip_add: "{{ node_ip_address.stdout }}"
+
+          - name: Check if zpool is present 
+            shell: >
+              sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }} "zpool list"
+            args:
+              executable: /bin/bash
+            register: zpool_status          
+
+          - name: Import the zpool after turning on the VM's
+            shell: >
+              sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
+              "echo {{ node_pwd }} | sudo -S su -c 'zpool import {{ zpool_name }}'"
+            args:
+              executable: /bin/bash
+            register: status
+            failed_when: "status.rc != 0"
+            when: "'{{ zpool_name }}' not in zpool_status.stdout"
+            
+          - name: verify that zfs dataset is available now
+            shell: >
+              sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }} "zfs list"
+            args: 
+              executable: /bin/bash
+            register: zfs_dataset
+            until: "'{{ zpool_name }}/{{ pv_name }}' in zfs_dataset.stdout"
+            delay: 10
+            retries: 30
+
+          - name: check the newly scheduled application pod status
+            shell: kubectl get pod {{ new_app_pod }} -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
+            args:
+              executable: /bin/bash
+            register: new_app_pod_status
+            until: "'Running' in new_app_pod_status.stdout"
+            delay: 5
+            retries: 50
+
+          when: stg_prov == "zfs.csi.openebs.io"
 
         - block:
 
@@ -212,7 +332,9 @@
             esx_ip: "{{ host_ip }}"
             target_node: "{{ app_node.stdout }}"
             operation: "on"
-          when: platform == 'vmware'
+          when: 
+          - platform == 'vmware'
+          - stg_prov == "openebs.io/provisioner-iscsi" or stg_prov == "cstor.csi.openebs.io"
 
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:

--- a/experiments/chaos/node_failure/test_vars.yml
+++ b/experiments/chaos/node_failure/test_vars.yml
@@ -18,3 +18,10 @@ esx_pwd: "{{ lookup('env','ESX_PASSWORD') }}"
 data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
 
 operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+user: "{{ lookup('env','USERNAME') }}"
+
+zpool_name: "{{ lookup('env','ZPOOL_NAME') }}"
+
+node_pwd: "{{ lookup('env','NODE_PASSWORD') }}"
+

--- a/k8s/on-prem/openshift-installer/revert_cluster_state.yml
+++ b/k8s/on-prem/openshift-installer/revert_cluster_state.yml
@@ -8,7 +8,7 @@
     - block:
 
         - name: Getting the VM id
-          shell: ssh -o StrictHostKeyChecking=no root@{{ esx_ip }} vim-cmd vmsvc/getallvms | grep {{item}} | awk '{print $1}'
+          shell: ssh -o StrictHostKeyChecking=no root@{{ esx_ip }} vim-cmd vmsvc/getallvms | awk '{print $1 " " $2}' | grep {{item}} | awk '{print $1}'
           register: vm_id
           with_lines: cat ./vm_name.csv
 


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #505 

**What this PR does / why we need it**:
- This PR modifies the node-failure scenario to incorporate with zfs-localpv.
- In this experiment, tasks to be executed will be filtered on basis of provisioner name.
- For node-failure VM machines will be turned off on which volume was provisiioned. after that wait for the time so that pod gets evicted from the node, but due to localpv node affinity application will stuck on the same node.
- after turning on the VM's we check for the status of application pod and data-consistency.


**Note**
- I'll make this PR ready for review after adding the README file and test with cstor as well