### PR TITLE
feat(affinity-check): Included a test case to verify the application and target pod affinity for csi volumes

### DIFF
--- a/experiments/functional/cstor-csi/app-target-affinity/app-target-affinity-policy.yml
+++ b/experiments/functional/cstor-csi/app-target-affinity/app-target-affinity-policy.yml
@@ -1,0 +1,17 @@
+apiVersion: cstor.openebs.io/v1
+kind: CStorVolumePolicy
+metadata:
+  name: app-target-affinity-policy
+  namespace: openebs
+spec:
+  target:
+    affinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: openebs.io/target-affinity
+            operator: In
+            values:
+            - app-label
+        topologyKey: kubernetes.io/hostname
+        namespaces: ["app-namespace"]                      

--- a/experiments/functional/cstor-csi/app-target-affinity/app-target-affinity-sc.yaml
+++ b/experiments/functional/cstor-csi/app-target-affinity/app-target-affinity-sc.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: testclass
+provisioner: cstor.csi.openebs.io
+allowVolumeExpansion: true
+volumeBindingMode: Immediate
+parameters:
+  replicaCount: "3"
+  cstorPoolCluster: "pool-name"
+  cas-type: "cstor"
+  cstorVolumePolicy: "app-target-affinity-policy"  

--- a/experiments/functional/cstor-csi/app-target-affinity/percona.yml
+++ b/experiments/functional/cstor-csi/app-target-affinity/percona.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    lkey: lvalue
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      lkey: lvalue
+      openebs.io/target-affinity: lvalue
+  template: 
+    metadata:
+      labels: 
+        lkey: lvalue
+        openebs.io/target-affinity: lvalue
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: openebs/tests-custom-percona:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: data-vol
+          livenessProbe:
+            exec:
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 60
+            periodSeconds: 1
+            timeoutSeconds: 10
+      volumes:
+        - name: data-vol
+          persistentVolumeClaim:
+            claimName: testclaim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    lkey: lvalue
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      lkey: lvalue

--- a/experiments/functional/cstor-csi/app-target-affinity/run_litmus_test.yml
+++ b/experiments/functional/cstor-csi/app-target-affinity/run_litmus_test.yml
@@ -1,0 +1,49 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: csi-cstor-app-target-affinity-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: app-target-affinity
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+          - name: POOL_NAME
+            value: ""
+
+            # Application label
+          - name: APP_LABEL
+            value: 'app=percona'
+
+            # Application label
+          - name: PROVIDER_STORAGE_CLASS
+            value: csi-app-target-affinity
+
+          - name: APP_PVC
+            value: percona-mysql-claim-csi-cstor
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-percona-ns
+
+            # Use 'deprovision' for app-clean up
+          - name: ACTION
+            value: provision
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/cstor-csi/app-target-affinity/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/experiments/functional/cstor-csi/app-target-affinity/test.yml
+++ b/experiments/functional/cstor-csi/app-target-affinity/test.yml
@@ -1,0 +1,114 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - block:
+
+            - name: Replace the application namespace placeholder with provider
+              replace:
+                path: "{{ affinity_policy }}"
+                regexp: "app-namespace"
+                replace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+            - name: Get the application label values from env
+              set_fact:
+                 app_key: "{{ app_label.split('=')[0] }}"
+                 application_label: "{{ app_label.split('=')[1] }}"                
+
+            - name: Replace the application label placeholder with provider
+              replace:
+                path: "{{ affinity_policy }}"
+                regexp: "app-label"
+                replace: "{{ application_label }}"                
+
+            - name: Deploying the applicstion target affinity volume policy
+              shell: kubectl apply -f "{{ affinity_policy }}"
+              args:
+                executable: /bin/bash
+
+            - name: Replace the pool name placeholder with provider
+              replace:
+                path: "{{ affinity_sc }}"
+                regexp: "pool-name"
+                replace: "{{ lookup('env','POOL_NAME') }}"
+           
+            - name: Replace the storage class name placeholder with provider
+              replace:
+                path: "{{ affinity_sc }}"
+                regexp: "testclass"
+                replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+            - name: Create the storage class for affinity policy
+              shell: kubectl apply -f "{{ affinity_sc }}"
+              args:
+                executable: /bin/bash
+
+            ## Actual test
+            ## Creating namespaces and making the application for deployment
+            - include_tasks: /utils/k8s/pre_create_app_deploy.yml
+
+            - name: Replace label name placeholder with provider
+              replace:
+                path: "{{ application_deployment }}"
+                regexp: "lvalue"
+                replace: "{{ app_lvalue }}"
+
+            ## Deploying the application, upper bound wait time: 900s 
+            - include_tasks: /utils/k8s/deploy_single_app.yml
+              vars:
+                check_app_pod: 'yes'
+                delay: 5 
+                retries: 180
+    
+            ## Fetching the pod name
+            - include_tasks: /utils/k8s/fetch_app_pod.yml
+    
+            ## Checking the db is ready for connection
+            - include_tasks: /utils/scm/applications/mysql/check_db_connection.yml
+   
+            ## Check application-target pod affinity
+            - include_tasks: /utils/scm/openebs/csi_target_affinity_check.yml
+
+            - set_fact:
+                flag: "Pass"  
+
+          when: "'deprovision' not in action"  
+
+        - block:
+
+            - name: Deprovisioning the Application
+              include_tasks: "/utils/k8s/deprovision_deployment.yml"
+              vars:
+                app_deployer: "{{ application_deployment }}"
+
+            - set_fact:
+                flag: "Pass"  
+
+          when: "'deprovision' is in action"        
+
+      rescue:
+        - set_fact:
+            flag: "Fail"     
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+              

