### PR TITLE
feat(exp): add e2e test for zfspv-clone creation directly from pvc as datasource

### DIFF
--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/README.md
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/README.md
@@ -20,7 +20,7 @@ ZFS-LocalPV version: v1.1.0+
 
 ## Steps performed
 
-This experiment consist of provisioning and deprovisioing of zfspv-clone but performs one task at a time based on ACTION env value < provision or deprovision >.
+This experiment consist of provisioning and deprovisioning of zfspv-clone but performs one task at a time based on ACTION env value < provision or deprovision >.
 
 Provision:
 

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/README.md
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/README.md
@@ -1,0 +1,62 @@
+## About this experiment
+
+This experiment creates the clone directly from the volume as datasource and use that cloned volume for some application. This experiment verifies that clone volume should have the same data for which snaphsot was taken and this data should be easily accessible from some new application when this clone volume is mounted on it.
+
+## Supported platforms:
+
+K8S : 1.17+
+
+OS : Ubuntu 18.04, Ubuntu 16.04, CentOS 7, CentOS 8
+
+ZFS : 0.7, 0.8
+
+ZFS-LocalPV version: v1.1.0+
+
+## Entry-Criteria
+
+- K8s cluster should be in healthy state including all the nodes in ready state.
+- zfs-controller and node-agent daemonset pods should be in running state.
+- size for the clone-pvc should be equal to the original pvc.
+
+## Steps performed
+
+This experiment consist of provisioning and deprovisioing of zfspv-clone but performs one task at a time based on ACTION env value < provision or deprovision >.
+
+Provision:
+
+- Create the clone by applying the pvc yaml with parent pvc name in the datasource.
+- Verify that clone-pvc gets bound.
+- Deploy new application and verifies that clone volume gets successully mounted on application.
+- Verify the data consistency that it should contain the same data as of volume snapshot.
+
+Deprovision:
+
+- Delete the application which is using the cloned volume.
+- Verify that clone pvc is deleted successfully.
+- Verify that zvolume is deleted successfully.
+
+## How to run
+
+- This experiment accepts the parameters in form of job environmental variables.
+- For running this experiment of zfspv-clone-from-pvc creation, clone openens/e2e-tests repo and then first apply the rbac and crds.
+```
+kubectl apply -f e2e-tests/hack/rbac.yaml
+kubectl apply -f e2e-tests/hack/crds.yaml
+```
+then update the needed test specific values in run_litmus_test.yml file and create the kubernetes job.
+
+
+## Experiment job env's
+
+| Parameters    | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| APP_NAMESPACE | Namespace where application and volume is deployed.    |
+| OPERATOR_NS   | Namespace in which all the resources created by zfs driver will be present for e.g. zfsvolume (zv) will be in this namespace |
+| STORAGE_CLASS| Storage class name by which original volume was provisioned |
+| PARENT_PVC_NAME | This parent pvc name will be used as datasource for clone creation  |
+| CLONED_PVC_NAME |Cloned pvc will be created by this name in the same namespace where spapshot is present |
+| CLONE_PVC_SIZE | clone PVC size should match the size of the snapshot  |
+| APP_NAME       | Provide the application name which will be deployed using cloned PVC. Supported values are: `busybox` and `percona` |
+| APP_LABEL     | Label name of the application                     |
+| DATA_PERSISTENCE | Data accessibility & integrity verification by dumping some test data into the application and verify if later. To check against busybox set value: "busybox" and for percona, set value: "mysql". Only supported for busybox and percona application, for other application leave this env blank.|
+

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/busybox.j2
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/busybox.j2
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ app_name }}-clone
+  namespace: "{{ app_ns }}"
+  labels:
+    app: "{{ app_label }}"
+spec:
+  selector:
+    matchLabels:
+      app: "{{ app_label }}"
+  template:
+    metadata:
+      labels:
+        app: "{{ app_label }}"
+    spec:
+      containers:
+      - name: app-busybox
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: data-vol
+          mountPath: /busybox
+      volumes:
+      - name: data-vol
+        persistentVolumeClaim:
+          claimName: "{{ clone_pvc_name }}"

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/clone_pvc.j2
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/clone_pvc.j2
@@ -1,0 +1,15 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: {{ clone_pvc_name }}
+    namespace: {{ app_ns }}
+spec:
+    storageClassName: {{ storage_class }}
+    dataSource:
+      name: {{ parent_pvc_name }}
+      kind: PersistentVolumeClaim
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: {{ clone_pvc_size }}  ## clone PVC size should match the size of the snapshot

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/percona.j2
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/percona.j2
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ app_name }}-clone
+  namespace: {{ app_ns }}
+  labels:
+    app: {{ app_label }}
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      app: {{ app_label }} 
+  template: 
+    metadata:
+      labels: 
+        app: {{ app_label }}
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: openebs/tests-custom-percona:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: data-vol
+          #<!-- BEGIN ANSIBLE MANAGED BLOCK -->
+          livenessProbe:
+            exec:
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 60
+            periodSeconds: 1
+            timeoutSeconds: 10
+          #<!-- END ANSIBLE MANAGED BLOCK --> 
+      volumes:
+        - name: data-vol
+          persistentVolumeClaim:
+            claimName: {{ clone_pvc_name }}

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
@@ -51,7 +51,7 @@ spec:
             value: ""                     ## For `Busybox` : `busybox`  &  For `Percona` : `mysql`
        
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./experiments/zfs-localpv/functional/zfspv-clone/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 
         volumeMounts:
         - name: parameters

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: zfspv-clone-from-pvc
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: zfspv-clone-from-pvc
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays  #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE           ## Namespace in which application is deployed
+            value: '' 
+
+          - name: OPERATOR_NAMESPACE      ## Namespace in which all the resources created by zfs driver will be present
+            value: ''                     ## for e.g. zfsvolume (zv) will be in this namespace
+
+          - name: STORAGE_CLASS           ## Storage class name by which original volume was provisioned
+            value: ''
+            
+          - name: PARENT_PVC_NAME         ## Give value of parent pvc name which is using by the application
+            value: '' 
+
+          - name: CLONED_PVC_NAME         ## Cloned pvc will be created by this name in the same namespace where spapshot is present
+            value: ''
+        
+          - name: CLONE_PVC_SIZE          ## clone PVC size should match the size of the snapshot
+            value: '' 
+      
+          - name: APP_NAME                ## Provide the application name which will be deployed using cloned PVC
+            value: ''                     ## Supported values are: `busybox` and `percona`
+            
+          - name: APP_LABEL               ## Here app label is in key-value pair of app="{{value}}"
+            value: ''                     ## Provide only "value" part in app_label
+                               
+          - name: ACTION                  ## Use 'deprovision' for clone cleanup
+            value: 'provision'
+             
+          - name: DATA_PERSISTENCE        ## Give values according to the application
+            value: ""                     ## For `Busybox` : `busybox`  &  For `Percona` : `mysql`
+       
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/zfs-localpv/functional/zfspv-clone/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: zfspv-clone-from-pvc

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
@@ -1,3 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zfspv-clone-from-pvc
+  namespace: litmus
+data:
+  parameters.yml: |
+  
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml
@@ -20,20 +20,55 @@
         
         - block:
 
