### PR TITLE
refactor(upgrade): Modified the cspc pool and csi volume upgrade test case

### DIFF
--- a/providers/openebs/cspc_csi_upgrade/README.md
+++ b/providers/openebs/cspc_csi_upgrade/README.md
@@ -17,12 +17,11 @@
 
 | Parameters              | Description                                                |
 | ----------------------- | ---------------------------------------------------------- |
-| FROM_VERSION            | Old version which needs to be upgraded                      |
+| FROM_VERSION            | Old version which needs to be upgraded                     |
 | TO_VERSION              | New version to upgrade                                     |
 | OPERATOR_NS             | Namespace where the openebs is deployed                    |
+| CSI_NAMESPACE           | Namespace where OpenEBS csi operator is deployed           |
 | UPGRADE_IMAGE_TAG       | Image tag for upgrade job                                  |
-| UPGRADE_TO_CI           | In case of upgrade to ci set the image tag to `ci`         |
-| NODE_OS                 | Supported operating system for worker nodes in case of upgrading csi provisioner |
 | CSPC_POOL_UPGRADE       | Set the value as `true` to Upgrade cspc pool               |
 | CSPC_VOLUME_UPGRADE     | Set the value as `true` to Upgrade csi volumes             |
 | CSTOR_OPERATOR_UPGRADE  | Set the value as `true` to upgrade the cstor opertor and csi provisioner |

--- a/providers/openebs/cspc_csi_upgrade/run_litmus_test.yml
+++ b/providers/openebs/cspc_csi_upgrade/run_litmus_test.yml
@@ -33,18 +33,14 @@ spec:
             
             # Namespace where OpenEBS is deployed
           - name: OPERATOR_NS
-            value: ""
+            value: "openebs"
+
+            # Namespace where OpenEBS csi operator is deployed
+          - name: CSI_NAMESPACE
+            value: "openebs"
 
             # Image tag for Upgrade Job
           - name: UPGRADE_IMAGE_TAG
-            value: ""
- 
-            # UPGRADE TO CI image tag then the value should be v1.x.x-ci
-          - name: UPGRADE_TO_CI
-            value: ""
-
-            # SUpported os for worker nodes ubuntu-16.04, ubuntu-18-04, centos
-          - name: NODE_OS
             value: ""
              
             # set to "true" if you want to upgrade cStor CSPC pool

--- a/providers/openebs/cspc_csi_upgrade/test.yml
+++ b/providers/openebs/cspc_csi_upgrade/test.yml
@@ -107,7 +107,7 @@
 
               when: "'OK' not in operator_file.msg"
 
-            - name: Enable auto-remount feature, when volumes recovers form the read-only state
+            - name: Enable auto-remount feature to recover volumes from readonly state
               replace:
                 path: "{{ cstor_operator }}"
                 regexp: 'value: "false"'
@@ -171,7 +171,7 @@
                     regexp: "openebs.io/version: dev"
                     replace: "openebs.io/version: {{ to_version }}"
 
-                - name: Enable auto-remount feature, when volumes recovers form the read-only state
+                - name: Enable auto-remount feature to recover volumes from readonly state
                   replace:
                     path: "{{ playbook_dir }}/{{ csi_operator }}"
                     regexp: 'value: "false"'

--- a/providers/openebs/cspc_csi_upgrade/test.yml
+++ b/providers/openebs/cspc_csi_upgrade/test.yml
@@ -37,9 +37,14 @@
               register: cspc_version
               failed_when: "cspc_version.stdout != from_version"
 
+            - name: Record the namespace for csi plugin pods
+              set_fact:
+                csi_ns: kube-system
+              when: from_version == '1.10.0' or from_version == '1.11.0' or from_version == '1.12.0'
+
             - name: Check if the csi daemonset is in expected version
               shell: >
-                kubectl get daemonset -n kube-system
+                kubectl get daemonset -n {{ csi_ns }}
                 -o jsonpath='{.items[?(@.metadata.labels.app=="openebs-cstor-csi-node")].metadata.labels.openebs\.io\/version}'
               args:
                 executable: /bin/bash
@@ -48,12 +53,12 @@
 
             - name: Check if the csi controller is in expected version
               shell: >
-                kubectl get sts -n kube-system
+                kubectl get sts -n {{ csi_ns }}
                 -o jsonpath='{.items[?(@.metadata.labels.name=="openebs-cstor-csi-controller")].metadata.labels.openebs\.io\/version}'
               args:
                 executable: /bin/bash
               register: csi_sts_version
-              failed_when: "csi_sts_version.stdout != from_version"        
+              failed_when: "csi_sts_version.stdout != from_version"
 
             - name: Downloading cstor Operator
               get_url:
@@ -90,7 +95,25 @@
                     regexp: ':ci'
                     replace: ":{{ to_version }}"
 
+                - name: Applying rbac rule
+                  shell: "kubectl apply -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/rbac.yaml"
+                  args:
+                    executable: /bin/bash
+
+                - name: Applying all crds
+                  shell: "kubectl apply -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/all_cstor_crds.yaml"
+                  args:
+                    executable: /bin/bash
+
               when: "'OK' not in operator_file.msg"
+
+            - name: Enable auto-remount feature, when volumes recovers form the read-only state
+              replace:
+                path: "{{ cstor_operator }}"
+                regexp: 'value: "false"'
+                after: '- name: REMOUNT'
+                replace: 'value: "true"'
+              when: "'OK' in operator_file.msg"
 
             - name: Applying cspc operator
               shell: "kubectl apply -f {{ cstor_operator }}"
@@ -99,7 +122,7 @@
 
             - name: Checking OpenEBS-CVC-Operator is running
               shell: >
-                kubectl get pods -n {{ operator_ns }} 
+                kubectl get pods -n {{ operator_ns }}
                 -o jsonpath='{.items[?(@.metadata.labels.name=="cvc-operator")].status.phase}'
               register: cvc_status
               until: "'Running' in cvc_status.stdout"
@@ -115,76 +138,56 @@
               delay: 5
               retries: 120
 
