### PR TITLE
refactor(pool-delete): Modified the task to check the cvr status before deleting the pool

### DIFF
--- a/providers/cstor/cstor-cspc-pool/test.yml
+++ b/providers/cstor/cstor-cspc-pool/test.yml
@@ -194,8 +194,10 @@
                 executable: /bin/bash
               register: cspi_rep_status
               with_items: "{{ cspi_list.stdout_lines }}"
-              failed_when: "cspi_rep_status.stdout != '0'"
-               
+              until: "'0' in cspi_rep_status.stdout "
+              retries: 30
+              delay: 10
+                            
             - name: Remove the CStor Pool Cluster
               shell: >
                 kubectl delete cspc {{ pool_name }} -n {{ operator_ns }}


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the task to check the volume replica status instead of failing the task wait until the replica count become '0'

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
k8s@e2e1-master:~$ kubectl logs -f cstor-cspc-pool-provision-d54kc-xlqvb -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2020-10-07T15:17:52.035496 (delta: 0.044396)         elapsed: 0.044396 ******** 
=============================================================================== 

TASK [include_tasks] ***********************************************************
2020-10-07T15:17:52.045858 (delta: 0.010335)         elapsed: 0.054758 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-10-07T15:17:52.124573 (delta: 0.078536)         elapsed: 0.133473 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-10-07T15:17:52.252346 (delta: 0.127745)         elapsed: 0.261246 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-10-07T15:17:52.336100 (delta: 0.083707)         elapsed: 0.345 *********** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-10-07T15:17:52.420501 (delta: 0.084367)         elapsed: 0.429401 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "035bacdb4b1fd8992a7683879a3fea2b885ee8ef", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "723a8fdf57f6efa3378c103e9eb54b09", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1602083872.46-21154223717767/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-10-07T15:17:52.900852 (delta: 0.480318)         elapsed: 0.909752 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.611777", "end": "2020-10-07 15:17:53.762304", "rc": 0, "start": "2020-10-07 15:17:53.150527", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-10-07T15:17:53.789020 (delta: 0.888103)         elapsed: 1.79792 ********* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-10-07T13:42:48Z", "generation": 9, "name": "cstor-pool-provision", "resourceVersion": "45737", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "954a89f0-58a5-41b0-a7e6-784f4d05fcf4"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-10-07T15:17:54.757414 (delta: 0.96835)         elapsed: 2.766314 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-10-07T15:17:54.812275 (delta: 0.046651)         elapsed: 2.821175 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-10-07T15:17:54.848517 (delta: 0.036191)         elapsed: 2.857417 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the compute node name] *******************************************
2020-10-07T15:17:54.884275 (delta: 0.03572)         elapsed: 2.893175 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v master | awk {'print $1'} | head -3", "delta": "0:00:00.819064", "end": "2020-10-07 15:17:55.929638", "failed_when_result": false, "rc": 0, "start": "2020-10-07 15:17:55.110574", "stderr": "", "stderr_lines": [], "stdout": "e2e1-node1\ne2e1-node2\ne2e1-node3", "stdout_lines": ["e2e1-node1", "e2e1-node2", "e2e1-node3"]}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
2020-10-07T15:17:55.965401 (delta: 1.081075)         elapsed: 3.974301 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:00.752548", "end": "2020-10-07 15:17:56.864918", "failed_when_result": false, "rc": 0, "start": "2020-10-07 15:17:56.112370", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set the value for the disk count to fetch the unclaimed blockDevice from each node] ***
2020-10-07T15:17:56.898499 (delta: 0.933036)         elapsed: 4.907399 ******** 
skipping: [127.0.0.1] => (item={'key': u'raidz2', 'value': {u'count': 6}})  => {"changed": false, "item": {"key": "raidz2", "value": {"count": 6}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'mirror', 'value': {u'count': 2}})  => {"changed": false, "item": {"key": "mirror", "value": {"count": 2}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'stripe', 'value': {u'count': 1}})  => {"changed": false, "item": {"key": "stripe", "value": {"count": 1}}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={'key': u'raidz', 'value': {u'count': 3}})  => {"changed": false, "item": {"key": "raidz", "value": {"count": 3}}, "skip_reason": "Conditional result was False"}

TASK [Add node labels for each nodes and create blockdevice template] **********
2020-10-07T15:17:56.973220 (delta: 0.074682)         elapsed: 4.98212 ********* 
skipping: [127.0.0.1] => (item=[u'e2e1-node1'])  => {"changed": false, "item": ["e2e1-node1"], "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=[u'e2e1-node2'])  => {"changed": false, "item": ["e2e1-node2"], "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=[u'e2e1-node3'])  => {"changed": false, "item": ["e2e1-node3"], "skip_reason": "Conditional result was False"}

