### PR TITLE
feat(jiva_node_failure): add tests for ungraceful node shutdowns

### DIFF
--- a/chaoslib/kernel_chaos/kill_node.yml
+++ b/chaoslib/kernel_chaos/kill_node.yml
@@ -1,0 +1,8 @@
+- 
+  block:
+          - name: Execute 'panic'
+            shell: >
+              sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_addr }}
+              "echo {{ node_pwd }} | sudo -S su -c 'sleep 5; echo c > /proc/sysrq-trigger'"
+            async: 10
+            poll: 0

--- a/chaoslib/kernel_chaos/kill_node.yml
+++ b/chaoslib/kernel_chaos/kill_node.yml
@@ -2,7 +2,7 @@
   block:
           - name: Execute 'panic'
             shell: >
-              sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_addr }}
+              sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
               "echo {{ node_pwd }} | sudo -S su -c 'sleep 5; echo c > /proc/sysrq-trigger'"
             async: 10
             poll: 0

--- a/experiments/chaos/jiva_node_failure/chaosutil.j2
+++ b/experiments/chaos/jiva_node_failure/chaosutil.j2
@@ -1,0 +1,3 @@
+{% if platform is defined and platform == 'vmware' %}
+  chaosutil: chaoslib/kernel_chaos/kill_node.yml
+{% endif %}

--- a/experiments/chaos/jiva_node_failure/crashutil.j2
+++ b/experiments/chaos/jiva_node_failure/crashutil.j2
@@ -1,3 +1,3 @@
 {% if platform is defined and platform == 'vmware' %}
-  chaosutil: chaoslib/kernel_chaos/kill_node.yml
+  crashutil: chaoslib/kernel_chaos/kill_node.yml
 {% endif %}

--- a/experiments/chaos/jiva_node_failure/crashutil.j2
+++ b/experiments/chaos/jiva_node_failure/crashutil.j2
@@ -1,3 +1,3 @@
 {% if platform is defined and platform == 'vmware' %}
-  chaosutil: chaoslib/vmware_chaos/vm_power_operations.yml
+  chaosutil: chaoslib/kernel_chaos/kill_node.yml
 {% endif %}

--- a/experiments/chaos/jiva_node_failure/data_persistence.j2
+++ b/experiments/chaos/jiva_node_failure/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/experiments/chaos/jiva_node_failure/prerequisites.yml
+++ b/experiments/chaos/jiva_node_failure/prerequisites.yml
@@ -1,0 +1,38 @@
+---
+- name: Identify the storage class used by the PVC
+  shell: >
+    kubectl get pvc {{ pvc }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:spec.storageClassName
+  args:
+    executable: /bin/bash
+  register: storage_class
+
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }}
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
+- name: Record the storage class name
+  set_fact: 
+    sc: "{{ storage_class.stdout }}"
+
+- name: Record the storage provisioner name
+  set_fact:
+    stg_prov: "{{ provisioner.stdout }}"
+
+- name: Record the storage engine name
+  set_fact:
+    stg_engine: "jiva"
+  when: stg_prov == "jiva.csi.openebs.io"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv

--- a/experiments/chaos/jiva_node_failure/run_litmus_test.yml
+++ b/experiments/chaos/jiva_node_failure/run_litmus_test.yml
@@ -1,0 +1,99 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jiva-node-failure
+  namespace: litmus
+data:
+  parameters.yml: |
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: host-password
+  namespace: litmus
+type: Opaque
+data:
+  password:
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: node-password
+  namespace: litmus
+type: Opaque
+data:
+  passwordNode:
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: jiva-node-failure-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: jiva-node-failure
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      #nodeSelector:
+      #  kubernetes.io/hostname:
+
+      tolerations:
+      - key: "infra-aid"
+        operator: "Equal"
+        value: "observer"
+        effect: "NoSchedule"
+
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-percona-ns
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: APP_PVC
+            value: ''
+            
+          # The platform where k8s cluster is created.
+          - name: PLATFORM
+            value: "vmware"
+
+          - name: OPERATOR_NS
+            value: openebs
+
+          - name: NODE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: node-password
+                key: passwordNode
+
+          - name: USERNAME
+            value: ''
+
+          # Application name to pick the relevant data persistence check util
+          - name: DATA_PERSISTENCE
+            value: "" 
+
+        command: ["/bin/bash"]
+        args: ["-c", "ANSIBLE_LOCAL_TEMP=$HOME/.ansible/tmp ANSIBLE_REMOTE_TEMP=$HOME/.ansible/tmp ansible-playbook ./experiments/chaos/jiva_node_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: jiva-node-failure

--- a/experiments/chaos/jiva_node_failure/test.yml
+++ b/experiments/chaos/jiva_node_failure/test.yml
@@ -41,6 +41,18 @@
           set_fact:
             chaos_util_path: "/{{ chaosutil }}"
 
+        - name: Identify the crash util to be invoked
+          template:
+            src: crashutil.j2
+            dest: crashutil.yml
+
+        - include_vars:
+            file: crashutil.yml
+
+        - name: Record the crash util path
+          set_fact:
+            crash_util_path: "/{{ crashutil }}"
+
         - name: Identify the data consistency util to be invoked
           template:
             src: data_persistence.j2
@@ -85,7 +97,7 @@
           register: pvc
 
         ## Obtain the node where application pod is running
-        - name: Get Application pod Node to perform chaos
+        - name: Get Application pod Node to perform crash
           shell: >
             kubectl get pod {{ app_pod_name.stdout }} -n {{ namespace }}
             --no-headers -o custom-columns=:spec.nodeName
@@ -94,7 +106,7 @@
           register: app_node
 
         ## Obtain the nodeIP where application pod is running
-        - name: Get Application pod Node IP to perform chaos
+        - name: Get Application pod Node IP to perform crash
           shell: >
             kubectl get nodes {{ app_node_name }}
             -o jsonpath=\'{ $.status.addresses[?(@.type=="InternalIP")].address }\'
@@ -190,7 +202,7 @@
           register: replica3_pod_name
 
         ## Obtain the node where replica1 pod is running
-        - name: Get replica1 pod Node to perform chaos
+        - name: Get replica1 pod Node to perform crash
           shell: >
             kubectl get pod {{ replica1_pod_name.stdout }} -n {{ namespace }}
             --no-headers -o custom-columns=:spec.nodeName
@@ -199,7 +211,7 @@
           register: replica1_node
 
         ## Obtain the node where replica2 pod is running
-        - name: Get replica2 pod Node to perform chaos
+        - name: Get replica2 pod Node to perform crash
           shell: >
             kubectl get pod {{ replica2_pod_name.stdout }} -n {{ namespace }}
             --no-headers -o custom-columns=:spec.nodeName
@@ -208,7 +220,7 @@
           register: replica2_node
 
         ## Obtain the node where replica2 pod is running
-        - name: Get replica3 pod Node to perform chaos
+        - name: Get replica3 pod Node to perform crash
           shell: >
             kubectl get pod {{ replica3_pod_name.stdout }} -n {{ namespace }}
             --no-headers -o custom-columns=:spec.nodeName
@@ -226,12 +238,12 @@
             pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''
 
-        ## Execute the chaos util to kill the application node
-        - include_tasks: "{{ chaos_util_path }}"
+        ## Execute the crash util to kill the application node
+        - include_tasks: "{{ crash_util_path }}"
           vars:
             node_ip_add: "{{ app_node_ip.stdout }}"
 
-        ## Application verification after injecting chaos
+        ## Application verification after injecting crash
         - name: check the application status
           shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
           args:
@@ -259,12 +271,12 @@
             pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''
 
-        ## Execute the chaos util to kill the replica1 node
-        - include_tasks: "{{ chaos_util_path }}"
+        ## Execute the crash util to kill the replica1 node
+        - include_tasks: "{{ crash_util_path }}"
           vars:
             node_ip_add: "{{ replica1_node_ip.stdout }}"
 
-        ## Application verification after injecting chaos
+        ## Application verification after injecting crash
         - name: check the application status
           shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
           args:
@@ -292,22 +304,22 @@
             pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''
 
-        ## Execute the chaos util to kill the replica1 node
-        - include_tasks: "{{ chaos_util_path }}"
+        ## Execute the crash util to kill the replica1 node
+        - include_tasks: "{{ crash_util_path }}"
           vars:
             node_ip_add: "{{ replica1_node_ip.stdout }}"
  
-        ## Execute the chaos util to kill the replica2 node
-        - include_tasks: "{{ chaos_util_path }}"
+        ## Execute the crash util to kill the replica2 node
+        - include_tasks: "{{ crash_util_path }}"
           vars:
             node_ip_add: "{{ replica2_node_ip.stdout }}"
 
-        ## Execute the chaos util to kill the replica3 node
-        - include_tasks: "{{ chaos_util_path }}"
+        ## Execute the crash util to kill the replica3 node
+        - include_tasks: "{{ crash_util_path }}"
           vars:
             node_ip_add: "{{ replica3_node_ip.stdout }}"
 
-        ## Application verification after injecting chaos
+        ## Application verification after injecting crash
         - name: check the application status
           shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
           args:
@@ -317,6 +329,77 @@
           delay: 5
           retries: 10
           ignore_errors: true
+
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
+
+    - block:
+        ## Execute the chaos util to turn off the target node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            esx_ip: "{{ host_ip }}"
+            target_node: "{{ replica3_node.stdout }}"
+            operation: "off"
+
+        - name: Check the node status
+          shell: kubectl get nodes {{ replica3_node.stdout }} --no-headers
+          args:
+            executable: /bin/bash
+          register: state
+          until: "'NotReady' in state.stdout"
+          delay: 15
+          retries: 30
+
+        ## Generate data on the application
+        - name: Generate data on the specified application.
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''
+
+        ## Execute the chaos util to turn on the target node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            esx_ip: "{{ host_ip }}"
+            target_node: "{{ replica3_node.stdout }}"
+            operation: "on"
+
+        - name: Get wo replica status from controller
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          uri:
+            url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+            method: GET
+            return_content: yes
+            status_code: 200
+            headers:
+              Content-Type: "application/json"
+            body_format: json
+          register: json_response
+          until: json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "WO"
+          retries: 20
+          delay: 60
+
+        ## Execute the crash util to kill the replica1 node
+        - include_tasks: "{{ crash_util_path }}"
+          vars:
+            node_ip_add: "{{ replica1_node_ip.stdout }}"
+
+        ## Execute the crash util to kill the replica2 node
+        - include_tasks: "{{ crash_util_path }}"
+          vars:
+            node_ip_add: "{{ replica2_node_ip.stdout }}"
+
+        ## Execute the crash util to kill the replica3 node
+        - include_tasks: "{{ crash_util_path }}"
+          vars:
+            node_ip_add: "{{ replica3_node_ip.stdout }}"
 
         - name: Verify application data persistence
           include: "{{ data_consistency_util_path }}"

--- a/experiments/chaos/jiva_node_failure/test.yml
+++ b/experiments/chaos/jiva_node_failure/test.yml
@@ -11,6 +11,14 @@
 
     - block:
 
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "node-failure"
+            app: ""
+
         ## DISPLAY APP INFORMATION
         - name: Display the app information passed via the test job
           debug:

--- a/experiments/chaos/jiva_node_failure/test.yml
+++ b/experiments/chaos/jiva_node_failure/test.yml
@@ -11,14 +11,6 @@
 
     - block:
 
-        - include_tasks: /utils/fcm/create_testname.yml
-
-        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
-          vars:
-            status: 'SOT'
-            chaostype: "node-failure"
-            app: ""
-
         ## DISPLAY APP INFORMATION
         - name: Display the app information passed via the test job
           debug:
@@ -108,8 +100,8 @@
         ## Obtain the nodeIP where application pod is running
         - name: Get Application pod Node IP to perform crash
           shell: >
-            kubectl get nodes {{ app_node_name }}
-            -o jsonpath=\'{ $.status.addresses[?(@.type=="InternalIP")].address }\'
+            kubectl get nodes {{ app_node.stdout }}
+            -o jsonpath='{ $.status.addresses[?(@.type=="InternalIP")].address }'
           args:
             executable: /bin/bash
           register: app_node_ip
@@ -128,11 +120,20 @@
             pv_name: "{{ pv.stdout }}"
 
 
-        - name: Get rw replica status from controller
+        - name: Get controller svc
+          shell: >
+           kubectl get svc -l openebs.io/persistent-volume={{ pv_name }}
+           -n {{ operator_ns }} --no-headers -o custom-columns=:spec.clusterIP
+          args:
+            executable: /bin/bash
+          register: controller_service
+          failed_when: controller_service.stdout == ""
+
+        - name: Get total replica count from controller
           vars:
-            replicas_endpoint: "9501/v1/replicas"
+            replicas_endpoint: "9501/v1/volumes"
           uri:
-            url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+            url: "http://{{ controller_service.stdout }}:{{ replicas_endpoint }}"
             method: GET
             return_content: yes
             status_code: 200
@@ -140,71 +141,81 @@
               Content-Type: "application/json"
             body_format: json
           register: json_response
-          until: json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "RW"
+          until: json_response.status == 200 and json_response.json.data[0].replicaCount == 3
+          retries: 180
+          delay: 1
+
+        - name: Get rw replica status from controller
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          uri:
+            url: "http://{{ controller_service.stdout }}:{{ replicas_endpoint }}"
+            method: GET
+            return_content: yes
+            status_code: 200
+            headers:
+              Content-Type: "application/json"
+            body_format: json
+          register: json_response
+          until: json_response.status == 200 and json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "RW"
           retries: 20
-          delay: 60
+          delay: 1
 
         - name: Getting replica1 IP
           vars:
             replicas_endpoint: "9501/v1/replicas"
-          shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[0].address' | sed -e 's/^"//' -e 's/"$//'
+          shell: curl http://{{ controller_service.stdout }}:{{ replicas_endpoint }} | jq '.data[0].address' | sed -e 's/^"//' -e 's/"$//'
           register: json_response
           until: "'tcp' in json_response.stdout"
-          delay: 15
+          delay: 1
           retries: 24
 
         - name: Set replica1 ip
           set_fact:
-            replica_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
-        - debug:
-            var: "replica1_ip"
+            replica1_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
 
         - name: Getting replica2 IP
           vars:
             replicas_endpoint: "9501/v1/replicas"
-          shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[1].address' | sed -e 's/^"//' -e 's/"$//'
+          shell: curl http://{{ controller_service.stdout }}:{{ replicas_endpoint }} | jq '.data[1].address' | sed -e 's/^"//' -e 's/"$//'
           register: json_response
           until: "'tcp' in json_response.stdout"
-          delay: 15
+          delay: 1
           retries: 24
 
         - name: Set replica2 ip
           set_fact:
-            replica_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
-        - debug:
-            var: "replica2_ip"
+            replica2_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
 
         - name: Getting replica3 IP
           vars:
             replicas_endpoint: "9501/v1/replicas"
-          shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[2].address' | sed -e 's/^"//' -e 's/"$//'
+          shell: curl http://{{ controller_service.stdout }}:{{ replicas_endpoint }} | jq '.data[2].address' | sed -e 's/^"//' -e 's/"$//'
           register: json_response
           until: "'tcp' in json_response.stdout"
-          delay: 15
+          delay: 1
           retries: 24
 
         - name: Set replica3 ip
           set_fact:
-            replica_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
-        - debug:
-            var: "replica3_ip"
+            replica3_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
 
         - name: Getting the replica1 pod name corresponding to the IP
-          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP==\"{{ replica1_ip }}\")].metadata.name}'
+          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP=="{{ replica1_ip }}")].metadata.name}'
           register: replica1_pod_name
 
         - name: Getting the replica1 pod name corresponding to the IP
-          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP==\"{{ replica2_ip }}\")].metadata.name}'
+          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP=="{{ replica2_ip }}")].metadata.name}'
           register: replica2_pod_name
 
         - name: Getting the replica1 pod name corresponding to the IP
-          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP==\"{{ replica3_ip }}\")].metadata.name}'
+          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP=="{{ replica3_ip }}")].metadata.name}'
           register: replica3_pod_name
 
         ## Obtain the node where replica1 pod is running
         - name: Get replica1 pod Node to perform crash
           shell: >
-            kubectl get pod {{ replica1_pod_name.stdout }} -n {{ namespace }}
+            kubectl get pod {{ replica1_pod_name.stdout }} -n {{ operator_ns }}
             --no-headers -o custom-columns=:spec.nodeName
           args:
             executable: /bin/bash
@@ -213,7 +224,7 @@
         ## Obtain the node where replica2 pod is running
         - name: Get replica2 pod Node to perform crash
           shell: >
-            kubectl get pod {{ replica2_pod_name.stdout }} -n {{ namespace }}
+            kubectl get pod {{ replica2_pod_name.stdout }} -n {{ operator_ns }}
             --no-headers -o custom-columns=:spec.nodeName
           args:
             executable: /bin/bash