-            - name: Update the clone_pvc template with the test specific values to create clone
-              template:
-                src: clone_pvc.j2
-                dest: clone_pvc.yml
-            
-            - name: Create the clone
-              shell: >
-                kubectl create -f clone_pvc.yml
-              args:
-                executable: /bin/bash
-              register: status
-              failed_when: "status.rc != 0"
+           - name: Get the application pod name
+             shell: >
+               kubectl get pod -n {{ app_ns }} -l {{ app_label }} 
+               --no-headers -o custom-columns=:.metadata.name
+             args:
+               executable: /bin/bash
+             register: app_pod_name
 
-            - block:
+           - name: Check if the application pod is in running state
+             shell: >
+               kubectl get pods -n {{ app_ns }} -l {{ app_label }} 
+               --no-headers -o custom-columns=:.status.phase
+             args:
+               executable: /bin/bash
+             register: app_pod_status
+             failed_when: "'Running' not in app_pod_status.stdout"
+
+           - block:
+              - name: Create some test data into the application
+                include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+                vars:
+                  status: 'LOAD'
+                  ns: "{{ app_ns }}"
+                  pod_name: "{{ app_pod_name.stdout }}"  
+             when: data_persistence == 'busybox'
+            
+           - block:
+              - name: Create some test data into the application
+                include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+                vars:
+                  status: 'LOAD'
+                  ns: "{{ app_ns }}"
+                  pod_name: "{{ app_pod_name.stdout }}"  
+             when: data_persistence == 'mysql'
+
+           - name: Update the clone_pvc template with the test specific values to create clone
+             template:
+               src: clone_pvc.j2
+               dest: clone_pvc.yml
+            
+           - name: Create the clone
+             shell: >
+               kubectl create -f clone_pvc.yml
+             args:
+               executable: /bin/bash
+             register: status
+             failed_when: "status.rc != 0"
+
+           - block:
               - name: Update the {{ app_name }} deployment yaml with test specific values
                 template:
                   src: busybox.j2
