### PR TITLE
refactor(app-provision): Modified percona application deploy test case based on the app target affinity env

### DIFF
--- a/apps/minio/deployers/minio.yml
+++ b/apps/minio/deployers/minio.yml
@@ -26,6 +26,7 @@ spec:
       - name: minio
         # Pulls the default Minio image from Docker Hub
         image: minio/minio
+        imagePullPolicy: "IfNotPresent"
         args:
         - server
         - /storage1

--- a/apps/percona/deployers/affinity-percona.yml
+++ b/apps/percona/deployers/affinity-percona.yml
@@ -5,6 +5,7 @@ metadata:
   name: percona
   labels:
     lkey: lvalue
+    openebs.io/target-affinity: percona
 spec:
   replicas: 1
   selector: 
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels: 
         lkey: lvalue
+        openebs.io/target-affinity: percona
     spec:
       containers:
         - resources:
@@ -51,6 +53,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: testclaim
+  labels: 
+    openebs.io/target-affinity: percona  
 spec:
   storageClassName: testclass
   accessModes:

--- a/apps/percona/deployers/csi-percona.yml
+++ b/apps/percona/deployers/csi-percona.yml
@@ -71,4 +71,3 @@ spec:
       targetPort: 3306
   selector:
       lkey: lvalue
-

--- a/apps/percona/deployers/deployemnt_spec.j2
+++ b/apps/percona/deployers/deployemnt_spec.j2
@@ -1,0 +1,9 @@
+{% if app_target_affinity is defined and app_target_affinity == 'cstor' %}
+  application_deployment: affinity-percona.yml
+{% elif app_target_affinity is defined and app_target_affinity == 'cstor-csi' %}
+  application_deployment: csi-percona.yml
+{% else %}
+  application_deployment: percona.yml
+{% endif %}
+
+

--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -49,6 +49,9 @@ spec:
             # Enable storage i/o based liveness probe
           - name: IO_PROBE
             value: enabled
+
+          - name: TARGET_AFFINITY
+            value: ""
           
           - name: TARGET_AFFINITY_CHECK
             value: enable

--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -17,7 +17,15 @@
         - include_tasks: "/utils/fcm/update_litmus_result_resource.yml"
           vars:
             status: 'SOT'
-   
+  
+        - name: Identify the deployment spec to be invoked
+          template:
+            src: deployemnt_spec.j2
+            dest: deployemnt_spec.yml
+
+        - include_vars:
+            file: deployemnt_spec.yml
+
         - name: Replace the storage capacity placeholder
           replace:
               path: "{{ application_deployment }}"
@@ -29,7 +37,12 @@
             ## Actual test
             ## Creating namespaces and making the application for deployment
             - include_tasks: /utils/k8s/pre_create_app_deploy.yml
-        
+
+            - name: Display application deployment spec for verification
+              debug: var=item
+              with_file:
+              - "{{ application_deployment }}"
+
             ## Deploying the application, upper bound wait time: 900s 
             - include_tasks: /utils/k8s/deploy_single_app.yml
               vars:
@@ -73,4 +86,3 @@
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:
             status: 'EOT'
-              

--- a/apps/percona/deployers/test_vars.yml
+++ b/apps/percona/deployers/test_vars.yml
@@ -1,6 +1,6 @@
 # Test-specific parametres
 
-application_deployment: percona.yml
+#application_deployment: percona.yml
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 operator_ns: 'openebs'
 app_label: "{{ lookup('env','APP_LABEL') }}"