--- a/experiments/functional/cstor-csi/app-target-affinity/test.yml
+++ b/experiments/functional/cstor-csi/app-target-affinity/test.yml
@@ -20,7 +20,7 @@
 
         - block:
 
-            - name: Replace the application namespace placeholder with provider
+            - name: Replace the application namespace placeholder in cstorvolumpolicy spec
               replace:
                 path: "{{ affinity_policy }}"
                 regexp: "app-namespace"
@@ -31,24 +31,24 @@
                  app_key: "{{ app_label.split('=')[0] }}"
                  application_label: "{{ app_label.split('=')[1] }}"                
 
-            - name: Replace the application label placeholder with provider
+            - name: Replace the application's label value placeholder in cstorvolumpolicy spec
               replace:
                 path: "{{ affinity_policy }}"
                 regexp: "app-label"
                 replace: "{{ application_label }}"                
 
-            - name: Deploying the applicstion target affinity volume policy
+            - name: Deploying the application target affinity volume policy
               shell: kubectl apply -f "{{ affinity_policy }}"
               args:
                 executable: /bin/bash
 
-            - name: Replace the pool name placeholder with provider
+            - name: Replace the pool name placeholder in storage class spec
               replace:
                 path: "{{ affinity_sc }}"
                 regexp: "pool-name"
                 replace: "{{ lookup('env','POOL_NAME') }}"
            
-            - name: Replace the storage class name placeholder with provider
+            - name: Replace the storage class name placeholder in storage class spec
               replace:
                 path: "{{ affinity_sc }}"
                 regexp: "testclass"
@@ -63,7 +63,7 @@
             ## Creating namespaces and making the application for deployment
             - include_tasks: /utils/k8s/pre_create_app_deploy.yml
 
-            - name: Replace label name placeholder with provider
+            - name: Replace label name placeholder in application spec
               replace:
                 path: "{{ application_deployment }}"
                 regexp: "lvalue"

--- a/experiments/functional/cstor-csi/app-target-affinity/test_vars.yml
+++ b/experiments/functional/cstor-csi/app-target-affinity/test_vars.yml
@@ -1,0 +1,12 @@
+# Test-specific parametres
+
+application_deployment: percona.yml
+affinity_policy: app-target-affinity-policy.yml
+affinity_sc: app-target-affinity-sc.yaml
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+operator_ns: 'openebs'
+app_label: "{{ lookup('env','APP_LABEL') }}"
+test_name: csi-app-target-affinity
+action: "{{ lookup('env','ACTION') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+pool_name: "{{ lookup('env','POOL_NAME') }}"

--- a/utils/scm/openebs/csi_target_affinity_check.yml
+++ b/utils/scm/openebs/csi_target_affinity_check.yml
@@ -70,7 +70,7 @@
     executable: /bin/bash
   register: new_app_node
 