@@ -222,11 +233,38 @@
         ## Obtain the node where replica2 pod is running
         - name: Get replica3 pod Node to perform crash
           shell: >
-            kubectl get pod {{ replica3_pod_name.stdout }} -n {{ namespace }}
+            kubectl get pod {{ replica3_pod_name.stdout }} -n {{ operator_ns }}
             --no-headers -o custom-columns=:spec.nodeName
           args:
             executable: /bin/bash
           register: replica3_node
+
+        ## Obtain the nodeIP where replica1 pod is running
+        - name: Get replica1 pod Node IP to perform crash
+          shell: >
+            kubectl get nodes {{ replica1_node.stdout }}
+            -o jsonpath='{ $.status.addresses[?(@.type=="InternalIP")].address }'
+          args:
+            executable: /bin/bash
+          register: replica1_node_ip
+
+        ## Obtain the nodeIP where replica2 pod is running
+        - name: Get replica2 pod Node IP to perform crash
+          shell: >
+            kubectl get nodes {{ replica2_node.stdout }}
+            -o jsonpath='{ $.status.addresses[?(@.type=="InternalIP")].address }'
+          args:
+            executable: /bin/bash
+          register: replica2_node_ip
+
+        ## Obtain the nodeIP where replica3 pod is running
+        - name: Get replica3 pod Node IP to perform crash
+          shell: >
+            kubectl get nodes {{ replica3_node.stdout }}
+            -o jsonpath='{ $.status.addresses[?(@.type=="InternalIP")].address }'
+          args:
+            executable: /bin/bash
+          register: replica3_node_ip
 
     - block:
         ## Generate data on the application
@@ -252,7 +290,6 @@
           until: "'Running' in app_status.stdout"
           delay: 5
           retries: 10
-          ignore_errors: true
 
         - name: Verify application data persistence
           include: "{{ data_consistency_util_path }}"
@@ -260,6 +297,7 @@
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
+          when: data_persistence != ''
 
     - block:
         ## Generate data on the application
@@ -285,7 +323,6 @@
           until: "'Running' in app_status.stdout"
           delay: 5
           retries: 10
-          ignore_errors: true
 
         - name: Verify application data persistence
           include: "{{ data_consistency_util_path }}"
@@ -293,6 +330,7 @@
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
+          when: data_persistence != ''
 
     - block:
         ## Generate data on the application
@@ -328,7 +366,6 @@
           until: "'Running' in app_status.stdout"
           delay: 5
           retries: 10
-          ignore_errors: true
 
         - name: Verify application data persistence
           include: "{{ data_consistency_util_path }}"
@@ -336,12 +373,14 @@
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
+          when: data_persistence != ''
 
     - block:
         ## Execute the chaos util to turn off the target node
         - include_tasks: "{{ chaos_util_path }}"
           vars:
-            esx_ip: "{{ host_ip }}"
+            esx_ip: "{{ esx_host_ip }}"
+            esx_pwd: "{{ esx_host_pass }}"
             target_node: "{{ replica3_node.stdout }}"
             operation: "off"
 
@@ -366,15 +405,16 @@
         ## Execute the chaos util to turn on the target node
         - include_tasks: "{{ chaos_util_path }}"
           vars:
-            esx_ip: "{{ host_ip }}"
+            esx_ip: "{{ esx_host_ip }}"
+            esx_pwd: "{{ esx_host_pass }}"
             target_node: "{{ replica3_node.stdout }}"
             operation: "on"
 
-        - name: Get wo replica status from controller
+        - name: Get total replica count from controller
           vars:
-            replicas_endpoint: "9501/v1/replicas"
+            replicas_endpoint: "9501/v1/volumes"
           uri:
-            url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+            url: "http://{{ controller_service.stdout }}:{{ replicas_endpoint }}"
             method: GET
             return_content: yes
             status_code: 200
@@ -382,9 +422,25 @@
               Content-Type: "application/json"
             body_format: json
           register: json_response
-          until: json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "WO"
+          until: json_response.status == 200 and json_response.json.data[0].replicaCount == 3
+          retries: 180
+          delay: 1
+
+        - name: Get wo replica status from controller
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          uri:
+            url: "http://{{ controller_service.stdout }}:{{ replicas_endpoint }}"
+            method: GET
+            return_content: yes
+            status_code: 200
+            headers:
+              Content-Type: "application/json"
+            body_format: json
+          register: json_response
+          until: json_response.status == 200 and json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "WO"
           retries: 20
-          delay: 60
+          delay: 1
 
         ## Execute the crash util to kill the replica1 node
         - include_tasks: "{{ crash_util_path }}"
@@ -407,6 +463,7 @@
             status: 'VERIFY'
             ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
+          when: data_persistence != ''
 
         - set_fact:
             flag: "Pass"

