### PR TITLE
refactor(upgrade): Modified the image name for openebs upgrade jobs

### DIFF
--- a/providers/openebs/bulk-upgrade/cstor-spc-upgrade-job.j2
+++ b/providers/openebs/bulk-upgrade/cstor-spc-upgrade-job.j2
@@ -22,6 +22,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         tty: true
-        image: quay.io/openebs/m-upgrade:{{ image_tag }}
+        image: openebs/m-upgrade:{{ image_tag }}
       restartPolicy: OnFailure
 ---

--- a/providers/openebs/bulk-upgrade/cstor-volume-upgrade-job.j2
+++ b/providers/openebs/bulk-upgrade/cstor-volume-upgrade-job.j2
@@ -22,6 +22,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         tty: true
-        image: quay.io/openebs/m-upgrade:{{ image_tag }}
+        image: openebs/m-upgrade:{{ image_tag }}
       restartPolicy: OnFailure
 ---

--- a/providers/openebs/bulk-upgrade/jiva-volume-upgrade-job.j2
+++ b/providers/openebs/bulk-upgrade/jiva-volume-upgrade-job.j2
@@ -22,6 +22,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         tty: true 
-        image: quay.io/openebs/m-upgrade:{{ image_tag }}
+        image: openebs/m-upgrade:{{ image_tag }}
       restartPolicy: OnFailure
 ---

--- a/providers/openebs/installers/operator/openebs-provision/test.yml
+++ b/providers/openebs/installers/operator/openebs-provision/test.yml
@@ -43,39 +43,54 @@
 
                 - block:
 
-                    - name: Downloading openebs-operator.yaml
+                    - name: Downloading openebs-operator from charts
                       get_url:
-                        url: "{{ openebs_operator_link }}"
+                        url: "{{ new_operator_link }}"
                         dest: "{{ playbook_dir }}/{{ openebs_operator }}"
                         force: yes
-                      register: result
-                      until:  "'OK' in result.msg"
+                      register: new_operator
+                      ignore_errors: true
+                      until:  "'OK' in new_operator.msg"
                       delay: 5
                       retries: 3
 
-                    - name: Change the Node Disk manager Image
-                      replace:
-                        path: "{{ openebs_operator }}"
-                        regexp: openebs/node-disk-manager:ci
-                        replace: openebs/node-disk-manager:{{ ndm_tag }}
+                    - block: 
 
-                    - name: Change the Node Disk operator Image
-                      replace:
-                        path: "{{ openebs_operator }}"
-                        regexp: openebs/node-disk-operator:ci
-                        replace: openebs/node-disk-operator:{{ ndm_tag }}
+                        - name: Downloading openebs-operator.yaml
+                          get_url:
+                            url: "{{ openebs_operator_link }}"
+                            dest: "{{ playbook_dir }}/{{ openebs_operator }}"
+                            force: yes
+                          register: result
+                          until:  "'OK' in result.msg"
+                          delay: 5
+                          retries: 3
 
-                    - name: Change the OpenEBS component labels to desired version in Operator yaml
-                      replace:
-                        path: "{{ openebs_operator }}"
-                        regexp: 'openebs.io/version: dev'
-                        replace: "openebs.io/version: {{ release_version }}"
+                        - name: Change the Node Disk manager Image
+                          replace:
+                            path: "{{ openebs_operator }}"
+                            regexp: openebs/node-disk-manager:ci
+                            replace: openebs/node-disk-manager:{{ ndm_tag }}
 
-                    - name: Change the Image tag to newer version in operator yaml
-                      replace:
-                        path: "{{ openebs_operator }}"
-                        regexp: ':ci'
-                        replace: ":{{ release_version }}"
+                        - name: Change the Node Disk operator Image
+                          replace:
+                            path: "{{ openebs_operator }}"
+                            regexp: openebs/node-disk-operator:ci
+                            replace: openebs/node-disk-operator:{{ ndm_tag }}
+
+                        - name: Change the OpenEBS component labels to desired version in Operator yaml
+                          replace:
+                            path: "{{ openebs_operator }}"
+                            regexp: 'openebs.io/version: dev'
+                            replace: "openebs.io/version: {{ release_version }}"
+
+                        - name: Change the Image tag to newer version in operator yaml
+                          replace:
+                            path: "{{ openebs_operator }}"
+                            regexp: ':ci'
+                            replace: ":{{ release_version }}"
+
+                      when: "'OK' not in new_operator.msg"
 
                   when: "'OK' not in operator_file.msg"
 

--- a/providers/openebs/installers/operator/openebs-provision/test_vars.yml
+++ b/providers/openebs/installers/operator/openebs-provision/test_vars.yml
@@ -1,6 +1,7 @@
 kubeapply: kubectl --kubeconfig /root/admin.conf
 openebs_operator_link: "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"
 openebs_link: "https://openebs.github.io/charts/openebs-operator-{{ lookup('env','RELEASE_VERSION') }}.yaml"
+new_operator_link: "https://openebs.github.io/charts/{{ lookup('env','RELEASE_VERSION') }}/openebs-operator.yaml"
 openebs_operator: openebs-operator.yaml
 psp_spec: openebs_psp.yaml
 test_name: openebs-provision


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- changed the image tags for openebs upgrade jobs
- Included a task to get the new operators from charts in openebs provision

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