-            - block:
-              - name: Downloading the csi-operator file
-                get_url:
-                  url: "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator.yaml"
-                  dest: "{{ playbook_dir }}/csi-operator.yaml"
-                  force: yes
-                register: status
-                until:  "'OK' in status.msg"
-                delay: 5
-                retries: 3
-
-              - name: Update the desired image tag for openebs-plugin
-                replace:
-                  path: "{{ playbook_dir }}/csi-operator.yaml"
-                  regexp: "cstor-csi-driver:ci"
-                  replace: "cstor-csi-driver:{{ to_version }}"
-
-              - name: Update the label tag for openebs-plugin
-                replace:
-                  path: "{{ playbook_dir }}/csi-operator.yaml"
-                  regexp: "openebs.io/version: dev"
-                  replace: "openebs.io/version: {{ to_version }}"
-
-              - name: Deploy CSI Driver if OS is either centos or ubuntu-16.04
-                shell: >
-                  kubectl apply -f csi-operator.yaml
-                args:
-                  executable: /bin/bash
-                register: deploy_status
-                failed_when: "deploy_status.rc != 0"
-
-              when: node_os == "ubuntu-16.04" or node_os == "centos"
+            - name: Checking OpenEBS admission server is running
+              shell: >
+                kubectl get pods -n {{ operator_ns }}
+                -o jsonpath='{.items[?(@.metadata.labels.app=="cstor-admission-webhook")].status.phase}'
+              register: admission_status
+              until: "'Running' in admission_status.stdout"
+              delay: 5
+              retries: 120
 
             - block:
 
-              - name: Downloading the csi-operator file
-                get_url:
-                  url: "https://raw.githubusercontent.com/openebs/cstor-csi/master/deploy/csi-operator-ubuntu-18.04.yaml"
-                  dest: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
-                  force: yes
-                register: status
-                until:  "'OK' in status.msg"
-                delay: 5
-                retries: 3
+                - name: Downloading the csi-operator file
+                  get_url:
+                    url: "{{ csi_operator_link }}"
+                    dest: "{{ playbook_dir }}/{{ csi_operator }}"
+                    force: yes
+                  register: status
+                  until:  "'OK' in status.msg"
+                  delay: 5
+                  retries: 3
 
-              - name: Update the desired image tag for openebs-plugin
-                replace:
-                  path: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
-                  regexp: "cstor-csi-driver:ci"
-                  replace: "cstor-csi-driver:{{ to_version }}"
+                - name: Update the desired image tag for openebs-plugin
+                  replace:
+                    path: "{{ playbook_dir }}/{{ csi_operator }}"
+                    regexp: "cstor-csi-driver:ci"
+                    replace: "cstor-csi-driver:{{ to_version }}"
 
-              - name: Update the label tag for openebs-plugin
-                replace:
-                  path: "{{ playbook_dir }}/csi-operator-ubuntu-18.04.yaml"
-                  regexp: "openebs.io/version: dev"
-                  replace: "openebs.io/version: {{ to_version }}"
+                - name: Update the label tag for openebs-plugin
+                  replace:
+                    path: "{{ playbook_dir }}/{{ csi_operator }}"
+                    regexp: "openebs.io/version: dev"
+                    replace: "openebs.io/version: {{ to_version }}"
 
-              - name: Deploy CSI Driver if OS is either centos or ubuntu-18.04
-                shell: >
-                  kubectl apply -f csi-operator-ubuntu-18.04.yaml
-                args:
-                  executable: /bin/bash
-                register: deploy_status
-                failed_when: "deploy_status.rc != 0"
+                - name: Enable auto-remount feature, when volumes recovers form the read-only state
+                  replace:
+                    path: "{{ playbook_dir }}/{{ csi_operator }}"
+                    regexp: 'value: "false"'
+                    after: '- name: REMOUNT'
+                    replace: 'value: "true"'
 
-              when: node_os == "ubuntu-18.04"
+                - name: Applying cspc operator
+                  shell: "kubectl apply -f {{ playbook_dir }}/{{ csi_operator }}"
+                  args:
+                    executable: /bin/bash
+                    
+              when: "'OK' not in operator_file.msg"
 
             - name: check if csi-controller pod is running
               shell: >
-                kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller
+                kubectl get pods -n {{ csi_ns }} -l app=openebs-cstor-csi-controller
                 --no-headers -o custom-columns=:status.phase
               args:
                 executable: /bin/bash
@@ -195,7 +198,7 @@
 
             - name: Obtain the desired number of openebs-csi-node pods
               shell: >
-                kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers
+                kubectl get ds -n {{ csi_ns }} openebs-cstor-csi-node --no-headers
                 -o custom-columns=:status.desiredNumberScheduled
               args:
                 executable: /bin/bash
@@ -203,7 +206,7 @@
 
             - name: Check if the desired count matches the ready pods
               command: >
-                kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers
+                kubectl get ds -n {{ csi_ns }} openebs-cstor-csi-node --no-headers
                 -o custom-columns=:status.numberReady
               args:
                 executable: /bin/bash
@@ -211,6 +214,22 @@
               until: "desired_count.stdout == ready_pods.stdout"
               delay: 5
               retries: 50
+
+            - block: 
+
+               - name: Remove the csi controler in kube-system namespace
+                 shell: kubectl delete statefulset -n kube-system openebs-cstor-csi-controller
+                 args: 
+                   executable: /bin/bash
+                 register: csi_ctrl
+
+               - name: Remove the csi cstor node daemonset in kube-system namespace
+                 shell: kubectl delete daemonset -n kube-system openebs-cstor-csi-node
+                 args: 
+                   executable: /bin/bash
+                 register: csi_daemonset
+ 
+              when: from_version == '1.10.0' or from_version == '1.11.0' or from_version == '1.12.0'
 
           when: cstor_operator_upgrade == "true"
 
@@ -234,7 +253,7 @@
 
         - name: Check if the csi daemonset is updated to new version
           shell: >
-            kubectl get daemonset -n kube-system
+            kubectl get daemonset -n {{ operator_ns }}
             -o jsonpath='{.items[?(@.metadata.labels.app=="openebs-cstor-csi-node")].metadata.labels.openebs\.io\/version}'
           args:
             executable: /bin/bash
@@ -243,12 +262,12 @@
 
         - name: Check if the csi controller is updated to new version
           shell: >
-            kubectl get sts -n kube-system
+            kubectl get sts -n {{ operator_ns }}
             -o jsonpath='{.items[?(@.metadata.labels.name=="openebs-cstor-csi-controller")].metadata.labels.openebs\.io\/version}'
           args:
             executable: /bin/bash
           register: new_csi_sts_version
