### PR TITLE
refact(yaml): removed the os dependecy to download the zfs-operator file

### DIFF
--- a/experiments/zfs-localpv/zfs-localpv-provisioner/run_litmus_test.yml
+++ b/experiments/zfs-localpv/zfs-localpv-provisioner/run_litmus_test.yml
@@ -34,13 +34,6 @@ spec:
           - name: ZFS_DRIVER_IMAGE
             value: ''
 
-            ## This env will be used to select zfs-operator file for 
-            ## specific Operating system on which k8s cluster is created
-            ## For ubuntu based cluster give value as `ubuntu` (for both either 18.04 or 16.04)
-            ## For CentOS based cluster give value as either `centos7` or `centos8` accordingly
-          - name: OS_NAME  
-            value: ''  
-
             ## If zpool need to be created on each worker node set this value as `true`
             ## If already present and no need of zpool creation then set this value as `false`
             ## If false then leave `POOL_NAME` & `POOL_TYPE` env values empty.

--- a/experiments/zfs-localpv/zfs-localpv-provisioner/test.yml
+++ b/experiments/zfs-localpv/zfs-localpv-provisioner/test.yml
@@ -24,39 +24,16 @@
             include_tasks: /utils/zpool_creation/create_zpool.yml
             when: lookup('env','ZPOOL_CREATION') == 'true'
         
-          - name: Download OpenEBS ZFS driver file when OS is ubuntu
+          - name: Download OpenEBS ZFS-LocalPV operator file
             get_url:
               url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ zfs_branch }}/deploy/zfs-operator.yaml
               dest: ./zfs_operator.yml
               force: yes
             register: result
-            when: lookup('env','OS_NAME') == 'ubuntu'
             until: "'OK' in result.msg"
             delay: 5
             retries: 3
-
-          - name: Download OpenEBS ZFS driver file when OS is CentOS7
-            get_url:
-              url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ zfs_branch }}/deploy/operators/centos7/zfs-operator.yaml
-              dest: ./zfs_operator.yml
-              force: yes
-            register: result
-            when: lookup('env','OS_NAME') == 'centos7'
-            until: "'OK' in result.msg"
-            delay: 5
-            retries: 3
-
-          - name: Download OpenEBS ZFS driver file when OS is CentOS8
-            get_url:
-              url: https://raw.githubusercontent.com/openebs/zfs-localpv/{{ zfs_branch }}/deploy/operators/centos8/zfs-operator.yaml
-              dest: ./zfs_operator.yml
-              force: yes
-            register: result
-            when: lookup('env','OS_NAME') == 'centos8'
-            until: "'OK' in result.msg"
-            delay: 5
-            retries: 3
-    
+   
           - name: Update the openebs zfs-driver image tag
             replace:
               path: ./zfs_operator.yml


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR removes the OS dependency to download the zfs-operator file. Before zfs-operator file is different different for ubuntu and centos. After this PR https://github.com/openebs/zfs-localpv/pull/204 we are good to download the zfs-operator file from single place [here](https://github.com/openebs/zfs-localpv/blob/master/deploy/zfs-operator.yaml) for either ubuntu or centos.