TASK [Getting the Unclaimed block-device count] ********************************
2020-10-07T15:17:57.033570 (delta: 0.060311)         elapsed: 5.04247 ********* 
skipping: [127.0.0.1] => (item=e2e1-node1)  => {"changed": false, "item": "e2e1-node1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node2)  => {"changed": false, "item": "e2e1-node2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node3)  => {"changed": false, "item": "e2e1-node3", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-10-07T15:17:57.095785 (delta: 0.062175)         elapsed: 5.104685 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Add the block devices for each node's block device template] *************
2020-10-07T15:17:57.129185 (delta: 0.033337)         elapsed: 5.138085 ******** 
skipping: [127.0.0.1] => (item=e2e1-node1)  => {"changed": false, "outer_item": "e2e1-node1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node2)  => {"changed": false, "outer_item": "e2e1-node2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node3)  => {"changed": false, "outer_item": "e2e1-node3", "skip_reason": "Conditional result was False"}

TASK [Include the blockdevice template in the CSPC spec] ***********************
2020-10-07T15:17:57.202644 (delta: 0.073422)         elapsed: 5.211544 ******** 
skipping: [127.0.0.1] => (item=e2e1-node1)  => {"changed": false, "item": "e2e1-node1", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node2)  => {"changed": false, "item": "e2e1-node2", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=e2e1-node3)  => {"changed": false, "item": "e2e1-node3", "skip_reason": "Conditional result was False"}

TASK [Replacing the pool name in CSPC spec] ************************************
2020-10-07T15:17:57.275872 (delta: 0.073178)         elapsed: 5.284772 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the namespace in CSPC spec] ************************************
2020-10-07T15:17:57.328452 (delta: 0.052543)         elapsed: 5.337352 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the pool type in CSPC spec] ************************************
2020-10-07T15:17:57.381491 (delta: 0.053005)         elapsed: 5.390391 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replacing the storage class name in CSPC spec] ***************************
2020-10-07T15:17:57.421163 (delta: 0.039634)         elapsed: 5.430063 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display cspc.yml for verification] ***************************************
2020-10-07T15:17:57.486252 (delta: 0.065051)         elapsed: 5.495152 ******** 
skipping: [127.0.0.1] => (item=apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: pool-name
  namespace: operator_ns
spec:
  pools:


---
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: sc-name
  annotations:
    openebs.io/cas-type: cstor
provisioner: cstor.csi.openebs.io
allowVolumeExpansion: true
parameters:
  replicaCount: "3"
  cas-type: cstor
  cstorPoolCluster: pool-name)  => {"item": "apiVersion: cstor.openebs.io/v1\nkind: CStorPoolCluster\nmetadata:\n  name: pool-name\n  namespace: operator_ns\nspec:\n  pools:\n\n\n---\nkind: StorageClass\napiVersion: storage.k8s.io/v1\nmetadata:\n  name: sc-name\n  annotations:\n    openebs.io/cas-type: cstor\nprovisioner: cstor.csi.openebs.io\nallowVolumeExpansion: true\nparameters:\n  replicaCount: \"3\"\n  cas-type: cstor\n  cstorPoolCluster: pool-name"}
skipping: [127.0.0.1] => {"msg": "All items completed"}

TASK [Create cstor disk pool] **************************************************
2020-10-07T15:17:57.532983 (delta: 0.046695)         elapsed: 5.541883 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether cspc is created] *******************************************
2020-10-07T15:17:57.569330 (delta: 0.036308)         elapsed: 5.57823 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the status of CSPI] ***********************************************
2020-10-07T15:17:57.605713 (delta: 0.036344)         elapsed: 5.614613 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the CSPI name to verify the status] *******************************
2020-10-07T15:17:57.645655 (delta: 0.039901)         elapsed: 5.654555 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the cStor Pool pods are Running] *******************************
2020-10-07T15:17:57.679095 (delta: 0.033402)         elapsed: 5.687995 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get cStor Pool pod names to verify the container statuses and check the required number of pools created.] ***
2020-10-07T15:17:57.718283 (delta: 0.039151)         elapsed: 5.727183 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the runningStatus of pool pod] ***************************************
2020-10-07T15:17:57.753583 (delta: 0.035266)         elapsed: 5.762483 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the storage class is created] ***********************************
2020-10-07T15:17:57.788920 (delta: 0.035282)         elapsed: 5.79782 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the CSPI list to verify the existence of replicas] ****************
2020-10-07T15:17:57.819379 (delta: 0.030423)         elapsed: 5.828279 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:00.762567", "end": "2020-10-07 15:17:58.726560", "rc": 0, "start": "2020-10-07 15:17:57.963993", "stderr": "", "stderr_lines": [], "stdout": "cstor-cspc-disk-pool-5kt8\ncstor-cspc-disk-pool-7bjr\ncstor-cspc-disk-pool-cflp", "stdout_lines": ["cstor-cspc-disk-pool-5kt8", "cstor-cspc-disk-pool-7bjr", "cstor-cspc-disk-pool-cflp"]}