-          failed_when: "new_csi_sts_version.stdout != to_version"          
+          failed_when: "new_csi_sts_version.stdout != to_version"
 
         - name: Obtain the service account name
           shell: kubectl get deploy -n {{ operator_ns }} -l name=maya-apiserver -o jsonpath="{.items[*].spec.template.spec.serviceAccount}"
@@ -275,7 +294,7 @@
 
             - name: Check the cspi are in ONLINE state before upgrade the pool
               shell: >
-                kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster={{ item }} -o custom-columns=:.status.phase --no-headers
+                kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ item }} -o custom-columns=:.status.phase --no-headers
               register: cspi_status
               until: "((cspi_status.stdout_lines|unique)|length) == 1 and 'ONLINE' in cspi_status.stdout"
               retries: 30
@@ -285,7 +304,7 @@
 
             - name: Check the cspi is not in readOnly state before upgrade the pool
               shell: >
-                kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster={{ item }} -o custom-columns=:.status.readOnly --no-headers
+                kubectl get cspi -n {{ operator_ns }} -l openebs.io/cstor-pool-cluster={{ item }} -o custom-columns=:.status.readOnly --no-headers
               register: cspi_ro_status
               until: "((cspi_ro_status.stdout_lines|unique)|length) == 1 and 'false' in cspi_ro_status.stdout"
               retries: 30
@@ -311,13 +330,6 @@
                 line: '        - "{{ item }}"'
               with_items:
                 - "{{ cspc_name.stdout_lines }}"
-
-            - name: Adding image tag to upgrade the pools into CSPC job spec
-              lineinfile:
-                path: ./cstor-cspc-upgrade-job.yml
-                insertbefore: '"--v=4"'
-                line: '        - "--to-version-image-tag={{ upgrade_to_ci }}"'
-              when: upgrade_to_ci != ""
 
             - name: Display cspc.yml for verification
               debug: var=item
@@ -423,13 +435,6 @@
                 line: '        - "{{ item }}"'
               with_items:
                   - "{{ pv_name.stdout_lines }}"
-
-            - name: Adding upgrade ci image tag in upgrade cstor volume job spec
-              lineinfile:
-                path: ./cstor-csi-volume-upgrade-job.yml
-                insertbefore: '"--v=4"'
-                line: '        - "--to-version-image-tag={{ upgrade_to_ci }}"'
-              when: upgrade_to_ci != ""
 
             - name: Create the job to upgrade the cstor volume
               shell: kubectl apply -f cstor-csi-volume-upgrade-job.yml

--- a/providers/openebs/cspc_csi_upgrade/test_vars.yml
+++ b/providers/openebs/cspc_csi_upgrade/test_vars.yml
@@ -4,11 +4,12 @@ test_name: cstor-cspc-csi-upgrade
 from_version: "{{ lookup('env','FROM_VERSION') }}"
 to_version: "{{ lookup('env','TO_VERSION') }}"
 upgrade_image_tag: "{{ lookup('env', 'UPGRADE_IMAGE_TAG') }}"
-upgrade_to_ci: "{{ lookup('env', 'UPGRADE_TO_CI') }}"
 cstor_operator: cstor-operator.yaml
+csi_operator: csi-operator.yaml
 cstor_operator_link: "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/cstor-operator.yaml"
-new_cstor_operator: "https://raw.githubusercontent.com/openebs/charts/gh-pages/{{ lookup('env','TO_VERSION') }}/cstor-operator-{{ lookup('env','TO_VERSION') }}.yaml"
+csi_operator_link: "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/csi-operator.yaml"
+new_cstor_operator: "https://raw.githubusercontent.com/openebs/charts/gh-pages/{{ lookup('env','TO_VERSION') }}/cstor-operator.yaml"
 cspc_pool_upgrade: "{{ lookup('env', 'CSPC_POOL_UPGRADE') }}"
 csi_volume_upgrade: "{{ lookup('env', 'CSI_VOLUME_UPGRADE') }}"
 cstor_operator_upgrade: "{{ lookup('env', 'CSTOR_OPERATOR_UPGRADE') }}"
-node_os: "{{ lookup('env','NODE_OS') }}"
+csi_ns: "{{ lookup('env', 'CSI_NAMESPACE') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Refactor the cspc csi upgrade tests as part of the new changes.
- removed the csi controler and daemonset in kube-system namespace in case of version 1.10 1.11 and 1.12
**Checklist**

* [x] Does this PR have a corresponding GitHub issue?
* [x] Have you included relevant README for the chaoslib/experiment with details?
* [x] Have you added debug messages where necessary? 
* [x] Have you added task comments where necessary? 
* [x] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [x] Have you used non-shell/command modules for Kubernetes tasks?
* [x] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [x] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [x] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [x] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [x] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
k8s@e2e1-master:~/e2e-tests$ kubectl logs -f cstor-csi-upgrade-wk9rq-ds4dd -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-09-03T15:39:20.116350 (delta: 0.064106)         elapsed: 0.064106 ******** 
=============================================================================== 

TASK [include_tasks] ***********************************************************
2020-09-03T15:39:20.128207 (delta: 0.011821)         elapsed: 0.075963 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-09-03T15:39:20.171867 (delta: 0.043631)         elapsed: 0.119623 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-09-03T15:39:20.201496 (delta: 0.029599)         elapsed: 0.149252 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-09-03T15:39:20.230843 (delta: 0.02931)         elapsed: 0.178599 ********* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-09-03T15:39:20.288177 (delta: 0.057297)         elapsed: 0.235933 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4d21b9e8147f20fd99ac911eafaecbb4c43af554", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1909e4054e8868e4686e82c5ad048118", "mode": "0644", "owner": "root", "size": 423, "src": "/root/.ansible/tmp/ansible-tmp-1599147560.33-26183783042496/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-09-03T15:39:20.778287 (delta: 0.49008)         elapsed: 0.726043 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.557008", "end": "2020-09-03 15:39:21.604498", "rc": 0, "start": "2020-09-03 15:39:21.047490", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-cspc-csi-upgrade \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-cspc-csi-upgrade ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-09-03T15:39:21.631413 (delta: 0.853094)         elapsed: 1.579169 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "create", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-09-03T15:39:22Z", "generation": 1, "name": "cstor-cspc-csi-upgrade", "resourceVersion": "24895", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-cspc-csi-upgrade", "uid": "d41bf170-e656-48a8-8533-390c4aaa72b2"}, "spec": {"testMetadata": {"app": null, "chaostype": null}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-09-03T15:39:22.565850 (delta: 0.934388)         elapsed: 2.513606 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-09-03T15:39:22.591141 (delta: 0.025259)         elapsed: 2.538897 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-09-03T15:39:22.619874 (delta: 0.028686)         elapsed: 2.56763 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the cStor cvc operator is in expected version] ******************
2020-09-03T15:39:22.646385 (delta: 0.026482)         elapsed: 2.594141 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cvc-operator\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:00.918950", "end": "2020-09-03 15:39:23.731197", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:22.812247", "stderr": "", "stderr_lines": [], "stdout": "1.12.0", "stdout_lines": ["1.12.0"]}