@@ -44,9 +79,9 @@
                   kubectl create -f busybox.yml 
                 args:
                   executable: /bin/bash
-              when: app_name == "busybox"
+             when: app_name == "busybox"
 
-            - block:
+           - block:
               - name: Update the {{ app_name }} deployment yaml with test specific values
                 template:
                   src: percona.j2
@@ -57,70 +92,70 @@
                   kubectl create -f percona.yml 
                 args:
                   executable: /bin/bash
-              when: app_name == "percona"
+             when: app_name == "percona"
            
-            - name: Check if the cloned PVC is bound
-              shell: >
-                kubectl get pvc {{ clone_pvc_name }} -n {{ app_ns }} 
-                --no-headers -o custom-columns=:.status.phase
-              args:
-                executable: /bin/bash
-              register: clone_pvc_status
-              until: "'Bound' in clone_pvc_status.stdout"
-              delay: 5
-              retries: 30
+           - name: Check if the cloned PVC is bound
+             shell: >
+               kubectl get pvc {{ clone_pvc_name }} -n {{ app_ns }} 
+               --no-headers -o custom-columns=:.status.phase
+             args:
+               executable: /bin/bash
+             register: clone_pvc_status
+             until: "'Bound' in clone_pvc_status.stdout"
+             delay: 5
+             retries: 30
 
-            - name: Get {{ app_name }} application pod name
-              shell: >
-                kubectl get pods -n {{ app_ns }} -l app={{ app_label }} --no-headers
-                -o=custom-columns=NAME:".metadata.name"
-              args:
-                executable: /bin/bash
-              register: pod_name
+           - name: Get {{ app_name }} application pod name
+             shell: >
+               kubectl get pods -n {{ app_ns }} -l app={{ app_label }} --no-headers
+               -o=custom-columns=NAME:".metadata.name"
+             args:
+               executable: /bin/bash
+             register: pod_name
 
-            - name: Record the {{ app_name }} application pod name
-              set_fact:
-                app_pod_name: "{{ pod_name.stdout }}"
+           - name: Record the {{ app_name }} application pod name
+             set_fact:
+               app_pod_name: "{{ pod_name.stdout }}"
 
-            - name: Checking {{ app_name }} application pod is in running state
-              shell: >
-                kubectl get pods {{app_pod_name}} -n {{ app_ns }} 
-                -o jsonpath='{.status.phase}'
-              register: pod_status
-              until: "'Running' in pod_status.stdout"
-              delay: 5
-              retries: 50
+           - name: Checking {{ app_name }} application pod is in running state
+             shell: >
+               kubectl get pods {{app_pod_name}} -n {{ app_ns }} 
+               -o jsonpath='{.status.phase}'
+             register: pod_status
+             until: "'Running' in pod_status.stdout"
+             delay: 5
+             retries: 50
         
-            - name: Get the container status of {{ app_name }} application pod
-              shell: >
-                kubectl get pods {{ app_pod_name }} -n {{ app_ns }} 
-                -o jsonpath='{.status.containerStatuses[].state}' | grep running
-              args:
-                executable: /bin/bash
-              register: containerStatus
-              until: "'running' in containerStatus.stdout"
-              delay: 2
-              retries: 50
+           - name: Get the container status of {{ app_name }} application pod
+             shell: >
+               kubectl get pods {{ app_pod_name }} -n {{ app_ns }} 
+               -o jsonpath='{.status.containerStatuses[].state}' | grep running
+             args:
+               executable: /bin/bash
+             register: containerStatus
+             until: "'running' in containerStatus.stdout"
+             delay: 2
+             retries: 50
                         