-- name: Obtain the cstor csi target network name
+- name: Obtain the cstor csi target pod name
   shell: >
     kubectl get pods -n {{ operator_ns }}
     -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume=="{{ pv.stdout }}")].metadata.name}'

--- a/utils/scm/openebs/csi_target_affinity_check.yml
+++ b/utils/scm/openebs/csi_target_affinity_check.yml
@@ -27,3 +27,92 @@
   debug:
     msg: "App and Target affinity is maintained"
   failed_when: target_node.stdout != app_node.stdout
+
+- name: Obtain the application pod name
+  shell: >
+    kubectl get pods -l {{ app_label }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:.metadata.name
+  args:
+    executable: /bin/bash
+  register: app_pod_name
+
+- name: Restart the application pod
+  shell: >
+    kubectl delete pods -n {{ app_ns }} {{ app_pod_name.stdout }}
+  args:
+    executable: /bin/bash
+
+- name: Check if the Application pod got deleted
+  shell: >
+    kubectl get pods -l {{ app_label }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:.metadata.name
+  args:
+    executable: /bin/bash
+  register: new_app_pod_name
+  until: "app_pod_name.stdout not in new_app_pod_name.stdout"
+  delay: 10
+  retries: 30
+
+- name: Check if the application pod is in Running state
+  shell: >
+     kubectl get pods {{ new_app_pod_name.stdout }}
+     -n {{ app_ns }} -o custom-columns=:.status.phase --no-headers
+  args:
+    executable: /bin/bash
+  register: app_pod_status
+  until: "'Running' in app_pod_status.stdout"
+
+- name: Obtain node where app pod resides after restart
+  shell: >
+    kubectl get pods {{ new_app_pod_name.stdout }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:spec.nodeName
+  args:
+    executable: /bin/bash
+  register: new_app_node
+
+- name: Obtain the cstor csi target network name
+  shell: >
+    kubectl get pods -n {{ operator_ns }}
+    -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume=="{{ pv.stdout }}")].metadata.name}'
+  args:
+    executable: /bin/bash
+  register: target_name
+
+- name: Restart the csi target pod
+  shell: >
+    kubectl delete pods -n {{ operator_ns }} {{ target_name.stdout }}
+  args:
+    executable: /bin/bash
+
+- name: Check if the csi target pod got deleted
+  shell: >
+    kubectl get pods -n {{ operator_ns }}
+    -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume=="{{ pv.stdout }}")].metadata.name}'
+  args:
+    executable: /bin/bash
+  register: new_target_pod_name
+  until: "target_name.stdout not in new_target_pod_name.stdout"
+  delay: 10
+  retries: 30
+
+- name: Check if the target is in Running state
+  shell: >
+     kubectl get pods {{ new_target_pod_name.stdout }}
+     -n {{ operator_ns }} -o custom-columns=:.status.phase --no-headers
+  args:
+    executable: /bin/bash
+  register: target_pod_status
+  until: "'Running' in target_pod_status.stdout"
+
+- name: Obtain node where target pod resides after restart
+  shell: >
+    kubectl get pod -n {{ operator_ns }}
+    -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume=="{{ pv.stdout }}")].spec.nodeName}'
+  args:
+    executable: /bin/bash
+  register: new_target_node
+
+- name: Verify whether the app & target pod co-exist on same node
+  debug:
+    msg: "App and Target affinity is maintained"
+  failed_when: new_target_node.stdout != new_app_node.stdout