TASK [Check if the cStor cspc operator is in expected version] *****************
2020-09-03T15:39:23.766270 (delta: 1.119849)         elapsed: 3.714026 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:00.918448", "end": "2020-09-03 15:39:24.839384", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:23.920936", "stderr": "", "stderr_lines": [], "stdout": "1.12.0", "stdout_lines": ["1.12.0"]}

TASK [Record the namespace for csi plugin pods] ********************************
2020-09-03T15:39:24.874278 (delta: 1.107974)         elapsed: 4.822034 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"csi_ns": "kube-system"}, "changed": false}

TASK [Check if the csi daemonset is in expected version] ***********************
2020-09-03T15:39:24.938724 (delta: 0.064414)         elapsed: 4.88648 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get daemonset -n kube-system -o jsonpath='{.items[?(@.metadata.labels.app==\"openebs-cstor-csi-node\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:00.783845", "end": "2020-09-03 15:39:25.886162", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:25.102317", "stderr": "", "stderr_lines": [], "stdout": "1.12.0", "stdout_lines": ["1.12.0"]}

TASK [Check if the csi controller is in expected version] **********************
2020-09-03T15:39:25.924491 (delta: 0.985731)         elapsed: 5.872247 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sts -n kube-system -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-cstor-csi-controller\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:00.954264", "end": "2020-09-03 15:39:27.196451", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:26.242187", "stderr": "", "stderr_lines": [], "stdout": "1.12.0", "stdout_lines": ["1.12.0"]}

TASK [Downloading cstor Operator] **********************************************
2020-09-03T15:39:27.231780 (delta: 1.307254)         elapsed: 7.179536 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "54cd3650b2af7839b481c8114ca516ca6c6b62b0", "dest": "/providers/openebs/cspc_csi_upgrade/cstor-operator.yaml", "gid": 0, "group": "root", "md5sum": "ebbee4f908e89ca4fdd4585bad6cdbbf", "mode": "0644", "msg": "OK (179239 bytes)", "owner": "root", "size": 179239, "src": "/root/.ansible/tmp/ansible-tmp-1599147567.28-236254632436210/tmpmXeFp2", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/charts/gh-pages/2.0.0/cstor-operator.yaml"}

TASK [Downloading cstor Operator] **********************************************
2020-09-03T15:39:28.362849 (delta: 1.131034)         elapsed: 8.310605 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the OpenEBS component labels to desired version in Operator yaml] ***
2020-09-03T15:39:28.425771 (delta: 0.062719)         elapsed: 8.373527 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the Image tag to newer version in operator yaml] ******************
2020-09-03T15:39:28.463504 (delta: 0.037602)         elapsed: 8.41126 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Applying rbac rule] ******************************************************
2020-09-03T15:39:28.497895 (delta: 0.034331)         elapsed: 8.445651 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Applying all crds] *******************************************************
2020-09-03T15:39:28.533671 (delta: 0.035744)         elapsed: 8.481427 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Enable auto-remount feature, when volumes recovers form the read-only state] ***
2020-09-03T15:39:28.566793 (delta: 0.033089)         elapsed: 8.514549 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Applying cspc operator] **************************************************
2020-09-03T15:39:28.848588 (delta: 0.281747)         elapsed: 8.796344 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cstor-operator.yaml", "delta": "0:00:04.782242", "end": "2020-09-03 15:39:33.789537", "rc": 0, "start": "2020-09-03 15:39:29.007295", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs unchanged\nserviceaccount/openebs-maya-operator unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-operator unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-operator unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-migration unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-migration unchanged\ncustomresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumeattachments.cstor.openebs.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io configured\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured\ncsidriver.storage.k8s.io/cstor.csi.openebs.io created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding configured\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged\nserviceaccount/openebs-cstor-csi-controller-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding configured\nstatefulset.apps/openebs-cstor-csi-controller created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding configured\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding configured\nserviceaccount/openebs-cstor-csi-node-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding configured\nconfigmap/openebs-cstor-csi-iscsiadm created\ndaemonset.apps/openebs-cstor-csi-node created\ncustomresourcedefinition.apiextensions.k8s.io/cstorpoolclusters.cstor.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorpoolinstances.cstor.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumeconfigs.cstor.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumepolicies.cstor.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumereplicas.cstor.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumes.cstor.openebs.io configured\ncustomresourcedefinition.apiextensions.k8s.io/cstorbackups.openebs.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/cstorcompletedbackups.openebs.io unchanged\ncustomresourcedefinition.apiextensions.k8s.io/cstorrestores.openebs.io unchanged\ndeployment.apps/cspc-operator configured\ndeployment.apps/cvc-operator configured\nservice/cvc-operator-service unchanged\ndeployment.apps/openebs-cstor-admission-server configured", "stdout_lines": ["namespace/openebs unchanged", "serviceaccount/openebs-maya-operator unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-operator unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-operator unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-migration unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-migration unchanged", "customresourcedefinition.apiextensions.k8s.io/csinodeinfos.csi.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorvolumeattachments.cstor.openebs.io unchanged", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io configured", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured", "csidriver.storage.k8s.io/cstor.csi.openebs.io created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding configured", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role unchanged", "serviceaccount/openebs-cstor-csi-controller-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding configured", "statefulset.apps/openebs-cstor-csi-controller created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding configured", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding configured", "serviceaccount/openebs-cstor-csi-node-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding configured", "configmap/openebs-cstor-csi-iscsiadm created", "daemonset.apps/openebs-cstor-csi-node created", "customresourcedefinition.apiextensions.k8s.io/cstorpoolclusters.cstor.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorpoolinstances.cstor.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorvolumeconfigs.cstor.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorvolumepolicies.cstor.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorvolumereplicas.cstor.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorvolumes.cstor.openebs.io configured", "customresourcedefinition.apiextensions.k8s.io/cstorbackups.openebs.io unchanged", "customresourcedefinition.apiextensions.k8s.io/cstorcompletedbackups.openebs.io unchanged", "customresourcedefinition.apiextensions.k8s.io/cstorrestores.openebs.io unchanged", "deployment.apps/cspc-operator configured", "deployment.apps/cvc-operator configured", "service/cvc-operator-service unchanged", "deployment.apps/openebs-cstor-admission-server configured"]}

