### PR TITLE
refact(yaml): Add deprovision task of application and volumes after e2e-test

### DIFF
--- a/experiments/zfs-localpv/functional/zfspv-custom-topology/test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-custom-topology/test.yml
@@ -131,6 +131,20 @@
           with_items: "{{ app_pod_list.stdout_lines }}"
           failed_when: "'{{ node_name.stdout }}' not in node_list.stdout"
 
+        - name: Deprovision the application
+          shell: kubectl delete -f app_yamls_immediate/ -n {{ app_ns}}-immediate
+          args:
+            executable: /bin/bash
+          register: deprovision_status
+          failed_when: "deprovision_status.rc != 0"
+
+        - name: Delete the namespace
+          shell: kubectl delete ns {{ app_ns }}-immediate
+          args:
+            executable: /bin/bash
+          register: namespace_status
+          failed_when: "namespace_status.rc != 0"
+
         - name: Create namespace
           shell: kubectl create ns {{ app_ns}}-wfc
           args:
@@ -245,6 +259,20 @@
           register: node_name
           with_items: "{{ app_pod_list.stdout_lines }}"
           failed_when: "'{{ node_name.stdout }}' not in node_list.stdout"
+
+        - name: Deprovision the application
+          shell: kubectl delete -f app_yamls_wfc/ -n {{ app_ns}}-wfc
+          args:
+            executable: /bin/bash
+          register: deprovision_status
+          failed_when: "deprovision_status.rc != 0"
+
+        - name: Delete the namespace
+          shell: kubectl delete ns {{ app_ns }}-wfc
+          args:
+            executable: /bin/bash
+          register: namespace_status
+          failed_when: "namespace_status.rc != 0"
 
         - set_fact:
             flag: "Pass"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR adds deprovision task of application and volumes after performing the custom-topology test.
- So doing this will remove the stale resources left after e2e-test which will ease the Memory and cpu pressure situation  in pipeline during execution of test.
- Deleting the Yaml files of application deployment and pvc will delete the resources and with the status.rc code of the deletion command we can verify that the task has done its work successfully.