--- a/utils/scm/openebs/csi_target_affinity_check.yml
+++ b/utils/scm/openebs/csi_target_affinity_check.yml
@@ -1,0 +1,29 @@
+---
+- name: Obtain node where app pod resides
+  shell: >
+    kubectl get pods -l {{ app_label }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:spec.nodeName
+  args:
+    executable: /bin/bash
+  register: app_node
+
+- name: Derive PV from application PVC
+  shell: >
+    kubectl get pvc {{ app_pvc }}
+    -o custom-columns=:spec.volumeName -n {{ app_ns }} --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Obtain the node where PV target pod resides
+  shell: >
+    kubectl get pod -n {{ operator_ns }}
+    -o jsonpath='{.items[?(@.metadata.labels.openebs\.io\/persistent-volume=="{{ pv.stdout }}")].spec.nodeName}'
+  args:
+    executable: /bin/bash
+  register: target_node
+
+- name: Verify whether the app & target pod co-exist on same node
+  debug:
+    msg: "App and Target affinity is maintained"
+  failed_when: target_node.stdout != app_node.stdout


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>
- This test case is to verify the application pod and the cstor csi target pod are scheduled on the same node.
- in this test case first to create the cstor target affinity policy
- Create the storage class using the affinity policy and deploying the application.
**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
k8s@e2e1-master:~$ kubectl logs -f csi-cstor-app-target-affinity-hc655-d54kc -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2020-09-07T15:05:26.662433 (delta: 0.040411)         elapsed: 0.040411 ******** 
=============================================================================== 

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:26.671637 (delta: 0.009181)         elapsed: 0.049615 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-09-07T15:05:26.700820 (delta: 0.029153)         elapsed: 0.078798 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-09-07T15:05:26.730927 (delta: 0.029975)         elapsed: 0.108905 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:26.760998 (delta: 0.030026)         elapsed: 0.138976 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-09-07T15:05:26.835980 (delta: 0.074922)         elapsed: 0.213958 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2c4faaf352b3aee6c1fe3ddd6f6191673b121e5d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9967bb28ad75a0553c448434f4652f2a", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1599491126.87-130606262017449/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-09-07T15:05:27.313737 (delta: 0.477728)         elapsed: 0.691715 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.545381", "end": "2020-09-07 15:05:28.095603", "rc": 0, "start": "2020-09-07 15:05:27.550222", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-app-target-affinity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-app-target-affinity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-09-07T15:05:28.120178 (delta: 0.806407)         elapsed: 1.498156 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-09-07T09:49:38Z", "generation": 11, "name": "csi-app-target-affinity", "resourceVersion": "111465", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-app-target-affinity", "uid": "34c608cc-484b-41be-91be-2dfd9e906e85"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-09-07T15:05:29.044135 (delta: 0.923924)         elapsed: 2.422113 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-09-07T15:05:29.068682 (delta: 0.024514)         elapsed: 2.44666 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-09-07T15:05:29.099155 (delta: 0.03044)         elapsed: 2.477133 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the application namespace placeholder with provider] *************
2020-09-07T15:05:29.125627 (delta: 0.026436)         elapsed: 2.503605 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application label values from env] *******************************
2020-09-07T15:05:29.386917 (delta: 0.261258)         elapsed: 2.764895 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_key": "name", "application_label": "percona"}, "changed": false}

TASK [Replace the application label placeholder with provider] *****************
2020-09-07T15:05:29.448700 (delta: 0.061734)         elapsed: 2.826678 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploying the applicstion target affinity volume policy] *****************
2020-09-07T15:05:29.619390 (delta: 0.170634)         elapsed: 2.997368 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"app-target-affinity-policy.yml\"", "delta": "0:00:01.143937", "end": "2020-09-07 15:05:30.976086", "rc": 0, "start": "2020-09-07 15:05:29.832149", "stderr": "", "stderr_lines": [], "stdout": "cstorvolumepolicy.cstor.openebs.io/app-target-affinity-policy created", "stdout_lines": ["cstorvolumepolicy.cstor.openebs.io/app-target-affinity-policy created"]}

TASK [Replace the pool name placeholder with provider] *************************
2020-09-07T15:05:31.006858 (delta: 1.387396)         elapsed: 4.384836 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the storage class name placeholder with provider] ****************
2020-09-07T15:05:31.175721 (delta: 0.168821)         elapsed: 4.553699 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create the storage class for affinity policy] ****************************
2020-09-07T15:05:31.335899 (delta: 0.160013)         elapsed: 4.713877 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"app-target-affinity-sc.yaml\"", "delta": "0:00:00.745495", "end": "2020-09-07 15:05:32.247033", "rc": 0, "start": "2020-09-07 15:05:31.501538", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/csi-app-target-affinity-cstor-sc created", "stdout_lines": ["storageclass.storage.k8s.io/csi-app-target-affinity-cstor-sc created"]}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:32.279029 (delta: 0.943046)         elapsed: 5.657007 ******** 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2020-09-07T15:05:32.340873 (delta: 0.061806)         elapsed: 5.718851 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc \"csi-app-target-affinity-cstor-sc\"", "delta": "0:00:00.654206", "end": "2020-09-07 15:05:33.139113", "failed_when_result": false, "rc": 0, "start": "2020-09-07 15:05:32.484907", "stderr": "", "stderr_lines": [], "stdout": "NAME                               PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE\ncsi-app-target-affinity-cstor-sc   cstor.csi.openebs.io   Delete          Immediate           true                   1s", "stdout_lines": ["NAME                               PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE", "csi-app-target-affinity-cstor-sc   cstor.csi.openebs.io   Delete          Immediate           true                   1s"]}