TASK [Checking OpenEBS-CVC-Operator is running] ********************************
2020-09-03T15:39:33.822821 (delta: 4.974199)         elapsed: 13.770577 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cvc-operator\")].status.phase}'", "delta": "0:00:01.134624", "end": "2020-09-03 15:39:35.105005", "rc": 0, "start": "2020-09-03 15:39:33.970381", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2020-09-03T15:39:35.200445 (delta: 1.377584)         elapsed: 15.148201 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:01.218388", "end": "2020-09-03 15:39:36.790905", "rc": 0, "start": "2020-09-03 15:39:35.572517", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking OpenEBS admission server is running] ****************************
2020-09-03T15:39:36.882213 (delta: 1.681732)         elapsed: 16.829969 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.app==\"cstor-admission-webhook\")].status.phase}'", "delta": "0:00:01.130294", "end": "2020-09-03 15:39:38.283717", "rc": 0, "start": "2020-09-03 15:39:37.153423", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Downloading the csi-operator file] ***************************************
2020-09-03T15:39:38.343901 (delta: 1.461652)         elapsed: 18.291657 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the desired image tag for openebs-plugin] *************************
2020-09-03T15:39:38.375905 (delta: 0.031968)         elapsed: 18.323661 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the label tag for openebs-plugin] *********************************
2020-09-03T15:39:38.411817 (delta: 0.035877)         elapsed: 18.359573 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Enable auto-remount feature, when volumes recovers form the read-only state] ***
2020-09-03T15:39:38.487685 (delta: 0.075829)         elapsed: 18.435441 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Applying cspc operator] **************************************************
2020-09-03T15:39:38.549558 (delta: 0.061839)         elapsed: 18.497314 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [check if csi-controller pod is running] **********************************
2020-09-03T15:39:38.621906 (delta: 0.072311)         elapsed: 18.569662 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n kube-system -l app=openebs-cstor-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.385211", "end": "2020-09-03 15:39:40.328750", "rc": 0, "start": "2020-09-03 15:39:38.943539", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
2020-09-03T15:39:40.550702 (delta: 1.928757)         elapsed: 20.498458 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n kube-system openebs-cstor-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:01.018626", "end": "2020-09-03 15:39:42.576501", "rc": 0, "start": "2020-09-03 15:39:41.557875", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check if the desired count matches the ready pods] ***********************
2020-09-03T15:39:42.657807 (delta: 2.107069)         elapsed: 22.605563 ******* 
 [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer
supported with the 'command' module. Not using '/bin/bash'.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": ["kubectl", "get", "ds", "-n", "kube-system", "openebs-cstor-csi-node", "--no-headers", "-o", "custom-columns=:status.numberReady"], "delta": "0:00:00.926768", "end": "2020-09-03 15:39:43.902992", "rc": 0, "start": "2020-09-03 15:39:42.976224", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Remove the csi controler in kube-system namespace] ***********************
2020-09-03T15:39:43.956213 (delta: 1.298372)         elapsed: 23.903969 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete statefulset -n kube-system openebs-cstor-csi-controller", "delta": "0:00:01.045625", "end": "2020-09-03 15:39:45.188138", "rc": 0, "start": "2020-09-03 15:39:44.142513", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps \"openebs-cstor-csi-controller\" deleted", "stdout_lines": ["statefulset.apps \"openebs-cstor-csi-controller\" deleted"]}

TASK [Remove the csi cstor node daemonset in kube-system namespace] ************
2020-09-03T15:39:45.299469 (delta: 1.343225)         elapsed: 25.247225 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete daemonset -n kube-system openebs-cstor-csi-node", "delta": "0:00:01.512149", "end": "2020-09-03 15:39:47.070654", "rc": 0, "start": "2020-09-03 15:39:45.558505", "stderr": "", "stderr_lines": [], "stdout": "daemonset.apps \"openebs-cstor-csi-node\" deleted", "stdout_lines": ["daemonset.apps \"openebs-cstor-csi-node\" deleted"]}

TASK [Check if the cStor cvc operator is updated to new version] ***************
2020-09-03T15:39:47.133877 (delta: 1.834369)         elapsed: 27.081633 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cvc-operator\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:01.134959", "end": "2020-09-03 15:39:48.469058", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:47.334099", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [Check if the cStor cspc operator is updated to new version] **************
2020-09-03T15:39:48.541083 (delta: 1.407171)         elapsed: 28.488839 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:01.042466", "end": "2020-09-03 15:39:50.582125", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:49.539659", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [Check if the csi daemonset is updated to new version] ********************
2020-09-03T15:39:50.621592 (delta: 2.080476)         elapsed: 30.569348 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get daemonset -n openebs -o jsonpath='{.items[?(@.metadata.labels.app==\"openebs-cstor-csi-node\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:00.918570", "end": "2020-09-03 15:39:52.230239", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:51.311669", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [Check if the csi controller is updated to new version] *******************
2020-09-03T15:39:52.291746 (delta: 1.670121)         elapsed: 32.239502 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sts -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-cstor-csi-controller\")].metadata.labels.openebs\\.io\\/version}'", "delta": "0:00:00.968672", "end": "2020-09-03 15:39:54.408330", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:53.439658", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [Obtain the service account name] *****************************************
2020-09-03T15:39:54.450423 (delta: 2.158642)         elapsed: 34.398179 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n openebs -l name=maya-apiserver -o jsonpath=\"{.items[*].spec.template.spec.serviceAccount}\"", "delta": "0:00:00.876750", "end": "2020-09-03 15:39:55.597422", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:54.720672", "stderr": "", "stderr_lines": [], "stdout": "openebs-maya-operator", "stdout_lines": ["openebs-maya-operator"]}

