### PR TITLE
fix(script): Wait for all jiva replica to be in RW before restart of leader replica

### DIFF
--- a/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
+++ b/experiments/functional/snapshot_deletion/jiva/test_replica_restart.yml
@@ -44,6 +44,22 @@
   #    delay: 10
   #    retries: 5
 
+   - name: Get rw replica status from controller
+     vars:
+       replicas_endpoint: "9501/v1/replicas"
+     uri:
+       url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+       method: GET
+       return_content: yes
+       status_code: 200
+       headers:
+         Content-Type: "application/json"
+       body_format: json
+     register: json_response
+     until: json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "RW"
+     retries: 20
+     delay: 60
+     
    - name: Getting master replica IP
      vars:
        replicas_endpoint: "9501/v1/replicas"


### PR DESCRIPTION
Signed-off-by: <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Fix flaky test of jiva internal snapshot deletion.
- Wait for all replicas to be in RW state before restarting leader replica.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
- Changes has been verified in konvoy pipeline(ref: https://gitlab.openebs.ci/openebs/e2e-konvoy/-/jobs/256129)