### PR TITLE
refact(yaml): Add restart of application pod after resizing volume

### DIFF
--- a/experiments/functional/csi-volume-resize/test.yml
+++ b/experiments/functional/csi-volume-resize/test.yml
@@ -107,13 +107,38 @@
               delay: 10
               retries: 50
 
+            - name: Restart the application pod after resizing the volume
+              shell: kubectl delete pod {{ app_pod.stdout }} -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: app_pod_status
+              failed_when: app_pod_status.rc != 0
+
+            - name: Verify that application pod is deleted successfully.
+              shell: >
+                kubectl get pods -n {{ app_ns }}
+              args:
+                executable: /bin/bash
+              register: app_pod_list
+              until: '"{{ app_pod.stdout }}" not in app_pod_list.stdout'
+              delay: 2
+              retries: 30
+
+            - name: Get the name of application pod after Restart
+              shell: >
+                kubectl get pod -n {{ app_ns }} -l {{ app_label }} --no-headers
+                -o custom-columns=:.metadata.name
+              args:
+                executable: /bin/bash
+              register: app_pod_name
+
              ## Here we will dump +1Gi data than to previous pvc size
             - set_fact:
                 value_num: '{{ ( (value_str.stdout | int + 1 | int) * 1024) |  int }}'
 
             - name: Dump some more dummy data in the application mount point for using resized volume
               shell: >
-                  kubectl exec -it "{{ app_pod.stdout }}" -n "{{ app_ns }}" 
+                  kubectl exec -it "{{ app_pod_name.stdout }}" -n "{{ app_ns }}" 
                   -- sh -c "cd {{ mount.stdout }} && dd if=/dev/urandom of=volume.txt bs=1024k count={{ value_num }}"
               args:
                   executable: /bin/bash

--- a/experiments/zfs-localpv/functional/zfspv-snapshot/test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-snapshot/test.yml
@@ -172,7 +172,7 @@
               register: ready_replica_count
               until: ready_replica_count.stdout == replica_count.stdout
               delay: 5
-              retries: 20
+              retries: 35
 
           when: action == 'provision' 
            


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-  This PR adds a task of restart the application pod after resizing the csi volume, and after restart resized space is used for dumping some dummy test data.

Additional Fix: #https://github.com/openebs/e2e-tests/issues/581