TASK [Obtain the CSPC name] ****************************************************
2020-09-03T15:39:55.631297 (delta: 1.180838)         elapsed: 35.579053 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspc -n openebs -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.989582", "end": "2020-09-03 15:39:56.828570", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:39:55.838988", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool", "stdout_lines": ["cstor-cspc-disk-pool"]}

TASK [Check if the CSPC pool pods are in running state before upgrade the pool] ***
2020-09-03T15:39:56.892249 (delta: 1.26092)         elapsed: 36.840005 ******** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.791394", "end": "2020-09-03 15:39:57.867712", "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:39:57.076318", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Check the cspi are in ONLINE state before upgrade the pool] **************
2020-09-03T15:39:57.902836 (delta: 1.010552)         elapsed: 37.850592 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:01.155878", "end": "2020-09-03 15:39:59.208779", "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:39:58.052901", "stderr": "", "stderr_lines": [], "stdout": "ONLINE\nONLINE\nONLINE", "stdout_lines": ["ONLINE", "ONLINE", "ONLINE"]}

TASK [Check the cspi is not in readOnly state before upgrade the pool] *********
2020-09-03T15:39:59.427671 (delta: 1.524777)         elapsed: 39.375427 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.readOnly --no-headers", "delta": "0:00:01.106566", "end": "2020-09-03 15:40:01.497081", "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:40:00.390515", "stderr": "", "stderr_lines": [], "stdout": "false\nfalse\nfalse", "stdout_lines": ["false", "false", "false"]}

TASK [create job yaml spec for cspc upgrade] ***********************************
2020-09-03T15:40:01.544498 (delta: 2.11679)         elapsed: 41.492254 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "90a279c0227959dde3e3557046f83d679afd6fda", "dest": "./cstor-cspc-upgrade-job.yml", "gid": 0, "group": "root", "md5sum": "9cddeac583c881889daf0c3739fe59ed", "mode": "0644", "owner": "root", "size": 653, "src": "/root/.ansible/tmp/ansible-tmp-1599147601.6-1292479946844/source", "state": "file", "uid": 0}

TASK [Replacing the service Account name in upgrade CSPC job spec] *************
2020-09-03T15:40:01.854224 (delta: 0.309692)         elapsed: 41.80198 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Adding CSPC name to upgrade the pools into CSPC job spec] ****************
2020-09-03T15:40:02.012684 (delta: 0.158424)         elapsed: 41.96044 ******** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"backup": "", "changed": true, "item": "cstor-cspc-disk-pool", "msg": "line added"}

TASK [Display cspc.yml for verification] ***************************************
2020-09-03T15:40:02.400617 (delta: 0.387898)         elapsed: 42.348373 ******* 
ok: [127.0.0.1] => (item=---
apiVersion: batch/v1
kind: Job
metadata:
  name: cstor-cspc-upgrade
  namespace: openebs
spec:
  backoffLimit: 4
  template:
    spec:
      serviceAccountName: openebs-maya-operator
      containers:
      - name: upgrade
        args:
        - "cstor-cspc"
        - "--from-version=1.12.0"
        - "--to-version=2.0.0"
        - "cstor-cspc-disk-pool"
        - "--v=4"
        # DO NOT CHANGE BELOW PARAMETERS
        env:
        - name: OPENEBS_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        tty: true
        image: "openebs/upgrade-amd64:2.0.0"
        imagePullPolicy: IfNotPresent
      restartPolicy: OnFailure
---) => {
    "item": "---\napiVersion: batch/v1\nkind: Job\nmetadata:\n  name: cstor-cspc-upgrade\n  namespace: openebs\nspec:\n  backoffLimit: 4\n  template:\n    spec:\n      serviceAccountName: openebs-maya-operator\n      containers:\n      - name: upgrade\n        args:\n        - \"cstor-cspc\"\n        - \"--from-version=1.12.0\"\n        - \"--to-version=2.0.0\"\n        - \"cstor-cspc-disk-pool\"\n        - \"--v=4\"\n        # DO NOT CHANGE BELOW PARAMETERS\n        env:\n        - name: OPENEBS_NAMESPACE\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n        tty: true\n        image: \"openebs/upgrade-amd64:2.0.0\"\n        imagePullPolicy: IfNotPresent\n      restartPolicy: OnFailure\n---"
}

TASK [Create the job to upgrade the CSPC pool] *********************************
2020-09-03T15:40:02.465271 (delta: 0.06442)         elapsed: 42.413027 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cstor-cspc-upgrade-job.yml", "delta": "0:00:01.106806", "end": "2020-09-03 15:40:03.725931", "rc": 0, "start": "2020-09-03 15:40:02.619125", "stderr": "", "stderr_lines": [], "stdout": "job.batch/cstor-cspc-upgrade created", "stdout_lines": ["job.batch/cstor-cspc-upgrade created"]}

