### PR TITLE
add(sc): adding storage class template for shared volume with btrfs

### DIFF
--- a/experiments/zfs-localpv/zfs-localpv-provisioner/openebs-zfspv-sc.j2
+++ b/experiments/zfs-localpv/zfs-localpv-provisioner/openebs-zfspv-sc.j2
@@ -122,3 +122,14 @@ parameters:
   fstype: "ext4"
   poolname: "{{ pool_name }}"
 provisioner: zfs.csi.openebs.io
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}-btrfs-shared"
+parameters:
+  shared: "yes"
+  fstype: "btrfs"
+  poolname: "{{ pool_name }}"
+provisioner: zfs.csi.openebs.io


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR adds the storage class template for provisioning shared-mount volume with btrfs file system