### PR TITLE
refact(yaml): fix the label mismatch in clone from pvc as datasource test

### DIFF
--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/busybox.j2
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/busybox.j2
@@ -4,15 +4,15 @@ metadata:
   name: {{ app_name }}-clone
   namespace: "{{ app_ns }}"
   labels:
-    app: "{{ app_label }}"
+    app: "{{ clone_app_label }}"
 spec:
   selector:
     matchLabels:
-      app: "{{ app_label }}"
+      app: "{{ clone_app_label }}"
   template:
     metadata:
       labels:
-        app: "{{ app_label }}"
+        app: "{{ clone_app_label }}"
     spec:
       containers:
       - name: app-busybox

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/percona.j2
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/percona.j2
@@ -4,16 +4,16 @@ metadata:
   name: {{ app_name }}-clone
   namespace: {{ app_ns }}
   labels:
-    app: {{ app_label }}
+    app: {{ clone_app_label }}
 spec:
   replicas: 1
   selector: 
     matchLabels:
-      app: {{ app_label }} 
+      app: {{ clone_app_label }} 
   template: 
     metadata:
       labels: 
-        app: {{ app_label }}
+        app: {{ clone_app_label }}
     spec:
       containers:
         - resources:

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/run_litmus_test.yml
@@ -33,6 +33,9 @@ spec:
           - name: APP_NAMESPACE           ## Namespace in which application is deployed
             value: '' 
 
+          - name: APP_LABEL               ## Parent application label
+            value: ''                     ## Give value in format (key=value)
+
           - name: OPERATOR_NAMESPACE      ## Namespace in which all the resources created by zfs driver will be present
             value: ''                     ## for e.g. zfsvolume (zv) will be in this namespace
 
@@ -51,7 +54,7 @@ spec:
           - name: APP_NAME                ## Provide the application name which will be deployed using cloned PVC
             value: ''                     ## Supported values are: `busybox` and `percona`
             
-          - name: APP_LABEL               ## Here app label is in key-value pair of app="{{value}}"
+          - name: CLONE_APP_LABEL         ## This is label of app which is clone pvc. Here app label is in key-value pair of app="{{value}}"
             value: ''                     ## Provide only "value" part in app_label
                                
           - name: ACTION                  ## Use 'deprovision' for clone cleanup

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test.yml
@@ -105,9 +105,9 @@
              delay: 5
              retries: 30
 
-           - name: Get {{ app_name }} application pod name
+           - name: Get {{ app_name }} application pod name which is using clone pvc
              shell: >
-               kubectl get pods -n {{ app_ns }} -l app={{ app_label }} --no-headers
+               kubectl get pods -n {{ app_ns }} -l app={{ clone_app_label }} --no-headers
                -o=custom-columns=NAME:".metadata.name"
              args:
                executable: /bin/bash
@@ -115,11 +115,11 @@
 
            - name: Record the {{ app_name }} application pod name
              set_fact:
-               app_pod_name: "{{ pod_name.stdout }}"
+               clone_pod_name: "{{ pod_name.stdout }}"
 
            - name: Checking {{ app_name }} application pod is in running state
              shell: >
-               kubectl get pods {{app_pod_name}} -n {{ app_ns }} 
+               kubectl get pods {{clone_pod_name}} -n {{ app_ns }} 
                -o jsonpath='{.status.phase}'
              register: pod_status
              until: "'Running' in pod_status.stdout"
@@ -128,7 +128,7 @@
         
            - name: Get the container status of {{ app_name }} application pod
              shell: >
-               kubectl get pods {{ app_pod_name }} -n {{ app_ns }} 
+               kubectl get pods {{ clone_pod_name }} -n {{ app_ns }} 
                -o jsonpath='{.status.containerStatuses[].state}' | grep running
              args:
                executable: /bin/bash
@@ -143,8 +143,8 @@
                 vars:
                   status: 'VERIFY'
                   ns: "{{ app_ns }}"
-                  label: app={{ app_label }}
-                  pod_name: "{{ app_pod_name }}"
+                  label: app={{ clone_app_label }}
+                  pod_name: "{{ clone_pod_name }}"
              when: data_persistence == 'mysql'
 
            - block: 
@@ -153,8 +153,8 @@
                 vars:
                   status: 'VERIFY'
                   ns: "{{ app_ns }}"
-                  label: app={{ app_label}}
-                  pod_name: "{{ app_pod_name }}"
+                  label: app={{ clone_app_label}}
+                  pod_name: "{{ clone_pod_name }}"
              when: data_persistence == 'busybox'
 
           when: lookup('env','ACTION') == 'provision'    
@@ -169,11 +169,11 @@
 
             - name: Get {{ app_name }} application pod name which is using cloned pvc
               shell: >
-                kubectl get pods -n {{ app_ns }} -l app={{ app_label }} --no-headers
+                kubectl get pods -n {{ app_ns }} -l app={{ clone_app_label }} --no-headers
                 -o=custom-columns=NAME:".metadata.name"
               args:
                 executable: /bin/bash
-              register: pod_name
+              register: clone_pod_name
             
             - block:
                 - name: Update the {{ app_name }} deployment yaml with test specific values
@@ -211,7 +211,7 @@
               args:
                 executable: /bin/bash
               register: app_status
-              until: "pod_name.stdout not in app_status.stdout"
+              until: "clone_pod_name.stdout not in app_status.stdout"
               delay: 15
               retries: 30   
 
@@ -220,8 +220,8 @@
                 kubectl delete pvc {{ clone_pvc_name }} -n {{ app_ns }} 
               args:
                  executable: /bin/bash
-              register: pvc_status
-              failed_when: "pvc_status.rc != 0"
+              register: clone_pvc_status
+              failed_when: "clone_pvc_status.rc != 0"
 
             - name: Check if the cloned pvc is deleted
               shell: >

--- a/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test_vars.yml
+++ b/experiments/zfs-localpv/functional/zfspv-clone-directly-from-pvc/test_vars.yml
@@ -14,6 +14,8 @@ app_name: "{{ lookup('env','APP_NAME') }}"
 
 app_label: "{{ lookup('env','APP_LABEL') }}"
 
+clone_app_label: "{{ lookup('env','CLONE_APP_LABEL') }}"
+
 action: "{{ lookup('env','ACTION') }}"
 
 operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR fixes the application pod label and the clone application mismatch. Before same label was used for both the application.