### PR TITLE
refact(yaml): verify the succesful deletion of pods in service failure test

### DIFF
--- a/chaoslib/service_failure/service_chaos.yml
+++ b/chaoslib/service_failure/service_chaos.yml
@@ -270,6 +270,16 @@
      until: "'NotReady' not in node_status.stdout"
      delay: 10
      retries: 30
+
+   - name: Verify that previous pods are deleted successfully after restart of {{ svc_type }}
+     shell: >
+       kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers | wc -l
+     args:
+       executable: /bin/bash
+     register: app_pod_count
+     until: "'1' in app_pod_count.stdout"
+     delay: 5
+     retries: 60
      
    - name: Get the status of newly created application pod
      shell: >


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- If the original application takes some time to terminate successfully, then pod can be present in terminate state thus task in e2e-test will fail as it will be waiting for running status of pod.