@@ -10,3 +10,4 @@ action: "{{ lookup('env','ACTION') }}"
 app_pvc: "{{ lookup('env','APP_PVC') }}"
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 capacity: "{{ lookup('env','CAPACITY') }}"
+app_target_affinity: "{{ lookup('env','TARGET_AFFINITY') }}"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Updated the test case to provision the percona application to obtain the deployment yaml based on the env

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
```
k8s@e2e1-master:~$ kubectl logs -f litmus-percona-mrrqq-k4nxf -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2020-12-11T08:28:48.121007 (delta: 0.040649)         elapsed: 0.040649 ******** 
=============================================================================== 

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:48.129927 (delta: 0.008897)         elapsed: 0.049569 ******** 
included: /utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2020-12-11T08:28:48.157920 (delta: 0.027978)         elapsed: 0.077562 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2020-12-11T08:28:48.185848 (delta: 0.027882)         elapsed: 0.10549 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:48.211796 (delta: 0.025914)         elapsed: 0.131438 ******** 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-12-11T08:28:48.275119 (delta: 0.063225)         elapsed: 0.194761 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "2fb43d87dfb4bba2e2fd205f2e69415962b85fac", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8988f4be16232bf55e019321913ae47e", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1607675328.31-93638142673541/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-12-11T08:28:48.769584 (delta: 0.494441)         elapsed: 0.689226 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.551248", "end": "2020-12-11 08:28:49.551781", "rc": 0, "start": "2020-12-11 08:28:49.000533", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: percona-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: percona-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2020-12-11T08:28:49.577911 (delta: 0.808276)         elapsed: 1.497553 ******** 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-12-11T08:20:37Z", "generation": 5, "name": "percona-deployment", "resourceVersion": "4131653", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/percona-deployment", "uid": "ded655d3-250b-40dd-b2cc-0c750a9ae37b"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "in-progress", "result": "none"}}}}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-12-11T08:28:50.349683 (delta: 0.771641)         elapsed: 2.269325 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-12-11T08:28:50.371938 (delta: 0.022226)         elapsed: 2.29158 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-12-11T08:28:50.398060 (delta: 0.026088)         elapsed: 2.317702 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the functional util to be invoked] ******************************
2020-12-11T08:28:50.422326 (delta: 0.024215)         elapsed: 2.341968 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "698b2b3677d67443e593a52ff87348cd2bd6501c", "dest": "./deployemnt_spec.yml", "gid": 0, "group": "root", "md5sum": "6a6d28f07f33b28bf8306c448acd6be5", "mode": "0644", "owner": "root", "size": 40, "src": "/root/.ansible/tmp/ansible-tmp-1607675330.45-202583727618762/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
2020-12-11T08:28:50.669643 (delta: 0.247235)         elapsed: 2.589285 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"application_deployment": "percona.yml"}, "ansible_included_var_files": ["/apps/percona/deployers/deployemnt_spec.yml"], "changed": false}

TASK [Replace the storage capacity placeholder] ********************************
2020-12-11T08:28:50.719941 (delta: 0.050264)         elapsed: 2.639583 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Display cspc.yml for verification] ***************************************
2020-12-11T08:28:50.992068 (delta: 0.272078)         elapsed: 2.91171 ********* 
ok: [127.0.0.1] => (item=---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: percona
  labels:
    lkey: lvalue
spec:
  replicas: 1
  selector: 
    matchLabels:
      lkey: lvalue 
  template: 
    metadata:
      labels: 
        lkey: lvalue
    spec:
      containers:
        - resources:
            limits:
              cpu: 0.5
          name: percona
          image: openebs/tests-custom-percona:latest
          imagePullPolicy: IfNotPresent
          args:
            - "--ignore-db-dir"
            - "lost+found"
          env:
            - name: MYSQL_ROOT_PASSWORD
              value: k8sDem0
          ports:
            - containerPort: 3306
              name: percona
          volumeMounts:
            - mountPath: /var/lib/mysql
              name: data-vol
          #<!-- BEGIN ANSIBLE MANAGED BLOCK -->
          livenessProbe:
            exec:
              command: ["bash", "sql-test.sh"]
            initialDelaySeconds: 60
            periodSeconds: 1
            timeoutSeconds: 10
          #<!-- END ANSIBLE MANAGED BLOCK --> 
      volumes:
        - name: data-vol
          persistentVolumeClaim:
            claimName: testclaim
---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: testclaim
spec:
  storageClassName: testclass
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
---
apiVersion: v1
kind: Service
metadata:
  name: percona-mysql
  labels:
    lkey: lvalue
spec:
  ports:
    - port: 3306
      targetPort: 3306
  selector:
      lkey: lvalue) => {
    "item": "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: percona\n  labels:\n    lkey: lvalue\nspec:\n  replicas: 1\n  selector: \n    matchLabels:\n      lkey: lvalue \n  template: \n    metadata:\n      labels: \n        lkey: lvalue\n    spec:\n      containers:\n        - resources:\n            limits:\n              cpu: 0.5\n          name: percona\n          image: openebs/tests-custom-percona:latest\n          imagePullPolicy: IfNotPresent\n          args:\n            - \"--ignore-db-dir\"\n            - \"lost+found\"\n          env:\n            - name: MYSQL_ROOT_PASSWORD\n              value: k8sDem0\n          ports:\n            - containerPort: 3306\n              name: percona\n          volumeMounts:\n            - mountPath: /var/lib/mysql\n              name: data-vol\n          #<!-- BEGIN ANSIBLE MANAGED BLOCK -->\n          livenessProbe:\n            exec:\n              command: [\"bash\", \"sql-test.sh\"]\n            initialDelaySeconds: 60\n            periodSeconds: 1\n            timeoutSeconds: 10\n          #<!-- END ANSIBLE MANAGED BLOCK --> \n      volumes:\n        - name: data-vol\n          persistentVolumeClaim:\n            claimName: testclaim\n---\nkind: PersistentVolumeClaim\napiVersion: v1\nmetadata:\n  name: testclaim\nspec:\n  storageClassName: testclass\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: 5Gi\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: percona-mysql\n  labels:\n    lkey: lvalue\nspec:\n  ports:\n    - port: 3306\n      targetPort: 3306\n  selector:\n      lkey: lvalue"
}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:51.045431 (delta: 0.053329)         elapsed: 2.965073 ******** 
included: /utils/k8s/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2020-12-11T08:28:51.094280 (delta: 0.048816)         elapsed: 3.013922 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc \"openebs-cstor-disk\"", "delta": "0:00:00.841733", "end": "2020-12-11 08:28:52.075832", "failed_when_result": false, "rc": 0, "start": "2020-12-11 08:28:51.234099", "stderr": "", "stderr_lines": [], "stdout": "NAME                 PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE\nopenebs-cstor-disk   openebs.io/provisioner-iscsi   Delete          Immediate           false                  23m", "stdout_lines": ["NAME                 PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE", "openebs-cstor-disk   openebs.io/provisioner-iscsi   Delete          Immediate           false                  23m"]}

TASK [Replace the pvc placeholder with provider] *******************************
2020-12-11T08:28:52.104575 (delta: 1.010247)         elapsed: 4.024217 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2020-12-11T08:28:52.267862 (delta: 0.163248)         elapsed: 4.187504 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:52.433799 (delta: 0.165888)         elapsed: 4.353441 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2020-12-11T08:28:52.478369 (delta: 0.044538)         elapsed: 4.398011 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "percona"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2020-12-11T08:28:52.539418 (delta: 0.061011)         elapsed: 4.45906 ********* 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2020-12-11T08:28:52.702813 (delta: 0.163362)         elapsed: 4.622455 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:52.737024 (delta: 0.034163)         elapsed: 4.656666 ******** 
included: /utils/k8s/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2020-12-11T08:28:52.790561 (delta: 0.053484)         elapsed: 4.710203 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.601220", "end": "2020-12-11 08:28:53.533674", "rc": 0, "start": "2020-12-11 08:28:52.932454", "stderr": "", "stderr_lines": [], "stdout": "app-percona-ns\ndefault\nkube-node-lease\nkube-public\nkube-system\nlitmus\nopenebs", "stdout_lines": ["app-percona-ns", "default", "kube-node-lease", "kube-public", "kube-system", "litmus", "openebs"]}

TASK [Create test specific namespace.] *****************************************
2020-12-11T08:28:53.564089 (delta: 0.773475)         elapsed: 5.483731 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-percona", "delta": "0:00:00.792741", "end": "2020-12-11 08:28:54.498846", "rc": 0, "start": "2020-12-11 08:28:53.706105", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-percona created", "stdout_lines": ["namespace/app-percona created"]}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:54.526731 (delta: 0.962612)         elapsed: 6.446373 ******** 
included: /utils/k8s/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2020-12-11T08:28:54.570096 (delta: 0.043246)         elapsed: 6.489738 ******** 
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "resources": [{"apiVersion": "v1", "kind": "Namespace", "metadata": {"creationTimestamp": "2020-12-11T08:28:54Z", "name": "app-percona", "resourceVersion": "4131673", "selfLink": "/api/v1/namespaces/app-percona", "uid": "cc659712-5fb7-4140-9bf8-69863391b4bf"}, "spec": {"finalizers": ["kubernetes"]}, "status": {"phase": "Active"}}]}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:55.411127 (delta: 0.840998)         elapsed: 7.330769 ******** 
included: /utils/k8s/deploy_single_app.yml for 127.0.0.1

TASK [Deploying percona] *******************************************************
2020-12-11T08:28:55.469098 (delta: 0.057923)         elapsed: 7.38874 ********* 
changed: [127.0.0.1] => {"changed": true, "result": {"results": [{"changed": true, "method": "create", "result": {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"creationTimestamp": "2020-12-11T08:28:56Z", "generation": 1, "labels": {"name": "percona"}, "name": "percona", "namespace": "app-percona", "resourceVersion": "4131681", "selfLink": "/apis/apps/v1/namespaces/app-percona/deployments/percona", "uid": "3aa404b4-f26c-429c-9779-bf41598bd019"}, "spec": {"progressDeadlineSeconds": 600, "replicas": 1, "revisionHistoryLimit": 10, "selector": {"matchLabels": {"name": "percona"}}, "strategy": {"rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"}, "type": "RollingUpdate"}, "template": {"metadata": {"creationTimestamp": null, "labels": {"name": "percona"}}, "spec": {"containers": [{"args": ["--ignore-db-dir", "lost+found"], "env": [{"name": "MYSQL_ROOT_PASSWORD", "value": "k8sDem0"}], "image": "openebs/tests-custom-percona:latest", "imagePullPolicy": "IfNotPresent", "livenessProbe": {"exec": {"command": ["bash", "sql-test.sh"]}, "failureThreshold": 3, "initialDelaySeconds": 60, "periodSeconds": 1, "successThreshold": 1, "timeoutSeconds": 10}, "name": "percona", "ports": [{"containerPort": 3306, "name": "percona", "protocol": "TCP"}], "resources": {"limits": {"cpu": "500m"}}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/var/lib/mysql", "name": "data-vol"}]}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "terminationGracePeriodSeconds": 30, "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "percona-mysql-claim"}}]}}}, "status": {}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"creationTimestamp": "2020-12-11T08:28:56Z", "finalizers": ["kubernetes.io/pvc-protection"], "name": "percona-mysql-claim", "namespace": "app-percona", "resourceVersion": "4131694", "selfLink": "/api/v1/namespaces/app-percona/persistentvolumeclaims/percona-mysql-claim", "uid": "f67d6dbb-9cc1-422c-b9f4-4688a7f02908"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "5Gi"}}, "storageClassName": "openebs-cstor-disk", "volumeMode": "Filesystem"}, "status": {"phase": "Pending"}}}, {"changed": true, "method": "create", "result": {"apiVersion": "v1", "kind": "Service", "metadata": {"creationTimestamp": "2020-12-11T08:28:56Z", "labels": {"name": "percona"}, "name": "percona-mysql", "namespace": "app-percona", "resourceVersion": "4131700", "selfLink": "/api/v1/namespaces/app-percona/services/percona-mysql", "uid": "f62d4d96-1649-40d2-a019-124c4427ae8f"}, "spec": {"clusterIP": "10.111.126.141", "ports": [{"port": 3306, "protocol": "TCP", "targetPort": 3306}], "selector": {"name": "percona"}, "sessionAffinity": "None", "type": "ClusterIP"}, "status": {"loadBalancer": {}}}}]}}

TASK [include_tasks] ***********************************************************
2020-12-11T08:28:56.269191 (delta: 0.80006)         elapsed: 8.188833 ********* 
included: /utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2020-12-11T08:28:56.323674 (delta: 0.054448)         elapsed: 8.243316 ******** 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
FAILED - RETRYING: Get the container status of application. (134 retries left).
FAILED - RETRYING: Get the container status of application. (133 retries left).
FAILED - RETRYING: Get the container status of application. (132 retries left).
changed: [127.0.0.1] => {"attempts": 20, "changed": true, "cmd": "kubectl get pod -n app-percona -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.892373", "end": "2020-12-11 08:29:51.994753", "rc": 0, "start": "2020-12-11 08:29:51.102380", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2020-12-11T08:29:50Z]]", "stdout_lines": ["map[running:map[startedAt:2020-12-11T08:29:50Z]]"]}

TASK [Checking percona pod is in running state] ********************************
2020-12-11T08:29:52.029363 (delta: 55.705505)         elapsed: 63.949005 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.792723", "end": "2020-12-11 08:29:52.964200", "rc": 0, "start": "2020-12-11 08:29:52.171477", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
2020-12-11T08:29:53.004386 (delta: 0.974974)         elapsed: 64.924028 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-12-11T08:29:53.053814 (delta: 0.049331)         elapsed: 64.973456 ******* 
included: /utils/k8s/fetch_app_pod.yml for 127.0.0.1

TASK [Getting the percona POD name] ********************************************
2020-12-11T08:29:53.125628 (delta: 0.07178)         elapsed: 65.04527 ********* 
ok: [127.0.0.1] => {"changed": false, "resources": [{"apiVersion": "v1", "kind": "Pod", "metadata": {"annotations": {"cni.projectcalico.org/podIP": "192.168.173.88/32"}, "creationTimestamp": "2020-12-11T08:28:56Z", "generateName": "percona-6959d4dbc9-", "labels": {"name": "percona", "pod-template-hash": "6959d4dbc9"}, "name": "percona-6959d4dbc9-668c9", "namespace": "app-percona", "ownerReferences": [{"apiVersion": "apps/v1", "blockOwnerDeletion": true, "controller": true, "kind": "ReplicaSet", "name": "percona-6959d4dbc9", "uid": "863505b4-c5c5-4c22-a1f2-ae525cf08e4e"}], "resourceVersion": "4132032", "selfLink": "/api/v1/namespaces/app-percona/pods/percona-6959d4dbc9-668c9", "uid": "dce6de7b-c803-47a0-bb22-4baa9f053277"}, "spec": {"containers": [{"args": ["--ignore-db-dir", "lost+found"], "env": [{"name": "MYSQL_ROOT_PASSWORD", "value": "k8sDem0"}], "image": "openebs/tests-custom-percona:latest", "imagePullPolicy": "IfNotPresent", "livenessProbe": {"exec": {"command": ["bash", "sql-test.sh"]}, "failureThreshold": 3, "initialDelaySeconds": 60, "periodSeconds": 1, "successThreshold": 1, "timeoutSeconds": 10}, "name": "percona", "ports": [{"containerPort": 3306, "name": "percona", "protocol": "TCP"}], "resources": {"limits": {"cpu": "500m"}, "requests": {"cpu": "500m"}}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File", "volumeMounts": [{"mountPath": "/var/lib/mysql", "name": "data-vol"}, {"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount", "name": "default-token-lztkn", "readOnly": true}]}], "dnsPolicy": "ClusterFirst", "enableServiceLinks": true, "nodeName": "e2e1-node3", "priority": 0, "restartPolicy": "Always", "schedulerName": "default-scheduler", "securityContext": {}, "serviceAccount": "default", "serviceAccountName": "default", "terminationGracePeriodSeconds": 30, "tolerations": [{"effect": "NoExecute", "key": "node.kubernetes.io/not-ready", "operator": "Exists", "tolerationSeconds": 300}, {"effect": "NoExecute", "key": "node.kubernetes.io/unreachable", "operator": "Exists", "tolerationSeconds": 300}], "volumes": [{"name": "data-vol", "persistentVolumeClaim": {"claimName": "percona-mysql-claim"}}, {"name": "default-token-lztkn", "secret": {"defaultMode": 420, "secretName": "default-token-lztkn"}}]}, "status": {"conditions": [{"lastProbeTime": null, "lastTransitionTime": "2020-12-11T08:28:58Z", "status": "True", "type": "Initialized"}, {"lastProbeTime": null, "lastTransitionTime": "2020-12-11T08:29:51Z", "status": "True", "type": "Ready"}, {"lastProbeTime": null, "lastTransitionTime": "2020-12-11T08:29:51Z", "status": "True", "type": "ContainersReady"}, {"lastProbeTime": null, "lastTransitionTime": "2020-12-11T08:28:58Z", "status": "True", "type": "PodScheduled"}], "containerStatuses": [{"containerID": "docker://b842d235e695cf5fdc6948f33436eb4664626682ca6419c711083eca2e1975a0", "image": "openebs/tests-custom-percona:latest", "imageID": "docker-pullable://openebs/tests-custom-percona@sha256:17fa3de8c5cef79695960f25ee06b9de69ddf2bf50d553afa151076c3cd59e1e", "lastState": {}, "name": "percona", "ready": true, "restartCount": 0, "started": true, "state": {"running": {"startedAt": "2020-12-11T08:29:50Z"}}}], "hostIP": "10.34.1.233", "phase": "Running", "podIP": "192.168.173.88", "podIPs": [{"ip": "192.168.173.88"}], "qosClass": "Burstable", "startTime": "2020-12-11T08:28:58Z"}}]}

TASK [debug] *******************************************************************
2020-12-11T08:29:53.923843 (delta: 0.798163)         elapsed: 65.843485 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "percona-6959d4dbc9-668c9"
    ]
}

TASK [include_tasks] ***********************************************************
2020-12-11T08:29:53.985718 (delta: 0.061819)         elapsed: 65.90536 ******** 
included: /utils/scm/applications/mysql/check_db_connection.yml for 127.0.0.1

TASK [Check if db is ready for connections] ************************************
2020-12-11T08:29:54.046480 (delta: 0.060724)         elapsed: 65.966122 ******* 
FAILED - RETRYING: Check if db is ready for connections (180 retries left).
FAILED - RETRYING: Check if db is ready for connections (179 retries left).
FAILED - RETRYING: Check if db is ready for connections (178 retries left).
FAILED - RETRYING: Check if db is ready for connections (177 retries left).
FAILED - RETRYING: Check if db is ready for connections (176 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl logs percona-6959d4dbc9-668c9 -n app-percona | grep 'ready for connections' | wc -l", "delta": "0:00:00.651599", "end": "2020-12-11 08:30:24.233662", "rc": 0, "start": "2020-12-11 08:30:23.582063", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [include_tasks] ***********************************************************
2020-12-11T08:30:24.265453 (delta: 30.218936)         elapsed: 96.185095 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-12-11T08:30:24.303299 (delta: 0.037788)         elapsed: 96.222941 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning the Application] ******************************************
2020-12-11T08:30:24.359856 (delta: 0.056496)         elapsed: 96.279498 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2020-12-11T08:30:24.406479 (delta: 0.045012)         elapsed: 96.326121 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2020-12-11T08:30:24.442473 (delta: 0.035459)         elapsed: 96.362115 ******* 
included: /utils/fcm/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2020-12-11T08:30:24.496533 (delta: 0.054005)         elapsed: 96.416175 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2020-12-11T08:30:24.526165 (delta: 0.029558)         elapsed: 96.445807 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2020-12-11T08:30:24.558618 (delta: 0.032394)         elapsed: 96.47826 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2020-12-11T08:30:24.590141 (delta: 0.031489)         elapsed: 96.509783 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "6bdd1ff2d018e616e50bff842ad05cafa7ec7f38", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5d64f6c678b53bfda23b3b57fa0d82ad", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1607675424.63-58760017660448/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2020-12-11T08:30:26.339181 (delta: 1.749003)         elapsed: 98.258823 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.690338", "end": "2020-12-11 08:30:27.161303", "rc": 0, "start": "2020-12-11 08:30:26.470965", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: percona-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: percona-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2020-12-11T08:30:27.193858 (delta: 0.854644)         elapsed: 99.1135 ********* 
changed: [127.0.0.1] => {"changed": true, "failed_when_result": false, "method": "patch", "result": {"apiVersion": "litmus.io/v1alpha1", "kind": "LitmusResult", "metadata": {"creationTimestamp": "2020-12-11T08:20:37Z", "generation": 6, "name": "percona-deployment", "resourceVersion": "4132196", "selfLink": "/apis/litmus.io/v1alpha1/litmusresults/percona-deployment", "uid": "ded655d3-250b-40dd-b2cc-0c750a9ae37b"}, "spec": {"testMetadata": {}, "testStatus": {"phase": "completed", "result": "Pass"}}}}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=35   changed=18   unreachable=0    failed=0   

2020-12-11T08:30:27.856717 (delta: 0.662688)         elapsed: 99.776359 ******* 
=============================================================================== 
```