### PR TITLE
refact(yaml): Check for the velero volumesnapshotter plugin before taking backups

### DIFF
--- a/experiments/zfs-localpv/functional/backup_and_restore/backup.yml
+++ b/experiments/zfs-localpv/functional/backup_and_restore/backup.yml
@@ -6,6 +6,15 @@
       args:
         executable: /bin/bash
 
+    - name: Check that volume snapshot location class is present
+      shell: kubectl get volumesnapshotlocation -n velero
+      args:
+       executable: /bin/bash
+      register: vol_snapshot_location
+      until: "'zfspv-snaplocation' in vol_snapshot_location.stdout"
+      delay: 2
+      retries: 30
+
     - name: Creating Backup 
       shell: >
         velero backup create {{ velero_backup_name }} --snapshot-volumes --include-namespaces={{ app_ns }} --volume-snapshot-locations=zfspv-snaplocation --storage-location=default

--- a/experiments/zfs-localpv/functional/backup_and_restore/setup_dependency.yml
+++ b/experiments/zfs-localpv/functional/backup_and_restore/setup_dependency.yml
@@ -117,4 +117,11 @@
   until: "'running' in velero_container.stdout"
   delay: 5
   retries: 20
+
+- name: Check velero plugin for VolumeSnapshotter is present
+  shell: velero plugin get
+  register: snapshotter_plugin
+  until: "'zfspv-blockstore' in snapshotter_plugin.stdout"
+  delay: 2
+  retries: 40
     


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR checks for velero volumesnapshotter plugin `zfspv-blockstore` availability before taking backups
- And check for volumesnapshotclass is present 