### PR TITLE
fix(svc_failure): fixed the service failure test

### DIFF
--- a/chaoslib/service_failure/service_chaos.yml
+++ b/chaoslib/service_failure/service_chaos.yml
@@ -205,7 +205,6 @@
               retries: 35
 
          when:
-         - stg_engine == 'jiva'
          - vol_provisioner == 'jiva-csi.openebs.io'
          - app_node == ctrl_node
 


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

- when vol_provisioner is jiva-csi then stg_engine env was not in test.yml [file](https://github.com/openebs/e2e-tests/blob/master/experiments/chaos/kubernetes/service_failure/test.yml)