--- a/experiments/chaos/jiva_node_failure/test.yml
+++ b/experiments/chaos/jiva_node_failure/test.yml
@@ -1,0 +1,333 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+
+  tasks:
+
+    - block:
+
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "node-failure"
+            app: ""
+
+        ## DISPLAY APP INFORMATION
+        - name: Display the app information passed via the test job
+          debug:
+            msg:
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+
+        - include: prerequisites.yml
+
+        - name: Identify the chaos util to be invoked
+          template:
+            src: chaosutil.j2
+            dest: chaosutil.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact:
+            chaos_util_path: "/{{ chaosutil }}"
+
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
+
+        - include_vars:
+            file: data_persistence.yml
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
+
+        ## Verify the APPLICATION UNDER TEST PRE CHAOS
+        - name: Verify if the application is running.
+          include_tasks: /utils/k8s/status_app_pod.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: '2'
+            retries: '60'
+
+        ## Fetch application pod name
+        - name: Get application pod name
+          shell: >
+            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Record the application pod name
+          set_fact:
+            application_pod: "{{ app_pod_name.stdout }}"
+
+        - name: Obtain PVC name from the application mount
+          shell: >
+            kubectl get pods "{{ app_pod_name.stdout }}" -n "{{ namespace }}" 
+            -o custom-columns=:.spec.volumes[*].persistentVolumeClaim.claimName --no-headers
+          args:
+            executable: /bin/bash
+          register: pvc
+
+        ## Obtain the node where application pod is running
+        - name: Get Application pod Node to perform chaos
+          shell: >
+            kubectl get pod {{ app_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: app_node
+
+        ## Obtain the nodeIP where application pod is running
+        - name: Get Application pod Node IP to perform chaos
+          shell: >
+            kubectl get nodes {{ app_node_name }}
+            -o jsonpath=\'{ $.status.addresses[?(@.type=="InternalIP")].address }\'
+          args:
+            executable: /bin/bash
+          register: app_node_ip
+
+        - name: Obtain the Persistent Volume name
+          shell: >
+            kubectl get pvc "{{ pvc.stdout }}" -n "{{ namespace }}" --no-headers 
+            -o custom-columns=:.spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv
+          failed_when: 'pv.stdout == ""'
+
+        - name: Record the pv name
+          set_fact:
+            pv_name: "{{ pv.stdout }}"
+
+
+        - name: Get rw replica status from controller
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          uri:
+            url: "http://{{ controller_service }}:{{ replicas_endpoint }}"
+            method: GET
+            return_content: yes
+            status_code: 200
+            headers:
+              Content-Type: "application/json"
+            body_format: json
+          register: json_response
+          until: json_response.json.data[0].mode == "RW" and json_response.json.data[1].mode == "RW" and json_response.json.data[2].mode == "RW"
+          retries: 20
+          delay: 60
+
+        - name: Getting replica1 IP
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[0].address' | sed -e 's/^"//' -e 's/"$//'
+          register: json_response
+          until: "'tcp' in json_response.stdout"
+          delay: 15
+          retries: 24
+
+        - name: Set replica1 ip
+          set_fact:
+            replica_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
+        - debug:
+            var: "replica1_ip"
+
+        - name: Getting replica2 IP
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[1].address' | sed -e 's/^"//' -e 's/"$//'
+          register: json_response
+          until: "'tcp' in json_response.stdout"
+          delay: 15
+          retries: 24
+
+        - name: Set replica2 ip
+          set_fact:
+            replica_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
+        - debug:
+            var: "replica2_ip"
+
+        - name: Getting replica3 IP
+          vars:
+            replicas_endpoint: "9501/v1/replicas"
+          shell: curl http://{{ controller_service }}:{{ replicas_endpoint }} | jq '.data[2].address' | sed -e 's/^"//' -e 's/"$//'
+          register: json_response
+          until: "'tcp' in json_response.stdout"
+          delay: 15
+          retries: 24
+
+        - name: Set replica3 ip
+          set_fact:
+            replica_ip: "{{ json_response.stdout | regex_replace('tcp://') | regex_replace(':9502') }}"
+        - debug:
+            var: "replica3_ip"
+
+        - name: Getting the replica1 pod name corresponding to the IP
+          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP==\"{{ replica1_ip }}\")].metadata.name}'
+          register: replica1_pod_name
+
+        - name: Getting the replica1 pod name corresponding to the IP
+          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP==\"{{ replica2_ip }}\")].metadata.name}'
+          register: replica2_pod_name
+
+        - name: Getting the replica1 pod name corresponding to the IP
+          shell: kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume={{ pv_name }} -n {{ operator_ns }} --no-headers -o jsonpath='{.items[?(@.status.podIP==\"{{ replica3_ip }}\")].metadata.name}'
+          register: replica3_pod_name
+
+        ## Obtain the node where replica1 pod is running
+        - name: Get replica1 pod Node to perform chaos
+          shell: >
+            kubectl get pod {{ replica1_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: replica1_node
+
+        ## Obtain the node where replica2 pod is running
+        - name: Get replica2 pod Node to perform chaos
+          shell: >
+            kubectl get pod {{ replica2_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: replica2_node
+
+        ## Obtain the node where replica2 pod is running
+        - name: Get replica3 pod Node to perform chaos
+          shell: >
+            kubectl get pod {{ replica3_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: replica3_node
+
+    - block:
+        ## Generate data on the application
+        - name: Generate data on the specified application.
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''
+
+        ## Execute the chaos util to kill the application node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            node_ip_add: "{{ app_node_ip.stdout }}"
+
+        ## Application verification after injecting chaos
+        - name: check the application status
+          shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
+
+    - block:
+        ## Generate data on the application
+        - name: Generate data on the specified application.
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''
+
+        ## Execute the chaos util to kill the replica1 node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            node_ip_add: "{{ replica1_node_ip.stdout }}"
+
+        ## Application verification after injecting chaos
+        - name: check the application status
+          shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
+
+    - block:
+        ## Generate data on the application
+        - name: Generate data on the specified application.
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''
+
+        ## Execute the chaos util to kill the replica1 node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            node_ip_add: "{{ replica1_node_ip.stdout }}"
+ 
+        ## Execute the chaos util to kill the replica2 node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            node_ip_add: "{{ replica2_node_ip.stdout }}"
+
+        ## Execute the chaos util to kill the replica3 node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            node_ip_add: "{{ replica3_node_ip.stdout }}"
+
+        ## Application verification after injecting chaos
+        - name: check the application status
+          shell: kubectl get pods -n {{ namespace}} -l {{ label }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        - name: Verify application data persistence
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"

--- a/experiments/chaos/jiva_node_failure/test_vars.yml
+++ b/experiments/chaos/jiva_node_failure/test_vars.yml
@@ -19,3 +19,7 @@ user: "{{ lookup('env','USERNAME') }}"
 
 node_pwd: "{{ lookup('env','NODE_PASSWORD') }}"
 
+esx_host_ip: "{{ lookup('env','ESX_HOST') }}"
+
+esx_host_pass: "{{ lookup('env','ESX_HOST_PASSWORD') }}"
+

--- a/experiments/chaos/jiva_node_failure/test_vars.yml
+++ b/experiments/chaos/jiva_node_failure/test_vars.yml
@@ -1,0 +1,21 @@
+---
+# Test specific parameters
+
+test_name: node-failure
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc: "{{ lookup('env','APP_PVC') }}"
+
+label: "{{ lookup('env','APP_LABEL') }}"
+
+platform: "{{ lookup('env','PLATFORM') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+user: "{{ lookup('env','USERNAME') }}"
+
+node_pwd: "{{ lookup('env','NODE_PASSWORD') }}"
+


### PR DESCRIPTION
**Which issue this PR fixes** : https://github.com/openebs/e2e-tests/issues/198
**What this PR does / why we need it**:
This PR adds the following tests to the suit:
1. Fill data in application                                                                                                                      
crash application node while writing data                                                                                                      
Verify Data consistency
2. Fill data in application                                                                                                                      
crash replica 1 node while writing data                                                                                                        
Verify Data consistency
3. Fill data in application                                                                                                                      
crash all 3 replica nodes while writing data                                                                                                   
Verify Data consistency 
4. Stop node 1 using vmware utils                                                                                                                                   
Fill data in application                                                                                                               
Start node 1                                                                                                                                  
Verify node 1 replica is in WO mode                                                                                                            
crash all 3 nodes                                                                                                                              
Verify Data consistency

Logs:
```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Sep 30 2020, 13:38:04) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /experiments/chaos/jiva_node_failure/prerequisites.yml

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/chaos/jiva_node_failure/test.yml

PLAY [localhost] ***************************************************************
2020-12-09T09:26:47.913470 (delta: 0.062882)         elapsed: 0.062882 ******** 
=============================================================================== 
META: ran handlers

TASK [Display the app information passed via the test job] *********************
task path: /experiments/chaos/jiva_node_failure/test.yml:15
2020-12-09T09:26:47.923190 (delta: 0.009693)         elapsed: 0.072602 ******** 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona"
    ]
}

TASK [Identify the storage class used by the PVC] ******************************
task path: /experiments/chaos/jiva_node_failure/prerequisites.yml:2
2020-12-09T09:26:47.972993 (delta: 0.049781)         elapsed: 0.122405 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc  -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:00.639573", "end": "2020-12-09 09:26:48.829808", "rc": 0, "start": "2020-12-09 09:26:48.190235", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-csi-sc", "stdout_lines": ["openebs-jiva-csi-sc"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /experiments/chaos/jiva_node_failure/prerequisites.yml:10
2020-12-09T09:26:48.854443 (delta: 0.881413)         elapsed: 1.003855 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-csi-sc --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.581780", "end": "2020-12-09 09:26:49.546795", "rc": 0, "start": "2020-12-09 09:26:48.965015", "stderr": "", "stderr_lines": [], "stdout": "jiva.csi.openebs.io", "stdout_lines": ["jiva.csi.openebs.io"]}

TASK [Record the storage class name] *******************************************
task path: /experiments/chaos/jiva_node_failure/prerequisites.yml:18
2020-12-09T09:26:49.570537 (delta: 0.71606)         elapsed: 1.719949 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-csi-sc"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /experiments/chaos/jiva_node_failure/prerequisites.yml:22
2020-12-09T09:26:49.609142 (delta: 0.038573)         elapsed: 1.758554 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "jiva.csi.openebs.io"}, "changed": false}

TASK [Record the storage engine name] ******************************************
task path: /experiments/chaos/jiva_node_failure/prerequisites.yml:26
2020-12-09T09:26:49.652549 (delta: 0.043372)         elapsed: 1.801961 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /experiments/chaos/jiva_node_failure/prerequisites.yml:32
2020-12-09T09:26:49.695710 (delta: 0.043126)         elapsed: 1.845122 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc  -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.581130", "end": "2020-12-09 09:26:50.388461", "rc": 0, "start": "2020-12-09 09:26:49.807331", "stderr": "", "stderr_lines": [], "stdout": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5", "stdout_lines": ["pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5"]}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:24
2020-12-09T09:26:50.413201 (delta: 0.717456)         elapsed: 2.562613 ******** 
ok: [127.0.0.1] => {"changed": false, "checksum": "c3d158e37e6690e06d2df05aaab730ac04f28e26", "dest": "chaosutil.yml", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "chaosutil.yml", "size": 59, "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:29
2020-12-09T09:26:51.845601 (delta: 1.432365)         elapsed: 3.995013 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "chaoslib/vmware_chaos/vm_power_operations.yml"}, "ansible_included_var_files": ["/experiments/chaos/jiva_node_failure/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:32
2020-12-09T09:26:51.884003 (delta: 0.038367)         elapsed: 4.033415 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/vmware_chaos/vm_power_operations.yml"}, "changed": false}

TASK [Identify the crash util to be invoked] ***********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:36
2020-12-09T09:26:51.927812 (delta: 0.04376)         elapsed: 4.077224 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "953d90e76830969eb7dbd222c1eb1802637cd7b7", "dest": "./crashutil.yml", "gid": 0, "group": "root", "md5sum": "a20d8f949ea14b03adc83965dc47c213", "mode": "0644", "owner": "root", "size": 49, "src": "/root/.ansible/tmp/ansible-tmp-1607506011.96-109454914923475/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:41
2020-12-09T09:26:53.277442 (delta: 1.349588)         elapsed: 5.426854 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"crashutil": "chaoslib/kernel_chaos/kill_node.yml"}, "ansible_included_var_files": ["/experiments/chaos/jiva_node_failure/crashutil.yml"], "changed": false}

TASK [Record the crash util path] **********************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:44
2020-12-09T09:26:53.318246 (delta: 0.040737)         elapsed: 5.467658 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"crash_util_path": "/chaoslib/kernel_chaos/kill_node.yml"}, "changed": false}

TASK [Identify the data consistency util to be invoked] ************************
task path: /experiments/chaos/jiva_node_failure/test.yml:48
2020-12-09T09:26:53.358166 (delta: 0.039884)         elapsed: 5.507578 ******** 
ok: [127.0.0.1] => {"changed": false, "checksum": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc", "dest": "data_persistence.yml", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "data_persistence.yml", "size": 1, "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:53
2020-12-09T09:26:54.620133 (delta: 1.261932)         elapsed: 6.769545 ******** 
ok: [127.0.0.1] => {"ansible_facts": {}, "ansible_included_var_files": ["/experiments/chaos/jiva_node_failure/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:56
2020-12-09T09:26:54.659271 (delta: 0.039103)         elapsed: 6.808683 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application is running.] ***********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:62
2020-12-09T09:26:54.688587 (delta: 0.02928)         elapsed: 6.837999 ********* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /utils/k8s/status_app_pod.yml:2
2020-12-09T09:26:54.721023 (delta: 0.0324)         elapsed: 6.870435 ********** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.584389", "end": "2020-12-09 09:26:55.440968", "rc": 0, "start": "2020-12-09 09:26:54.856579", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-12-09T09:25:50Z]]", "stdout_lines": ["map[running:map[startedAt:2020-12-09T09:25:50Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /utils/k8s/status_app_pod.yml:13
2020-12-09T09:26:55.473133 (delta: 0.752078)         elapsed: 7.622545 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.581752", "end": "2020-12-09 09:26:56.177976", "rc": 0, "start": "2020-12-09 09:26:55.596224", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:72
2020-12-09T09:26:56.205782 (delta: 0.732596)         elapsed: 8.355194 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.580744", "end": "2020-12-09 09:26:56.899880", "rc": 0, "start": "2020-12-09 09:26:56.319136", "stderr": "", "stderr_lines": [], "stdout": "percona-6945f666c8-vdc2v", "stdout_lines": ["percona-6945f666c8-vdc2v"]}

TASK [Record the application pod name] *****************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:79
2020-12-09T09:26:56.923290 (delta: 0.717473)         elapsed: 9.072702 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"application_pod": "percona-6945f666c8-vdc2v"}, "changed": false}

TASK [Obtain PVC name from the application mount] ******************************
task path: /experiments/chaos/jiva_node_failure/test.yml:83
2020-12-09T09:26:56.963738 (delta: 0.040415)         elapsed: 9.11315 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods \"percona-6945f666c8-vdc2v\" -n \"app-percona-ns\" -o custom-columns=:.spec.volumes[*].persistentVolumeClaim.claimName --no-headers", "delta": "0:00:00.576031", "end": "2020-12-09 09:26:57.653111", "rc": 0, "start": "2020-12-09 09:26:57.077080", "stderr": "", "stderr_lines": [], "stdout": "testclaim", "stdout_lines": ["testclaim"]}

TASK [Get Application pod Node to perform crash] *******************************
task path: /experiments/chaos/jiva_node_failure/test.yml:92
2020-12-09T09:26:57.676957 (delta: 0.713184)         elapsed: 9.826369 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-6945f666c8-vdc2v -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.584578", "end": "2020-12-09 09:26:58.373143", "rc": 0, "start": "2020-12-09 09:26:57.788565", "stderr": "", "stderr_lines": [], "stdout": "payes-worker1", "stdout_lines": ["payes-worker1"]}

TASK [Get Application pod Node IP to perform crash] ****************************
task path: /experiments/chaos/jiva_node_failure/test.yml:101
2020-12-09T09:26:58.397522 (delta: 0.720532)         elapsed: 10.546934 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes payes-worker1 -o jsonpath='{ $.status.addresses[?(@.type==\"InternalIP\")].address }'", "delta": "0:00:00.598984", "end": "2020-12-09 09:26:59.104404", "rc": 0, "start": "2020-12-09 09:26:58.505420", "stderr": "", "stderr_lines": [], "stdout": "10.56.2.11", "stdout_lines": ["10.56.2.11"]}

TASK [Obtain the Persistent Volume name] ***************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:109
2020-12-09T09:26:59.130043 (delta: 0.732486)         elapsed: 11.279455 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc \"testclaim\" -n \"app-percona-ns\" --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.578149", "end": "2020-12-09 09:26:59.823874", "failed_when_result": false, "rc": 0, "start": "2020-12-09 09:26:59.245725", "stderr": "", "stderr_lines": [], "stdout": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5", "stdout_lines": ["pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5"]}

TASK [Record the pv name] ******************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:118
2020-12-09T09:26:59.851673 (delta: 0.721594)         elapsed: 12.001085 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pv_name": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5"}, "changed": false}

TASK [Get controller svc] ******************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:123
2020-12-09T09:26:59.901952 (delta: 0.050238)         elapsed: 12.051364 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/persistent-volume=pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5 -n openebs --no-headers -o custom-columns=:spec.clusterIP", "delta": "0:00:00.578429", "end": "2020-12-09 09:27:00.601335", "failed_when_result": false, "rc": 0, "start": "2020-12-09 09:27:00.022906", "stderr": "", "stderr_lines": [], "stdout": "10.111.116.118", "stdout_lines": ["10.111.116.118"]}

TASK [Get total replica count from controller] *********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:132
2020-12-09T09:27:00.628392 (delta: 0.726404)         elapsed: 12.777804 ******* 
FAILED - RETRYING: Get total replica count from controller (180 retries left).
FAILED - RETRYING: Get total replica count from controller (179 retries left).
FAILED - RETRYING: Get total replica count from controller (178 retries left).
FAILED - RETRYING: Get total replica count from controller (177 retries left).
FAILED - RETRYING: Get total replica count from controller (176 retries left).
FAILED - RETRYING: Get total replica count from controller (175 retries left).
FAILED - RETRYING: Get total replica count from controller (174 retries left).
FAILED - RETRYING: Get total replica count from controller (173 retries left).
ok: [127.0.0.1] => {"attempts": 9, "changed": false, "connection": "close", "content": "{\"data\":[{\"actions\":{\"deleteSnapshot\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=deleteSnapshot\",\"resize\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=resize\",\"revert\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=revert\",\"setlogging\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=setlogging\",\"shutdown\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=shutdown\",\"snapshot\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=snapshot\"},\"id\":\"cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==\"},\"name\":\"pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}],\"links\":{\"self\":\"http://10.111.116.118:9501/v1/volumes\"},\"resourceType\":\"volume\",\"type\":\"collection\"}\n", "content_length": "1158", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Wed, 09 Dec 2020 09:27:10 GMT", "json": {"data": [{"actions": {"deleteSnapshot": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=deleteSnapshot", "resize": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=resize", "revert": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=revert", "setlogging": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=setlogging", "shutdown": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=shutdown", "snapshot": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=snapshot"}, "id": "cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==", "links": {"self": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ=="}, "name": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5", "readOnly": "false", "replicaCount": 3, "type": "volume"}], "links": {"self": "http://10.111.116.118:9501/v1/volumes"}, "resourceType": "volume", "type": "collection"}, "msg": "OK (1158 bytes)", "redirected": false, "status": 200, "url": "http://10.111.116.118:9501/v1/volumes", "x_api_schemas": "http://10.111.116.118:9501/v1/schemas"}

TASK [Get rw replica status from controller] ***********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:148
2020-12-09T09:27:10.319620 (delta: 9.691195)         elapsed: 22.469032 ******* 
FAILED - RETRYING: Get rw replica status from controller (20 retries left).
FAILED - RETRYING: Get rw replica status from controller (19 retries left).
FAILED - RETRYING: Get rw replica status from controller (18 retries left).
FAILED - RETRYING: Get rw replica status from controller (17 retries left).
ok: [127.0.0.1] => {"attempts": 5, "changed": false, "connection": "close", "content": "{\"createTypes\":{\"replica\":\"http://10.111.116.118:9501/v1/replicas\"},\"data\":[{\"actions\":{\"preparerebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy?action=preparerebuild\",\"verifyrebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy?action=verifyrebuild\"},\"address\":\"tcp://192.168.1.142:9502\",\"id\":\"dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy?action=preparerebuild\",\"verifyrebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy?action=verifyrebuild\"},\"address\":\"tcp://192.168.2.178:9502\",\"id\":\"dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=?action=preparerebuild\",\"verifyrebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=?action=verifyrebuild\"},\"address\":\"tcp://192.168.3.92:9502\",\"id\":\"dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=\"},\"mode\":\"RW\",\"type\":\"replica\"}],\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas\"},\"resourceType\":\"replica\",\"type\":\"collection\"}\n", "content_length": "1485", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Wed, 09 Dec 2020 09:27:15 GMT", "json": {"createTypes": {"replica": "http://10.111.116.118:9501/v1/replicas"}, "data": [{"actions": {"preparerebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy?action=preparerebuild", "verifyrebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy?action=verifyrebuild"}, "address": "tcp://192.168.1.142:9502", "id": "dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy", "links": {"self": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0Mjo5NTAy"}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy?action=preparerebuild", "verifyrebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy?action=verifyrebuild"}, "address": "tcp://192.168.2.178:9502", "id": "dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy", "links": {"self": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE3ODo5NTAy"}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=?action=preparerebuild", "verifyrebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=?action=verifyrebuild"}, "address": "tcp://192.168.3.92:9502", "id": "dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI=", "links": {"self": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjkyOjk1MDI="}, "mode": "RW", "type": "replica"}], "links": {"self": "http://10.111.116.118:9501/v1/replicas"}, "resourceType": "replica", "type": "collection"}, "msg": "OK (1485 bytes)", "redirected": false, "status": 200, "url": "http://10.111.116.118:9501/v1/replicas", "x_api_schemas": "http://10.111.116.118:9501/v1/schemas"}

TASK [Getting replica1 IP] *****************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:164
2020-12-09T09:27:15.224083 (delta: 4.904428)         elapsed: 27.373495 ******* 
 [WARNING]: Consider using the get_url or uri module rather than running curl.
If you need to use command because get_url or uri is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "curl http://10.111.116.118:9501/v1/replicas | jq '.data[0].address' | sed -e 's/^\"//' -e 's/\"$//'", "delta": "0:00:00.514658", "end": "2020-12-09 09:27:15.851977", "rc": 0, "start": "2020-12-09 09:27:15.337319", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1485  100  1485    0     0  1450k      0 --:--:-- --:--:-- --:--:-- 1450k", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1485  100  1485    0     0  1450k      0 --:--:-- --:--:-- --:--:-- 1450k"], "stdout": "tcp://192.168.1.142:9502", "stdout_lines": ["tcp://192.168.1.142:9502"]}

TASK [Set replica1 ip] *********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:173
2020-12-09T09:27:15.882824 (delta: 0.658707)         elapsed: 28.032236 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica1_ip": "192.168.1.142"}, "changed": false}

TASK [Getting replica2 IP] *****************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:177
2020-12-09T09:27:15.925164 (delta: 0.042304)         elapsed: 28.074576 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "curl http://10.111.116.118:9501/v1/replicas | jq '.data[1].address' | sed -e 's/^\"//' -e 's/\"$//'", "delta": "0:00:00.517211", "end": "2020-12-09 09:27:16.554516", "rc": 0, "start": "2020-12-09 09:27:16.037305", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1485  100  1485    0     0  1450k      0 --:--:-- --:--:-- --:--:-- 1450k", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1485  100  1485    0     0  1450k      0 --:--:-- --:--:-- --:--:-- 1450k"], "stdout": "tcp://192.168.2.178:9502", "stdout_lines": ["tcp://192.168.2.178:9502"]}

TASK [Set replica2 ip] *********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:186
2020-12-09T09:27:16.583472 (delta: 0.658273)         elapsed: 28.732884 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica2_ip": "192.168.2.178"}, "changed": false}

TASK [Getting replica3 IP] *****************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:190
2020-12-09T09:27:16.626214 (delta: 0.042706)         elapsed: 28.775626 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "curl http://10.111.116.118:9501/v1/replicas | jq '.data[2].address' | sed -e 's/^\"//' -e 's/\"$//'", "delta": "0:00:00.515431", "end": "2020-12-09 09:27:17.259971", "rc": 0, "start": "2020-12-09 09:27:16.744540", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1485  100  1485    0     0  1450k      0 --:--:-- --:--:-- --:--:-- 1450k", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100  1485  100  1485    0     0  1450k      0 --:--:-- --:--:-- --:--:-- 1450k"], "stdout": "tcp://192.168.3.92:9502", "stdout_lines": ["tcp://192.168.3.92:9502"]}

TASK [Set replica3 ip] *********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:199
2020-12-09T09:27:17.288460 (delta: 0.662211)         elapsed: 29.437872 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica3_ip": "192.168.3.92"}, "changed": false}

TASK [Getting the replica1 pod name corresponding to the IP] *******************
task path: /experiments/chaos/jiva_node_failure/test.yml:203
2020-12-09T09:27:17.329864 (delta: 0.041369)         elapsed: 29.479276 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume=pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5 -n openebs --no-headers -o jsonpath='{.items[?(@.status.podIP==\"192.168.1.142\")].metadata.name}'", "delta": "0:00:00.586266", "end": "2020-12-09 09:27:18.032606", "rc": 0, "start": "2020-12-09 09:27:17.446340", "stderr": "", "stderr_lines": [], "stdout": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-2", "stdout_lines": ["pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-2"]}

TASK [Getting the replica1 pod name corresponding to the IP] *******************
task path: /experiments/chaos/jiva_node_failure/test.yml:207
2020-12-09T09:27:18.061164 (delta: 0.731265)         elapsed: 30.210576 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume=pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5 -n openebs --no-headers -o jsonpath='{.items[?(@.status.podIP==\"192.168.2.178\")].metadata.name}'", "delta": "0:00:00.615657", "end": "2020-12-09 09:27:18.793669", "rc": 0, "start": "2020-12-09 09:27:18.178012", "stderr": "", "stderr_lines": [], "stdout": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-1", "stdout_lines": ["pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-1"]}

TASK [Getting the replica1 pod name corresponding to the IP] *******************
task path: /experiments/chaos/jiva_node_failure/test.yml:211
2020-12-09T09:27:18.818905 (delta: 0.757705)         elapsed: 30.968317 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l openebs.io/component=jiva-replica,openebs.io/persistent-volume=pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5 -n openebs --no-headers -o jsonpath='{.items[?(@.status.podIP==\"192.168.3.92\")].metadata.name}'", "delta": "0:00:00.594782", "end": "2020-12-09 09:27:19.543887", "rc": 0, "start": "2020-12-09 09:27:18.949105", "stderr": "", "stderr_lines": [], "stdout": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-0", "stdout_lines": ["pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-0"]}

TASK [Get replica1 pod Node to perform crash] **********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:216
2020-12-09T09:27:19.568466 (delta: 0.749507)         elapsed: 31.717878 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-2 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.586559", "end": "2020-12-09 09:27:20.274064", "rc": 0, "start": "2020-12-09 09:27:19.687505", "stderr": "", "stderr_lines": [], "stdout": "payes-worker2", "stdout_lines": ["payes-worker2"]}

TASK [Get replica2 pod Node to perform crash] **********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:225
2020-12-09T09:27:20.300331 (delta: 0.731832)         elapsed: 32.449743 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-1 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.581360", "end": "2020-12-09 09:27:21.021918", "rc": 0, "start": "2020-12-09 09:27:20.440558", "stderr": "", "stderr_lines": [], "stdout": "payes-worker3", "stdout_lines": ["payes-worker3"]}

TASK [Get replica3 pod Node to perform crash] **********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:234
2020-12-09T09:27:21.046905 (delta: 0.746536)         elapsed: 33.196317 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5-jiva-rep-0 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.588929", "end": "2020-12-09 09:27:21.753296", "rc": 0, "start": "2020-12-09 09:27:21.164367", "stderr": "", "stderr_lines": [], "stdout": "payes-worker1", "stdout_lines": ["payes-worker1"]}

TASK [Get replica1 pod Node IP to perform crash] *******************************
task path: /experiments/chaos/jiva_node_failure/test.yml:243
2020-12-09T09:27:21.778332 (delta: 0.731394)         elapsed: 33.927744 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes payes-worker2 -o jsonpath='{ $.status.addresses[?(@.type==\"InternalIP\")].address }'", "delta": "0:00:00.608819", "end": "2020-12-09 09:27:22.508840", "rc": 0, "start": "2020-12-09 09:27:21.900021", "stderr": "", "stderr_lines": [], "stdout": "10.56.2.12", "stdout_lines": ["10.56.2.12"]}

TASK [Get replica2 pod Node IP to perform crash] *******************************
task path: /experiments/chaos/jiva_node_failure/test.yml:252
2020-12-09T09:27:22.541854 (delta: 0.763485)         elapsed: 34.691266 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes payes-worker3 -o jsonpath='{ $.status.addresses[?(@.type==\"InternalIP\")].address }'", "delta": "0:00:00.594320", "end": "2020-12-09 09:27:23.248909", "rc": 0, "start": "2020-12-09 09:27:22.654589", "stderr": "", "stderr_lines": [], "stdout": "10.56.2.13", "stdout_lines": ["10.56.2.13"]}

TASK [Get replica3 pod Node IP to perform crash] *******************************
task path: /experiments/chaos/jiva_node_failure/test.yml:261
2020-12-09T09:27:23.273502 (delta: 0.731601)         elapsed: 35.422914 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes payes-worker1 -o jsonpath='{ $.status.addresses[?(@.type==\"InternalIP\")].address }'", "delta": "0:00:00.583923", "end": "2020-12-09 09:27:23.967224", "rc": 0, "start": "2020-12-09 09:27:23.383301", "stderr": "", "stderr_lines": [], "stdout": "10.56.2.11", "stdout_lines": ["10.56.2.11"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/jiva_node_failure/test.yml:271
2020-12-09T09:27:23.990418 (delta: 0.716879)         elapsed: 36.13983 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:280
2020-12-09T09:27:24.021981 (delta: 0.031529)         elapsed: 36.171393 ******* 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:27:24.060953 (delta: 0.038937)         elapsed: 36.210365 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "190667540777.1103", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/190667540777.1103", "started": 1}

TASK [check the application status] ********************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:285
2020-12-09T09:27:25.163599 (delta: 1.10261)         elapsed: 37.313011 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.607758", "end": "2020-12-09 09:27:25.893484", "rc": 0, "start": "2020-12-09 09:27:25.285726", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:295
2020-12-09T09:27:25.921277 (delta: 0.757643)         elapsed: 38.070689 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/jiva_node_failure/test.yml:305
2020-12-09T09:27:25.952091 (delta: 0.030765)         elapsed: 38.101503 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:314
2020-12-09T09:27:25.981962 (delta: 0.029835)         elapsed: 38.131374 ******* 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:27:26.009541 (delta: 0.027546)         elapsed: 38.158953 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "812365912251.1165", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/812365912251.1165", "started": 1}

TASK [check the application status] ********************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:319
2020-12-09T09:27:27.104563 (delta: 1.094969)         elapsed: 39.253975 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.581908", "end": "2020-12-09 09:27:27.824695", "rc": 0, "start": "2020-12-09 09:27:27.242787", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:329
2020-12-09T09:27:27.851805 (delta: 0.747206)         elapsed: 40.001217 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/jiva_node_failure/test.yml:339
2020-12-09T09:27:27.883020 (delta: 0.031149)         elapsed: 40.032432 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:348
2020-12-09T09:27:27.916046 (delta: 0.032989)         elapsed: 40.065458 ******* 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:27:27.944977 (delta: 0.028883)         elapsed: 40.094389 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "109662755831.1227", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/109662755831.1227", "started": 1}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:353
2020-12-09T09:27:29.042283 (delta: 1.097272)         elapsed: 41.191695 ******* 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:27:29.078174 (delta: 0.035837)         elapsed: 41.227586 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "683544010867.1254", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/683544010867.1254", "started": 1}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:358
2020-12-09T09:27:30.180120 (delta: 1.101903)         elapsed: 42.329532 ******* 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:27:30.211156 (delta: 0.030999)         elapsed: 42.360568 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "887727791012.1281", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/887727791012.1281", "started": 1}

TASK [check the application status] ********************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:363
2020-12-09T09:27:31.313883 (delta: 1.102692)         elapsed: 43.463295 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.659065", "end": "2020-12-09 09:27:32.090744", "rc": 0, "start": "2020-12-09 09:27:31.431679", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:373
2020-12-09T09:27:32.125057 (delta: 0.811138)         elapsed: 44.274469 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:383
2020-12-09T09:27:32.153805 (delta: 0.028712)         elapsed: 44.303217 ******* 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2020-12-09T09:27:32.193964 (delta: 0.040129)         elapsed: 44.343376 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.56.1.1 vim-cmd vmsvc/getallvms | awk '{print $1 \" \" $2}' | grep payes-worker1 | awk '{print $1}'", "delta": "0:00:01.237478", "end": "2020-12-09 09:27:33.599812", "rc": 0, "start": "2020-12-09 09:27:32.362334", "stderr": "Warning: Permanently added '10.56.1.1' (RSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '10.56.1.1' (RSA) to the list of known hosts."], "stdout": "3", "stdout_lines": ["3"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2020-12-09T09:27:33.623620 (delta: 1.42962)         elapsed: 45.773032 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.56.1.1 vim-cmd vmsvc/power.off 3", "delta": "0:00:04.828693", "end": "2020-12-09 09:27:38.566862", "failed_when_result": false, "rc": 0, "start": "2020-12-09 09:27:33.738169", "stderr": "", "stderr_lines": [], "stdout": "Powering off VM:", "stdout_lines": ["Powering off VM:"]}

TASK [Check the node status] ***************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:390
2020-12-09T09:27:38.596477 (delta: 4.972809)         elapsed: 50.745889 ******* 
FAILED - RETRYING: Check the node status (30 retries left).
FAILED - RETRYING: Check the node status (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get nodes payes-worker1 --no-headers", "delta": "0:00:00.606757", "end": "2020-12-09 09:28:10.723788", "rc": 0, "start": "2020-12-09 09:28:10.117031", "stderr": "", "stderr_lines": [], "stdout": "payes-worker1   NotReady   <none>   186d   v1.18.3", "stdout_lines": ["payes-worker1   NotReady   <none>   186d   v1.18.3"]}

TASK [Generate data on the specified application.] *****************************
task path: /experiments/chaos/jiva_node_failure/test.yml:400
2020-12-09T09:28:10.750294 (delta: 32.153782)         elapsed: 82.899706 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:409
2020-12-09T09:28:10.784335 (delta: 0.034008)         elapsed: 82.933747 ******* 
included: /chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:9
2020-12-09T09:28:10.815828 (delta: 0.031457)         elapsed: 82.96524 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.56.1.1 vim-cmd vmsvc/getallvms | awk '{print $1 \" \" $2}' | grep payes-worker1 | awk '{print $1}'", "delta": "0:00:01.198776", "end": "2020-12-09 09:28:12.139211", "rc": 0, "start": "2020-12-09 09:28:10.940435", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Perform operation on the target vm] **************************************
task path: /chaoslib/vmware_chaos/vm_power_operations.yml:15
2020-12-09T09:28:12.164211 (delta: 1.348353)         elapsed: 84.313623 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.56.1.1 vim-cmd vmsvc/power.on 3", "delta": "0:00:01.616069", "end": "2020-12-09 09:28:13.905678", "failed_when_result": false, "rc": 0, "start": "2020-12-09 09:28:12.289609", "stderr": "", "stderr_lines": [], "stdout": "Powering on VM:", "stdout_lines": ["Powering on VM:"]}

TASK [Get total replica count from controller] *********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:416
2020-12-09T09:28:13.934729 (delta: 1.770484)         elapsed: 86.084141 ******* 
FAILED - RETRYING: Get total replica count from controller (180 retries left).
FAILED - RETRYING: Get total replica count from controller (179 retries left).
FAILED - RETRYING: Get total replica count from controller (178 retries left).
FAILED - RETRYING: Get total replica count from controller (177 retries left).
FAILED - RETRYING: Get total replica count from controller (176 retries left).
FAILED - RETRYING: Get total replica count from controller (175 retries left).
FAILED - RETRYING: Get total replica count from controller (174 retries left).
FAILED - RETRYING: Get total replica count from controller (173 retries left).
FAILED - RETRYING: Get total replica count from controller (172 retries left).
FAILED - RETRYING: Get total replica count from controller (171 retries left).
FAILED - RETRYING: Get total replica count from controller (170 retries left).
FAILED - RETRYING: Get total replica count from controller (169 retries left).
FAILED - RETRYING: Get total replica count from controller (168 retries left).
FAILED - RETRYING: Get total replica count from controller (167 retries left).
FAILED - RETRYING: Get total replica count from controller (166 retries left).
FAILED - RETRYING: Get total replica count from controller (165 retries left).
FAILED - RETRYING: Get total replica count from controller (164 retries left).
FAILED - RETRYING: Get total replica count from controller (163 retries left).
FAILED - RETRYING: Get total replica count from controller (162 retries left).
FAILED - RETRYING: Get total replica count from controller (161 retries left).
FAILED - RETRYING: Get total replica count from controller (160 retries left).
FAILED - RETRYING: Get total replica count from controller (159 retries left).
FAILED - RETRYING: Get total replica count from controller (158 retries left).
FAILED - RETRYING: Get total replica count from controller (157 retries left).
FAILED - RETRYING: Get total replica count from controller (156 retries left).
FAILED - RETRYING: Get total replica count from controller (155 retries left).
FAILED - RETRYING: Get total replica count from controller (154 retries left).
FAILED - RETRYING: Get total replica count from controller (153 retries left).
FAILED - RETRYING: Get total replica count from controller (152 retries left).
FAILED - RETRYING: Get total replica count from controller (151 retries left).
FAILED - RETRYING: Get total replica count from controller (150 retries left).
FAILED - RETRYING: Get total replica count from controller (149 retries left).
FAILED - RETRYING: Get total replica count from controller (148 retries left).
FAILED - RETRYING: Get total replica count from controller (147 retries left).
FAILED - RETRYING: Get total replica count from controller (146 retries left).
FAILED - RETRYING: Get total replica count from controller (145 retries left).
FAILED - RETRYING: Get total replica count from controller (144 retries left).
FAILED - RETRYING: Get total replica count from controller (143 retries left).
FAILED - RETRYING: Get total replica count from controller (142 retries left).
FAILED - RETRYING: Get total replica count from controller (141 retries left).
FAILED - RETRYING: Get total replica count from controller (140 retries left).
FAILED - RETRYING: Get total replica count from controller (139 retries left).
FAILED - RETRYING: Get total replica count from controller (138 retries left).
FAILED - RETRYING: Get total replica count from controller (137 retries left).
ok: [127.0.0.1] => {"attempts": 45, "changed": false, "connection": "close", "content": "{\"data\":[{\"actions\":{\"deleteSnapshot\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=deleteSnapshot\",\"resize\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=resize\",\"revert\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=revert\",\"setlogging\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=setlogging\",\"shutdown\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=shutdown\",\"snapshot\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=snapshot\"},\"id\":\"cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==\"},\"name\":\"pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}],\"links\":{\"self\":\"http://10.111.116.118:9501/v1/volumes\"},\"resourceType\":\"volume\",\"type\":\"collection\"}\n", "content_length": "1158", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Wed, 09 Dec 2020 09:29:24 GMT", "json": {"data": [{"actions": {"deleteSnapshot": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=deleteSnapshot", "resize": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=resize", "revert": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=revert", "setlogging": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=setlogging", "shutdown": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=shutdown", "snapshot": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==?action=snapshot"}, "id": "cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ==", "links": {"self": "http://10.111.116.118:9501/v1/volumes/cHZjLWZlNTQ0NDc0LWQyYzYtNDkzZC04NmQ3LWM4ZWJlOGE1MTJjNQ=="}, "name": "pvc-fe544474-d2c6-493d-86d7-c8ebe8a512c5", "readOnly": "false", "replicaCount": 3, "type": "volume"}], "links": {"self": "http://10.111.116.118:9501/v1/volumes"}, "resourceType": "volume", "type": "collection"}, "msg": "OK (1158 bytes)", "redirected": false, "status": 200, "url": "http://10.111.116.118:9501/v1/volumes", "x_api_schemas": "http://10.111.116.118:9501/v1/schemas"}

TASK [Get wo replica status from controller] ***********************************
task path: /experiments/chaos/jiva_node_failure/test.yml:432
2020-12-09T09:29:24.155418 (delta: 70.220654)         elapsed: 156.30483 ****** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "connection": "close", "content": "{\"createTypes\":{\"replica\":\"http://10.111.116.118:9501/v1/replicas\"},\"data\":[{\"actions\":{\"preparerebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=?action=preparerebuild\",\"verifyrebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=?action=verifyrebuild\"},\"address\":\"tcp://192.168.3.94:9502\",\"id\":\"dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy?action=preparerebuild\",\"verifyrebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy?action=verifyrebuild\"},\"address\":\"tcp://192.168.2.183:9502\",\"id\":\"dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy\"},\"mode\":\"RW\",\"type\":\"replica\"},{\"actions\":{\"preparerebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy?action=preparerebuild\",\"verifyrebuild\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy?action=verifyrebuild\"},\"address\":\"tcp://192.168.1.145:9502\",\"id\":\"dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy\",\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy\"},\"mode\":\"WO\",\"type\":\"replica\"}],\"links\":{\"self\":\"http://10.111.116.118:9501/v1/replicas\"},\"resourceType\":\"replica\",\"type\":\"collection\"}\n", "content_length": "1485", "content_type": "application/json", "cookies": {}, "cookies_string": "", "date": "Wed, 09 Dec 2020 09:29:24 GMT", "json": {"createTypes": {"replica": "http://10.111.116.118:9501/v1/replicas"}, "data": [{"actions": {"preparerebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=?action=preparerebuild", "verifyrebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=?action=verifyrebuild"}, "address": "tcp://192.168.3.94:9502", "id": "dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI=", "links": {"self": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4zLjk0Ojk1MDI="}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy?action=preparerebuild", "verifyrebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy?action=verifyrebuild"}, "address": "tcp://192.168.2.183:9502", "id": "dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy", "links": {"self": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4yLjE4Mzo5NTAy"}, "mode": "RW", "type": "replica"}, {"actions": {"preparerebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy?action=preparerebuild", "verifyrebuild": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy?action=verifyrebuild"}, "address": "tcp://192.168.1.145:9502", "id": "dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy", "links": {"self": "http://10.111.116.118:9501/v1/replicas/dGNwOi8vMTkyLjE2OC4xLjE0NTo5NTAy"}, "mode": "WO", "type": "replica"}], "links": {"self": "http://10.111.116.118:9501/v1/replicas"}, "resourceType": "replica", "type": "collection"}, "msg": "OK (1485 bytes)", "redirected": false, "status": 200, "url": "http://10.111.116.118:9501/v1/replicas", "x_api_schemas": "http://10.111.116.118:9501/v1/schemas"}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:449
2020-12-09T09:29:24.389708 (delta: 0.234244)         elapsed: 156.53912 ******* 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:29:24.427193 (delta: 0.03745)         elapsed: 156.576605 ******* 
changed: [127.0.0.1] => {"ansible_job_id": "487058970952.2380", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/487058970952.2380", "started": 1}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:454
2020-12-09T09:29:25.533351 (delta: 1.106069)         elapsed: 157.682763 ****** 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:29:25.566275 (delta: 0.032888)         elapsed: 157.715687 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "601330845534.2407", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/601330845534.2407", "started": 1}

TASK [include_tasks] ***********************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:459
2020-12-09T09:29:26.665166 (delta: 1.098803)         elapsed: 158.814578 ****** 
included: /chaoslib/kernel_chaos/kill_node.yml for 127.0.0.1

TASK [Execute 'panic'] *********************************************************
task path: /chaoslib/kernel_chaos/kill_node.yml:3
2020-12-09T09:29:26.703000 (delta: 0.037798)         elapsed: 158.852412 ****** 
changed: [127.0.0.1] => {"ansible_job_id": "859443904722.2434", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/859443904722.2434", "started": 1}

TASK [Verify application data persistence] *************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:463
2020-12-09T09:29:27.818684 (delta: 1.115648)         elapsed: 159.968096 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /experiments/chaos/jiva_node_failure/test.yml:471
2020-12-09T09:29:27.854735 (delta: 0.036016)         elapsed: 160.004147 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=72   changed=40   unreachable=0    failed=0   

2020-12-09T09:29:27.891855 (delta: 0.037083)         elapsed: 160.041267 ****** 
=============================================================================== 
```