### PR TITLE
refact(yaml): increase the delay-retries count in zfspv snapshot test-case

### DIFF
--- a/experiments/zfs-localpv/functional/zfspv-snapshot/test.yml
+++ b/experiments/zfs-localpv/functional/zfspv-snapshot/test.yml
@@ -98,7 +98,7 @@
               register: modify_replica_count
               until: "modify_replica_count.stdout == \"0\""
               delay: 5
-              retries: 20
+              retries: 30
 
             - name: Verify that the application pod is not present after scaling down the deployment
               shell: >
@@ -108,7 +108,7 @@
               register: app_pod_status
               until: "app_pod_name.stdout not in app_pod_status.stdout"
               delay: 5
-              retries: 30
+              retries: 60
 
               ## As we are checking the status of only one pod if is terminated successfully
               ## but in case of shared mount support other pods may not be terminate at the same time
@@ -144,7 +144,7 @@
               register: isSnapshotReady
               until: "isSnapshotReady.stdout == 'true'"
               delay: 5
-              retries: 30
+              retries: 50
 
             - name: Check the status for openebs resource for the created snapshot {{ snapshot_name }}
               shell: >
@@ -172,7 +172,7 @@
               register: ready_replica_count
               until: ready_replica_count.stdout == replica_count.stdout
               delay: 5
-              retries: 35
+              retries: 60
 
           when: action == 'provision' 
            
@@ -242,5 +242,4 @@
         - include_tasks: /utils/fcm/update_litmus_result_resource.yml
           vars:
             status: 'EOT'
-
-  
+            


### PR DESCRIPTION

Signed-off-by: w3aman <aman.gupta@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR increases the delay_retries count in zfspv snapshot test case. Sometimes it happens that scaling down application takes some time before capturing the snapshot.