TASK [Verify if the replicas are removed] **************************************
2020-10-07T15:17:58.757199 (delta: 0.937771)         elapsed: 6.766099 ******** 
FAILED - RETRYING: Verify if the replicas are removed (30 retries left).
FAILED - RETRYING: Verify if the replicas are removed (29 retries left).
FAILED - RETRYING: Verify if the replicas are removed (28 retries left).
FAILED - RETRYING: Verify if the replicas are removed (27 retries left).
FAILED - RETRYING: Verify if the replicas are removed (26 retries left).
FAILED - RETRYING: Verify if the replicas are removed (25 retries left).
FAILED - RETRYING: Verify if the replicas are removed (24 retries left).
FAILED - RETRYING: Verify if the replicas are removed (23 retries left).
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-5kt8) => {"attempts": 9, "changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-5kt8 -o custom-columns=:.status.provisionedReplicas --no-headers", "delta": "0:00:01.132856", "end": "2020-10-07 15:19:27.369103", "item": "cstor-cspc-disk-pool-5kt8", "rc": 0, "start": "2020-10-07 15:19:26.236247", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-7bjr) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-7bjr -o custom-columns=:.status.provisionedReplicas --no-headers", "delta": "0:00:00.809067", "end": "2020-10-07 15:19:28.427187", "item": "cstor-cspc-disk-pool-7bjr", "rc": 0, "start": "2020-10-07 15:19:27.618120", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}
changed: [127.0.0.1] => (item=cstor-cspc-disk-pool-cflp) => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs cstor-cspc-disk-pool-cflp -o custom-columns=:.status.provisionedReplicas --no-headers", "delta": "0:00:00.743129", "end": "2020-10-07 15:19:29.315218", "item": "cstor-cspc-disk-pool-cflp", "rc": 0, "start": "2020-10-07 15:19:28.572089", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}

TASK [Remove the CStor Pool Cluster] *******************************************
2020-10-07T15:19:29.355318 (delta: 90.598085)         elapsed: 97.364218 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete cspc cstor-cspc-disk-pool -n openebs", "delta": "0:00:15.625758", "end": "2020-10-07 15:19:45.181667", "rc": 0, "start": "2020-10-07 15:19:29.555909", "stderr": "", "stderr_lines": [], "stdout": "cstorpoolcluster.cstor.openebs.io \"cstor-cspc-disk-pool\" deleted", "stdout_lines": ["cstorpoolcluster.cstor.openebs.io \"cstor-cspc-disk-pool\" deleted"]}

TASK [Verify if the CStor Pool Cluster is deleted] *****************************
2020-10-07T15:19:45.212690 (delta: 15.857106)         elapsed: 113.22159 ****** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ pool_name }}" not in cspc_status.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspc -n openebs", "delta": "0:00:01.306202", "end": "2020-10-07 15:19:46.766890", "rc": 0, "start": "2020-10-07 15:19:45.460688", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the CSPI is getting removed] ***********************************
2020-10-07T15:19:46.827363 (delta: 1.614635)         elapsed: 114.836263 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cspi -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool", "delta": "0:00:01.269716", "end": "2020-10-07 15:19:48.418368", "rc": 0, "start": "2020-10-07 15:19:47.148652", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Verify if the cStor pool pods are deleted] *******************************
2020-10-07T15:19:48.471014 (delta: 1.643616)         elapsed: 116.479914 ****** 
FAILED - RETRYING: Verify if the cStor pool pods are deleted (30 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (29 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (28 retries left).
FAILED - RETRYING: Verify if the cStor pool pods are deleted (27 retries left).
changed: [127.0.0.1] => {"attempts": 5, "changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/cstor-pool-cluster=cstor-cspc-disk-pool", "delta": "0:00:00.670908", "end": "2020-10-07 15:20:33.162444", "rc": 0, "start": "2020-10-07 15:20:32.491536", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2020-10-07T15:20:33.192481 (delta: 44.721431)         elapsed: 161.201381 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2020-10-07T15:20:33.241558 (delta: 0.049045)         elapsed: 161.250458 ****** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-10-07T15:20:33.291237 (delta: 0.049642)         elapsed: 161.300137 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-10-07T15:20:33.319285 (delta: 0.028014)         elapsed: 161.328185 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-10-07T15:20:33.347363 (delta: 0.02804)         elapsed: 161.356263 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-10-07T15:20:33.375640 (delta: 0.028241)         elapsed: 161.38454 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "501786648ab66e7fc2a021e95e8fcc53f8ff4f77", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "23c79b43245ac077305a179ea8f3e971", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1602084033.42-72161467772695/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-10-07T15:20:35.233241 (delta: 1.857567)         elapsed: 163.242141 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.742411", "end": "2020-10-07 15:20:36.160771", "rc": 0, "start": "2020-10-07 15:20:35.418360", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cstor-pool-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cstor-pool-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-10-07T15:20:36.199065 (delta: 0.965787)         elapsed: 164.207965 ****** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-10-07T13:42:48Z", "generation": 10, "name": "cstor-pool-provision", "resourceVersion": "46681", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/cstor-pool-provision", "uid": "954a89f0-58a5-41b0-a7e6-784f4d05fcf4"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=18   changed=14   unreachable=0    failed=0   

2020-10-07T15:20:37.243399 (delta: 1.044288)         elapsed: 165.252299 ****** 
=============================================================================== 
```