TASK [Replace the pvc placeholder with provider] *******************************
2020-09-07T15:05:33.172312 (delta: 0.831387)         elapsed: 6.55029 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2020-09-07T15:05:33.331649 (delta: 0.159297)         elapsed: 6.709627 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:33.499708 (delta: 0.168021)         elapsed: 6.877686 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2020-09-07T15:05:33.531111 (delta: 0.031372)         elapsed: 6.909089 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "percona"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2020-09-07T15:05:33.586194 (delta: 0.055042)         elapsed: 6.964172 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2020-09-07T15:05:33.760002 (delta: 0.173774)         elapsed: 7.13798 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:33.814755 (delta: 0.05472)         elapsed: 7.192733 ********* 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2020-09-07T15:05:33.860529 (delta: 0.045718)         elapsed: 7.238507 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.905015", "end": "2020-09-07 15:05:34.901895", "rc": 0, "start": "2020-09-07 15:05:33.996880", "stderr": "", "stderr_lines": [], "stdout": "app-percona-aff\napp-percona-csi\napp-percona-cstor\napp-percona-ns\napp-percona-test\ndefault\nkube-node-lease\nkube-public\nkube-system\nlitmus\nopenebs", "stdout_lines": ["app-percona-aff", "app-percona-csi", "app-percona-cstor", "app-percona-ns", "app-percona-test", "default", "kube-node-lease", "kube-public", "kube-system", "litmus", "openebs"]}

TASK [Create test specific namespace.] *****************************************
2020-09-07T15:05:34.946334 (delta: 1.085647)         elapsed: 8.324312 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-percona", "delta": "0:00:00.660450", "end": "2020-09-07 15:05:35.787158", "rc": 0, "start": "2020-09-07 15:05:35.126708", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-percona created", "stdout_lines": ["namespace/app-percona created"]}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:35.819210 (delta: 0.872828)         elapsed: 9.197188 ******** 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2020-09-07T15:05:35.866300 (delta: 0.047015)         elapsed: 9.244278 ******** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2020-09-07T15:05:35Z", "name": "app-percona", "resourceVersion": "111517", "selfLink": "/api/v1/namespaces/app-percona", "uid": "ac068991-1bfe-4fba-90e5-897bd2b53e96"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [Replace label name placeholder with provider] ****************************
2020-09-07T15:05:36.645361 (delta: 0.778873)         elapsed: 10.023339 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:36.802878 (delta: 0.157345)         elapsed: 10.180856 ******* 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying {{ application_name }}] ****************************************
2020-09-07T15:05:36.857034 (delta: 0.05398)         elapsed: 10.235012 ******** 
changed: [127.0.0.1] => {"changed": true, "result": {"results": [{"changed": true, "method": "create", "result": {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"creationTimestamp": "2020-09-07T15:05:37Z", "generation": 1, "labels": {"name": "percona"}, "name": "percona", "namespace": "app-percona", "resourceVersion": "111528", "selfLink": "/apis/apps/v1/namespaces/app-percona/deployments/percona", "uid": "aa50573a-e8d1-4240-bdf3-8aad9cc9a3f4"}, "spec": {"progressDeadlineSeconds": 600, "replicas": 1, "revisionHistoryLimit": 10, "selector": {"matchLabels": {"name": "percona", "openebs.io/target-affinity": "percona"}}, "strategy": {"rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"}, "type": "RollingUpdate"}, "template": {"metadata": {"creationTimestamp": null, "labels": {"name": "percona", "openebs.io/target-affinity": "percona"}}, "spec": {"containers": [{"args": ["--ignore-db-dir", "lost+found"], "env": [{"name": "MYSQL_ROOT_PASSWORD", "value": "k8sDem0"}], "image": "openebs/tests-custom-percona:latest", "imagePullPolicy": "IfNotPresent", "livenessProbe": {"exec": {"command": ["bash", "sql-test.sh"]}, "failureThreshold": 3, "initialDelaySeconds": 60, "periodSeconds": 1, "successThreshold": 1, "timeoutSeconds": 10}, "name": "percona", "ports": [{"containerPort": 3306, "name": "percona", "protocol": "TCP"}], "resources": {"limits": {"cpu": "500m"}}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/var/lib/mysql", "name": "data-vol"}]}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "terminationGracePeriodSeconds": 30, "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "percona-mysql-claim-csi-cstor"}}]}}}, "status": {}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"creationTimestamp": "2020-09-07T15:05:37Z", "finalizers": ["kubernetes.io/pvc-protection"], "name": "percona-mysql-claim-csi-cstor", "namespace": "app-percona", "resourceVersion": "111541", "selfLink": "/api/v1/namespaces/app-percona/persistentvolumeclaims/percona-mysql-claim-csi-cstor", "uid": "e206e80b-0765-4c39-8aff-1ee69b069ccf"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "5Gi"}}, "storageClassName": "csi-app-target-affinity-cstor-sc", "volumeMode": "Filesystem"}, "status": {"phase": "Pending"}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "Service", "metadata": {"creationTimestamp": "2020-09-07T15:05:37Z", "labels": {"name": "percona"}, "name": "percona-mysql", "namespace": "app-percona", "resourceVersion": "111546", "selfLink": "/api/v1/namespaces/app-percona/services/percona-mysql", "uid": "e7361014-9c1b-4475-bf72-1c9b346405ef"}, "spec": {"clusterIP": "10.105.145.36", "ports": [{"port": 3306, "protocol": "TCP", "targetPort": 3306}], "selector": {"name": "percona"}, "sessionAffinity": "None", "type": "ClusterIP"}, "status": {"loadBalancer": {}}}}]}}

