### PR TITLE
update(yaml): increase the cpu resource limit in percona deployment

### DIFF
--- a/apps/percona/deployers/percona.yml
+++ b/apps/percona/deployers/percona.yml
@@ -18,7 +18,7 @@ spec:
       containers:
         - resources:
             limits:
-              cpu: 0.5
+              cpu: 1
           name: percona
           image: openebs/tests-custom-percona:latest
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Due to cpu resource limit in percona deployment sometimes we hit error rc: 137.
- Increasing the cpu limit to `cpu: 1` from `cpu: 0.5`