-            - block:
-                - name: Verify the data persistency
-                  include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
-                  vars:
-                    status: 'VERIFY'
-                    ns: "{{ app_ns }}"
-                    label: app={{ app_label }}
-                    pod_name: "{{ app_pod_name }}"
-              when: data_persistence == 'mysql'
+           - block:
+              - name: Verify the data persistency
+                include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+                vars:
+                  status: 'VERIFY'
+                  ns: "{{ app_ns }}"
+                  label: app={{ app_label }}
+                  pod_name: "{{ app_pod_name }}"
+             when: data_persistence == 'mysql'
 
-            - block: 
-                - name: Verify the data persistency
-                  include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
-                  vars:
-                    status: 'VERIFY'
-                    ns: "{{ app_ns }}"
-                    label: app={{ app_label}}
-                    pod_name: "{{ app_pod_name }}"
-              when: data_persistence == 'busybox'
+           - block: 
+              - name: Verify the data persistency
+                include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+                vars:
+                  status: 'VERIFY'
+                  ns: "{{ app_ns }}"
+                  label: app={{ app_label}}
+                  pod_name: "{{ app_pod_name }}"
+             when: data_persistence == 'busybox'
 
           when: lookup('env','ACTION') == 'provision'    
 

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml
@@ -1,0 +1,224 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+    
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /utils/fcm/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+        
+        - block:
+
+            - name: Update the clone_pvc template with the test specific values to create clone
+              template:
+                src: clone_pvc.j2
+                dest: clone_pvc.yml
+            
+            - name: Create the clone
+              shell: >
+                kubectl create -f clone_pvc.yml
+              args:
+                executable: /bin/bash
+              register: status
+              failed_when: "status.rc != 0"
+
+            - block:
+              - name: Update the {{ app_name }} deployment yaml with test specific values
+                template:
+                  src: busybox.j2
+                  dest: busybox.yml
+
+              - name: Deploy the {{ app_name }} application using cloned PVC
+                shell: >
+                  kubectl create -f busybox.yml 
+                args:
+                  executable: /bin/bash
+              when: app_name == "busybox"
+
+            - block:
+              - name: Update the {{ app_name }} deployment yaml with test specific values
+                template:
+                  src: percona.j2
+                  dest: percona.yml
+
+              - name: Deploy the {{ app_name }} application using cloned PVC
+                shell: >
+                  kubectl create -f percona.yml 
+                args:
+                  executable: /bin/bash
+              when: app_name == "percona"
+           
+            - name: Check if the cloned PVC is bound
+              shell: >
+                kubectl get pvc {{ clone_pvc_name }} -n {{ app_ns }} 
+                --no-headers -o custom-columns=:.status.phase
+              args:
+                executable: /bin/bash
+              register: clone_pvc_status
+              until: "'Bound' in clone_pvc_status.stdout"
+              delay: 5
+              retries: 30
+
+            - name: Get {{ app_name }} application pod name
+              shell: >
+                kubectl get pods -n {{ app_ns }} -l app={{ app_label }} --no-headers
+                -o=custom-columns=NAME:".metadata.name"
+              args:
+                executable: /bin/bash
+              register: pod_name
+
+            - name: Record the {{ app_name }} application pod name
+              set_fact:
+                app_pod_name: "{{ pod_name.stdout }}"
+
+            - name: Checking {{ app_name }} application pod is in running state
+              shell: >
+                kubectl get pods {{app_pod_name}} -n {{ app_ns }} 
+                -o jsonpath='{.status.phase}'
+              register: pod_status
+              until: "'Running' in pod_status.stdout"
+              delay: 5
+              retries: 50
+        
+            - name: Get the container status of {{ app_name }} application pod
+              shell: >
+                kubectl get pods {{ app_pod_name }} -n {{ app_ns }} 
+                -o jsonpath='{.status.containerStatuses[].state}' | grep running
+              args:
+                executable: /bin/bash
+              register: containerStatus
+              until: "'running' in containerStatus.stdout"
+              delay: 2
+              retries: 50
+                        
+            - block:
+                - name: Verify the data persistency
+                  include_tasks: "/utils/scm/applications/mysql/mysql_data_persistence.yml"
+                  vars:
+                    status: 'VERIFY'
+                    ns: "{{ app_ns }}"
+                    label: app={{ app_label }}
+                    pod_name: "{{ app_pod_name }}"
+              when: data_persistence == 'mysql'
+
+            - block: 
+                - name: Verify the data persistency
+                  include_tasks: "/utils/scm/applications/busybox/busybox_data_persistence.yml"
+                  vars:
+                    status: 'VERIFY'
+                    ns: "{{ app_ns }}"
+                    label: app={{ app_label}}
+                    pod_name: "{{ app_pod_name }}"
+              when: data_persistence == 'busybox'
+
+          when: lookup('env','ACTION') == 'provision'    
+
+        - block:  
+            - name: Get the ZV name for the cloned PVC
+              shell: >
+                kubectl get pvc {{ clone_pvc_name }} -n {{ app_ns }} -o jsonpath='{.spec.volumeName}'
+              args:
+                executable: /bin/bash
+              register: zv_name
+
+            - name: Get {{ app_name }} application pod name which is using cloned pvc
+              shell: >
+                kubectl get pods -n {{ app_ns }} -l app={{ app_label }} --no-headers
+                -o=custom-columns=NAME:".metadata.name"
+              args:
+                executable: /bin/bash
+              register: pod_name
+            
+            - block:
+                - name: Update the {{ app_name }} deployment yaml with test specific values
+                  template:
+                    src: busybox.j2
+                    dest: busybox.yml
+
+                - name: delete the {{ app_name }} application which is using cloned pvc
+                  shell: >
+                    kubectl delete -f busybox.yml 
+                  args:
+                    executable: /bin/bash
+                  register: status
+                  failed_when: "status.rc != 0"
+              when: app_name == 'busybox'
+
+            - block:
+                - name: Update the {{ app_name }} deployment yaml with test specific values
+                  template:
+                    src: percona.j2
+                    dest: percona.yml
+
+                - name: delete the {{ app_name }} application which is using cloned pvc
+                  shell: >
+                    kubectl delete -f percona.yml 
+                  args:
+                    executable: /bin/bash
+                  register: status
+                  failed_when: "status.rc != 0"
+              when: app_name == 'percona'
+
+            - name: Check if the {{ app_name }} application pod which is using cloned pvc is deleted successfully
+              shell: >
+                kubectl get pods -n {{ app_ns }} 
+              args:
+                executable: /bin/bash
+              register: app_status
+              until: "pod_name.stdout not in app_status.stdout"
+              delay: 15
+              retries: 30   
+
+            - name: Delete the cloned pvc
+              shell: >
+                kubectl delete pvc {{ clone_pvc_name }} -n {{ app_ns }} 
+              args:
+                 executable: /bin/bash
+              register: pvc_status
+              failed_when: "pvc_status.rc != 0"
+
+            - name: Check if the cloned pvc is deleted
+              shell: >
+                kubectl get pvc -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: clone_pvc_status
+              until: "clone_pvc_name not in clone_pvc_status.stdout"
+              delay: 5
+              retries: 30
+
+            - name: Check if the ZV for cloned pvc is deleted
+              shell: >
+                kubectl get zv -n {{ operator_ns }} 
+              args:
+                executable: /bin/bash
+              register: zv_status
+              until: "zv_name.stdout not in zv_status.stdout"
+              delay: 5
+              retries: 15
+
+          when: lookup('env','ACTION') == 'deprovision'
+            
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /utils/fcm/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test_vars.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test_vars.yml
@@ -1,0 +1,21 @@
+test_name: zfspv-clone-from-pvc
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+storage_class: "{{ lookup('env','STORAGE_CLASS') }}"
+
+parent_pvc_name: "{{ lookup('env', 'PARENT_PVC_NAME') }}"
+
+clone_pvc_name: "{{ lookup('env','CLONED_PVC_NAME') }}"
+
+clone_pvc_size: "{{ lookup('env','CLONE_PVC_SIZE') }}"
+
+app_name: "{{ lookup('env','APP_NAME') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+action: "{{ lookup('env','ACTION') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #568

**What this PR does / why we need it**:
- This PR adds e2e test for zfspv clone creation directly from pvc as datasource. Here we don't need to create snapshot first to create any clone, we can directly create the clone from parent pvc.
- zfs_lcoalpv driver will take care of creating one internal snapshot and will create the clone from it. and when we will delete this clone volume snapshot will also be deleted which is taken care by zfs_localpv driver itself.