TASK [Check if the upgrade job has been completed] *****************************
2020-09-03T15:40:03.758313 (delta: 1.291356)         elapsed: 43.706069 ******* 
FAILED - RETRYING: Check if the upgrade job has been completed (60 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (59 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (58 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (57 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (56 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (55 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (54 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (53 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (52 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (51 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (50 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (49 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (48 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (47 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (46 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (45 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (44 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (43 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (42 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (41 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (40 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (39 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (38 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (37 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (36 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (35 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (34 retries left).
FAILED - RETRYING: Check if the upgrade job has been completed (33 retries left).
changed: [127.0.0.1] => {"attempts": 29, "changed": true, "cmd": "kubectl get pods -n openebs -l job-name=cstor-cspc-upgrade -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.697744", "end": "2020-09-03 15:45:12.994932", "rc": 0, "start": "2020-09-03 15:45:12.297188", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Check if the CSPC pool pods are in running state after upgrade the pool] ***
2020-09-03T15:45:13.022928 (delta: 309.264582)         elapsed: 352.970684 **** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.736436", "end": "2020-09-03 15:45:13.909034", "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:45:13.172598", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running"]}

TASK [Check the cspi are in ONLINE state after upgrade the pool] ***************
2020-09-03T15:45:13.956183 (delta: 0.933214)         elapsed: 353.903939 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.739047", "end": "2020-09-03 15:45:14.848633", "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:45:14.109586", "stderr": "", "stderr_lines": [], "stdout": "ONLINE\nONLINE\nONLINE", "stdout_lines": ["ONLINE", "ONLINE", "ONLINE"]}

TASK [Check the cspi are not in readOnly state after upgrade the pool] *********
2020-09-03T15:45:14.890728 (delta: 0.93451)         elapsed: 354.838484 ******* 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.status.readOnly --no-headers", "delta": "0:00:00.725113", "end": "2020-09-03 15:45:15.773854", "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:45:15.048741", "stderr": "", "stderr_lines": [], "stdout": "false\nfalse\nfalse", "stdout_lines": ["false", "false", "false"]}

TASK [Obtain the CSPI name to check the version] *******************************
2020-09-03T15:45:15.855589 (delta: 0.964806)         elapsed: 355.803345 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool) => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o=jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'", "delta": "0:00:00.940803", "end": "2020-09-03 15:45:17.034686", "failed_when_result": false, "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:45:16.093883", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-c99m\ncstor-cspc-disk-pool-n674\ncstor-cspc-disk-pool-xwg5", "stdout_lines": ["cstor-cspc-disk-pool-c99m", "cstor-cspc-disk-pool-n674", "cstor-cspc-disk-pool-xwg5"]}

TASK [Initialize an empty list to store cspi names] ****************************
2020-09-03T15:45:17.088281 (delta: 1.232659)         elapsed: 357.036037 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"cspi_list": []}, "changed": false}

TASK [Store name of all cspi in the list] **************************************
2020-09-03T15:45:17.149192 (delta: 0.060876)         elapsed: 357.096948 ****** 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-cspc-disk-pool-c99m\ncstor-cspc-disk-pool-n674\ncstor-cspc-disk-pool-xwg5', '_ansible_item_result': True, u'delta': u'0:00:00.940803', 'stdout_lines': [u'cstor-cspc-disk-pool-c99m', u'cstor-cspc-disk-pool-n674', u'cstor-cspc-disk-pool-xwg5'], 'failed_when_result': False, '_ansible_item_label': u'cstor-cspc-disk-pool', u'end': u'2020-09-03 15:45:17.034686', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o=jsonpath=\'{range .items[*]}{.metadata.name}{"\\n"}{end}\'', 'item': u'cstor-cspc-disk-pool', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o=jsonpath=\'{range .items[*]}{.metadata.name}{"\\n"}{end}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2020-09-03 15:45:16.093883', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cspi_list": ["cstor-cspc-disk-pool-c99m", "cstor-cspc-disk-pool-n674", "cstor-cspc-disk-pool-xwg5"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o=jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'", "delta": "0:00:00.940803", "end": "2020-09-03 15:45:17.034686", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o=jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-cspc-disk-pool", "rc": 0, "start": "2020-09-03 15:45:16.093883", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-c99m\ncstor-cspc-disk-pool-n674\ncstor-cspc-disk-pool-xwg5", "stdout_lines": ["cstor-cspc-disk-pool-c99m", "cstor-cspc-disk-pool-n674", "cstor-cspc-disk-pool-xwg5"]}}

TASK [Check if the CSPI resources are upgraded to newer version] ***************
2020-09-03T15:45:17.247713 (delta: 0.097894)         elapsed: 357.195469 ****** 
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-c99m) => {"changed": true, "cmd": "kubectl get cspi cstor-cspc-disk-pool-c99m -n openebs -o custom-columns=:.versionDetails.status.current --no-headers", "delta": "0:00:00.691282", "end": "2020-09-03 15:45:18.101541", "failed_when_result": false, "item": "cstor-cspc-disk-pool-c99m", "rc": 0, "start": "2020-09-03 15:45:17.410259", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-n674) => {"changed": true, "cmd": "kubectl get cspi cstor-cspc-disk-pool-n674 -n openebs -o custom-columns=:.versionDetails.status.current --no-headers", "delta": "0:00:00.698271", "end": "2020-09-03 15:45:18.938384", "failed_when_result": false, "item": "cstor-cspc-disk-pool-n674", "rc": 0, "start": "2020-09-03 15:45:18.240113", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-xwg5) => {"changed": true, "cmd": "kubectl get cspi cstor-cspc-disk-pool-xwg5 -n openebs -o custom-columns=:.versionDetails.status.current --no-headers", "delta": "0:00:00.771860", "end": "2020-09-03 15:45:19.844205", "failed_when_result": false, "item": "cstor-cspc-disk-pool-xwg5", "rc": 0, "start": "2020-09-03 15:45:19.072345", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [Obtain the cStor PV name] ************************************************
2020-09-03T15:45:19.877218 (delta: 2.629465)         elapsed: 359.824974 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv -o=jsonpath='{.items[?(@.spec.csi.driver==\"cstor.csi.openebs.io\")].metadata.name}' | tr \" \" \"\\n\"", "delta": "0:00:00.680567", "end": "2020-09-03 15:45:20.698850", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:45:20.018283", "stderr": "", "stderr_lines": [], "stdout": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3", "stdout_lines": ["pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3"]}

TASK [create job yaml spec for upgrade cstor volume] ***************************
2020-09-03T15:45:20.731498 (delta: 0.854211)         elapsed: 360.679254 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "fac37bfd649fb56c3760e23adb54a90a3b6f31ce", "dest": "./cstor-csi-volume-upgrade-job.yml", "gid": 0, "group": "root", "md5sum": "f370bc7b656f6573c612b849851549b6", "mode": "0644", "owner": "root", "size": 620, "src": "/root/.ansible/tmp/ansible-tmp-1599147920.77-55299332307519/source", "state": "file", "uid": 0}

TASK [Replacing the service Account name in upgrade cstor volume job spec] *****
2020-09-03T15:45:21.016426 (delta: 0.284898)         elapsed: 360.964182 ****** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Adding volume name in upgrade cstor volume job spec] *********************
2020-09-03T15:45:21.223453 (delta: 0.20699)         elapsed: 361.171209 ******* 
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3) => {"backup": "", "changed": true, "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3", "msg": "line added"}

TASK [Create the job to upgrade the cstor volume] ******************************
2020-09-03T15:45:21.405984 (delta: 0.182489)         elapsed: 361.35374 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cstor-csi-volume-upgrade-job.yml", "delta": "0:00:00.904947", "end": "2020-09-03 15:45:22.464604", "rc": 0, "start": "2020-09-03 15:45:21.559657", "stderr": "", "stderr_lines": [], "stdout": "job.batch/cstor-csi-volume-upgrade created", "stdout_lines": ["job.batch/cstor-csi-volume-upgrade created"]}

TASK [Check if the upgrade jobs have been completed] ***************************
2020-09-03T15:45:22.497941 (delta: 1.091908)         elapsed: 362.445697 ****** 
FAILED - RETRYING: Check if the upgrade jobs have been completed (60 retries left).
FAILED - RETRYING: Check if the upgrade jobs have been completed (59 retries left).
FAILED - RETRYING: Check if the upgrade jobs have been completed (58 retries left).
FAILED - RETRYING: Check if the upgrade jobs have been completed (57 retries left).
FAILED - RETRYING: Check if the upgrade jobs have been completed (56 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl get pods -n openebs -l job-name=cstor-csi-volume-upgrade -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.888607", "end": "2020-09-03 15:47:58.474832", "rc": 0, "start": "2020-09-03 15:47:57.586225", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Check if the target pod is in Running state] *****************************
2020-09-03T15:47:58.511115 (delta: 156.013044)         elapsed: 518.458871 **** 
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.740352", "end": "2020-09-03 15:47:59.411871", "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3", "rc": 0, "start": "2020-09-03 15:47:58.671519", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Check if the target has been upgraded to latest version] *****************
2020-09-03T15:47:59.446379 (delta: 0.935222)         elapsed: 519.394135 ****** 
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3) => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3 -o=jsonpath='{range .items[*]}{.metadata.labels.openebs\\.io\\/version}{\"\\n\"}{end}'", "delta": "0:00:00.752801", "end": "2020-09-03 15:48:00.384999", "failed_when_result": false, "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3", "rc": 0, "start": "2020-09-03 15:47:59.632198", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [Check if the CVRs are in Healthy state] **********************************
2020-09-03T15:48:00.418295 (delta: 0.970713)         elapsed: 520.366051 ****** 
FAILED - RETRYING: Check if the CVRs are in Healthy state (45 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (44 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (43 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (42 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (41 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (40 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (39 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (38 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (37 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (36 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (35 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (34 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (33 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (32 retries left).
FAILED - RETRYING: Check if the CVRs are in Healthy state (31 retries left).
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3) => {"attempts": 16, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.622599", "end": "2020-09-03 15:49:30.668785", "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3", "rc": 0, "start": "2020-09-03 15:49:30.046186", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [Verify the cstor replicas are upgraded to new version] *******************
2020-09-03T15:49:30.699237 (delta: 90.280912)         elapsed: 610.646993 ***** 
included: /providers/openebs/cspc_csi_upgrade/cstor_replica_version_check.yml for 127.0.0.1

TASK [Obtain the CVR name to verify the current version] ***********************
2020-09-03T15:49:30.758490 (delta: 0.059176)         elapsed: 610.706246 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3 -o=jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'", "delta": "0:00:00.739751", "end": "2020-09-03 15:49:31.639689", "failed_when_result": false, "rc": 0, "start": "2020-09-03 15:49:30.899938", "stderr": "", "stderr_lines": [], "stdout": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-c99m\npvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-n674\npvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-xwg5", "stdout_lines": ["pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-c99m", "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-n674", "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-xwg5"]}

TASK [Check if the CVRs are upgraded to newer version] *************************
2020-09-03T15:49:31.673561 (delta: 0.915028)         elapsed: 611.621317 ****** 
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-c99m) => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-c99m -o custom-columns=:.versionDetails.status.current --no-headers", "delta": "0:00:00.683614", "end": "2020-09-03 15:49:32.503120", "failed_when_result": false, "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-c99m", "rc": 0, "start": "2020-09-03 15:49:31.819506", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-n674) => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-n674 -o custom-columns=:.versionDetails.status.current --no-headers", "delta": "0:00:00.764027", "end": "2020-09-03 15:49:33.396758", "failed_when_result": false, "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-n674", "rc": 0, "start": "2020-09-03 15:49:32.632731", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}
changed: [127.0.0.1] => (item=pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-xwg5) => {"changed": true, "cmd": "kubectl get cvr -n openebs pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-xwg5 -o custom-columns=:.versionDetails.status.current --no-headers", "delta": "0:00:00.686914", "end": "2020-09-03 15:49:34.233962", "failed_when_result": false, "item": "pvc-81698ecb-e720-4a44-8ba0-68d95bdc37e3-cstor-cspc-disk-pool-xwg5", "rc": 0, "start": "2020-09-03 15:49:33.547048", "stderr": "", "stderr_lines": [], "stdout": "2.0.0", "stdout_lines": ["2.0.0"]}

TASK [set_fact] ****************************************************************
2020-09-03T15:49:34.269716 (delta: 2.596122)         elapsed: 614.217472 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-09-03T15:49:34.315128 (delta: 0.045381)         elapsed: 614.262884 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-09-03T15:49:34.368773 (delta: 0.053612)         elapsed: 614.316529 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-09-03T15:49:34.396036 (delta: 0.027118)         elapsed: 614.343792 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-09-03T15:49:34.422218 (delta: 0.026151)         elapsed: 614.369974 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-09-03T15:49:34.448726 (delta: 0.026478)         elapsed: 614.396482 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "d278a851cc9f30d4a92b01ffaf574df40824a679", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "429d939a2ccb1173becbf4604cd2c894", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1599148174.49-43307036872196/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-09-03T15:49:35.943497 (delta: 1.494743)         elapsed: 615.891253 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.697293", "end": "2020-09-03 15:49:36.803662", "rc": 0, "start": "2020-09-03 15:49:36.106369", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-cspc-csi-upgrade \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-cspc-csi-upgrade ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-09-03T15:49:36.871886 (delta: 0.928338)         elapsed: 616.819642 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-09-03T15:39:22Z", "generation": 2, "name": "cstor-cspc-csi-upgrade", "resourceVersion": "28251", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-cspc-csi-upgrade", "uid": "d41bf170-e656-48a8-8533-390c4aaa72b2"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=60   changed=51   unreachable=0    failed=0   

2020-09-03T15:49:37.753052 (delta: 0.881136)         elapsed: 617.700808 ****** 
=============================================================================== 
```