TASK [include_tasks] ***********************************************************
2020-09-07T15:05:37.600783 (delta: 0.743716)         elapsed: 10.978761 ******* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2020-09-07T15:05:37.665020 (delta: 0.064201)         elapsed: 11.042998 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
changed: [127.0.0.1] => {"attempts": 17, "changed": true, "cmd": "kubectl get pod -n app-percona -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.816014", "end": "2020-09-07 15:06:23.942532", "rc": 0, "start": "2020-09-07 15:06:23.126518", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-09-07T15:06:21Z]]", "stdout_lines": ["map[running:map[startedAt:2020-09-07T15:06:21Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
2020-09-07T15:06:23.977722 (delta: 46.312668)         elapsed: 57.3557 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.675021", "end": "2020-09-07 15:06:24.803302", "rc": 0, "start": "2020-09-07 15:06:24.128281", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
2020-09-07T15:06:24.840524 (delta: 0.862746)         elapsed: 58.218502 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-09-07T15:06:24.878414 (delta: 0.037842)         elapsed: 58.256392 ******* 
included: /utils/k8s/fetch_app_pod.yml for 127.0.0.1

TASK [Getting the {{ application_name }} POD name] *****************************
2020-09-07T15:06:24.941642 (delta: 0.063173)         elapsed: 58.31962 ******** 
ok: [127.0.0.1] => {"changed": false, "resources": [{"apiVersion": "v1", "kind": "Pod", "metadata": {"annotations": {"cni.projectcalico.org/podIP": "192.168.204.210/32"}, "creationTimestamp": "2020-09-07T15:05:37Z", "generateName": "percona-7c7655c4bb-", "labels": {"name": "percona", "openebs.io/target-affinity": "percona", "pod-template-hash": "7c7655c4bb"}, "name": "percona-7c7655c4bb-xlqvb", "namespace": "app-percona", "ownerReferences": [{"apiVersion": "apps/v1", "blockOwnerDeletion": true, "controller": true, "kind": "ReplicaSet", "name": "percona-7c7655c4bb", "uid": "aad53a35-83de-4686-8947-493a331d46c2"}], "resourceVersion": "111875", "selfLink": "/api/v1/namespaces/app-percona/pods/percona-7c7655c4bb-xlqvb", "uid": "bb6258e0-15b7-4c3c-ae41-5e7fc299662e"}, "spec": {"containers": [{"args": ["--ignore-db-dir", "lost+found"], "env": [{"name": "MYSQL_ROOT_PASSWORD", "value": "k8sDem0"}], "image": "openebs/tests-custom-percona:latest", "imagePullPolicy": "IfNotPresent", "livenessProbe": {"exec": {"command": ["bash", "sql-test.sh"]}, "failureThreshold": 3, "initialDelaySeconds": 60, "periodSeconds": 1, "successThreshold": 1, "timeoutSeconds": 10}, "name": "percona", "ports": [{"containerPort": 3306, "name": "percona", "protocol": "TCP"}], "resources": {"limits": {"cpu": "500m"}, "requests": {"cpu": "500m"}}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/var/lib/mysql", "name": "data-vol"}, {"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount", "name": "default-token-jxmd4", "readOnly": true}]}], "dnsPolicy": "ClusterFirst", "enableServiceLinks": true, "nodeName": "e2e1-node1", "priority": 0, "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "serviceAccount": "default", "serviceAccountName": "default", "terminationGracePeriodSeconds": 30, "tolerations": [{"effect": "NoExecute", "key": "node.kubernetes.io/not-ready", "operator": "Exists", "tolerationSeconds": 300}, {"effect": "NoExecute", "key": "node.kubernetes.io/unreachable", "operator": "Exists", "tolerationSeconds": 300}], "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "percona-mysql-claim-csi-cstor"}}, {"name": "default-token-jxmd4", "secret": {"defaultMode": 420, "secretName": "default-token-jxmd4"}}]}, "status": {"conditions": [{"lastProbeTime": null, "lastTransitionTime": "2020-09-07T15:05:39Z", "status": "True", "type": "Initialized"}, {"lastProbeTime": null, "lastTransitionTime": "2020-09-07T15:06:22Z", "status": "True", "type": "Ready"}, {"lastProbeTime": null, "lastTransitionTime": "2020-09-07T15:06:22Z", "status": "True", "type": "ContainersReady"}, {"lastProbeTime": null, "lastTransitionTime": "2020-09-07T15:05:39Z", "status": "True", "type": "PodScheduled"}], "containerStatuses": [{"containerID": "docker://218bb7a19e170519ff6df200f92fc1a63c0b4976e2a5bb47326df14487c8a8d0", "image": "openebs/tests-custom-percona:latest", "imageID": "docker-pullable://openebs/tests-custom-percona@sha256:17fa3de8c5cef79695960f25ee06b9de69ddf2bf50d553afa151076c3cd59e1e", "lastState": {}, "name": "percona", "ready": true, "restartCount": 0, "started": true, "state": {"running": {"startedAt": "2020-09-07T15:06:21Z"}}}], "hostIP": "10.34.1.231", "phase": "Running", "podIP": "192.168.204.210", "podIPs": [{"ip": "192.168.204.210"}], "qosClass": "Burstable", "startTime": "2020-09-07T15:05:39Z"}}]}

TASK [debug] *******************************************************************
2020-09-07T15:06:25.718403 (delta: 0.776709)         elapsed: 59.096381 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "percona-7c7655c4bb-xlqvb"
    ]
}

TASK [include_tasks] ***********************************************************
2020-09-07T15:06:25.791580 (delta: 0.073142)         elapsed: 59.169558 ******* 
included: /utils/scm/applications/mysql/check_db_connection.yml for 127.0.0.1

TASK [Check if db is ready for connections] ************************************
2020-09-07T15:06:25.871434 (delta: 0.079658)         elapsed: 59.249412 ******* 
FAILED - RETRYING: Check if db is ready for connections (180 retries left).
FAILED - RETRYING: Check if db is ready for connections (179 retries left).
FAILED - RETRYING: Check if db is ready for connections (178 retries left).
FAILED - RETRYING: Check if db is ready for connections (177 retries left).
FAILED - RETRYING: Check if db is ready for connections (176 retries left).
FAILED - RETRYING: Check if db is ready for connections (175 retries left).
changed: [127.0.0.1] => {"attempts": 7, "changed": true, "cmd": "kubectl logs percona-7c7655c4bb-xlqvb -n app-percona | grep 'ready for connections' | wc -l", "delta": "0:00:00.813681", "end": "2020-09-07 15:07:02.180124", "rc": 0, "start": "2020-09-07 15:07:01.366443", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [include_tasks] ***********************************************************
2020-09-07T15:07:02.207470 (delta: 36.335732)         elapsed: 95.585448 ****** 
included: /utils/scm/openebs/csi_target_affinity_check.yml for 127.0.0.1

TASK [Obtain node where app pod resides] ***************************************
2020-09-07T15:07:02.259621 (delta: 0.052118)         elapsed: 95.637599 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l name=percona -n app-percona --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.774456", "end": "2020-09-07 15:07:03.167620", "rc": 0, "start": "2020-09-07 15:07:02.393164", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1", "stdout_lines": ["e2e1-node1"]}

TASK [Derive PV from application PVC] ******************************************
2020-09-07T15:07:03.197866 (delta: 0.93821)         elapsed: 96.575844 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim-csi-cstor -o custom-columns=:spec.volumeName -n app-percona --no-headers", "delta": "0:00:00.674075", "end": "2020-09-07 15:07:04.013081", "rc": 0, "start": "2020-09-07 15:07:03.339006", "stderr": "", "stderr_lines": [], "stdout": "pvc-e206e80b-0765-4c39-8aff-1ee69b069ccf", "stdout_lines": ["pvc-e206e80b-0765-4c39-8aff-1ee69b069ccf"]}

TASK [Obtain the node where PV target pod resides] *****************************
2020-09-07T15:07:04.039340 (delta: 0.841422)         elapsed: 97.417318 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n openebs -o jsonpath='{.items[?(@.metadata.labels.openebs\\.io\\/persistent-volume==\"pvc-e206e80b-0765-4c39-8aff-1ee69b069ccf\")].spec.nodeName}'", "delta": "0:00:00.917768", "end": "2020-09-07 15:07:05.105200", "rc": 0, "start": "2020-09-07 15:07:04.187432", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1", "stdout_lines": ["e2e1-node1"]}

TASK [Verify whether the app & target pod co-exist on same node] ***************
2020-09-07T15:07:05.134253 (delta: 1.094878)         elapsed: 98.512231 ******* 
ok: [127.0.0.1] => {
    "msg": "App and Target affinity is maintained"
}

TASK [set_fact] ****************************************************************
2020-09-07T15:07:05.199743 (delta: 0.065454)         elapsed: 98.577721 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning the Application] ******************************************
2020-09-07T15:07:05.252918 (delta: 0.05314)         elapsed: 98.630896 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-09-07T15:07:05.283556 (delta: 0.030604)         elapsed: 98.661534 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-09-07T15:07:05.323144 (delta: 0.039555)         elapsed: 98.701122 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-09-07T15:07:05.360943 (delta: 0.037761)         elapsed: 98.738921 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-09-07T15:07:05.386916 (delta: 0.025927)         elapsed: 98.764894 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-09-07T15:07:05.411224 (delta: 0.024261)         elapsed: 98.789202 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-09-07T15:07:05.441513 (delta: 0.030259)         elapsed: 98.819491 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "bd060fcce1ada85537a6a043ce4f84600513051e", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "74ea426989a4ab355edcd4ecdb70466e", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1599491225.48-196340865595428/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-09-07T15:07:06.802549 (delta: 1.361005)         elapsed: 100.180527 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.516458", "end": "2020-09-07 15:07:07.443541", "rc": 0, "start": "2020-09-07 15:07:06.927083", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: csi-app-target-affinity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: csi-app-target-affinity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-09-07T15:07:07.471053 (delta: 0.668474)         elapsed: 100.849031 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-09-07T09:49:38Z", "generation": 12, "name": "csi-app-target-affinity", "resourceVersion": "112117", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/csi-app-target-affinity", "uid": "34c608cc-484b-41be-91be-2dfd9e906e85"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=44   changed=26   unreachable=0    failed=0   

2020-09-07T15:07:08.116548 (delta: 0.645462)         elapsed: 101.494526 ****** 
=============================================================================== 
```
