### PR TITLE
refactor(script): Add retry in snapshot verify task in cstor csi snapshot test

### DIFF
--- a/experiments/functional/cstor-csi/csi-snapshot/test.yml
+++ b/experiments/functional/cstor-csi/csi-snapshot/test.yml
@@ -107,7 +107,9 @@
               args:
                 executable: /bin/bash
               register: snap
-              failed_when: "snap.stdout == ''"
+              until: "snap.stdout != ''"
+              retries: 5
+              delay: 10
               with_items:
                 - "{{ pool_pods.results }}"
 


### PR DESCRIPTION

Signed-off-by: <ranjanshashank855@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Resolves fleaky test (ref: https://gitlab.openebs.ci/openebs/e2e-konvoy/-/jobs/268282) by adding reties in snapshot verify task. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
- Following is the log of ansible test container: https://gist.github.com/shashank855/644805361cfa7d77e14a905dd3846a31