### PR TITLE
Refactor the jiva csi replica status check util

### DIFF
--- a/experiments/chaos/openebs_target_network_delay/test.yml
+++ b/experiments/chaos/openebs_target_network_delay/test.yml
@@ -189,7 +189,7 @@
               args:
                 executable: /bin/bash
               register: csi_pod_status
-              until: '"{{ controller_pod_before.stdout }}" not in pod_status.stdout' 
+              until: '"{{ csi_controller_pod_before.stdout }}" not in csi_pod_status.stdout' 
               delay: 5
               retries: 60
               when: "'no change' not in csi_patch_status.stdout"
@@ -205,12 +205,12 @@
 
             - name: Check for the jiva controller container status
               shell: >
-                kubectl get pods {{ controller_pod_after.stdout }} -n {{ operator_ns }} 
+                kubectl get pods {{ csi_controller_pod_after.stdout }} -n {{ operator_ns }} 
                 -o jsonpath='{.status.containerStatuses[?(@.name=="jiva-controller")].state}' | grep running
               args:
                 executable: /bin/bash
               register: csi_container_status
-              until: "'running' in container_status.stdout"
+              until: "'running' in csi_container_status.stdout"
               delay: 3
               retries: 20
 

--- a/funclib/openebs/jiva-csi-access-mode-check.yml
+++ b/funclib/openebs/jiva-csi-access-mode-check.yml
@@ -7,13 +7,17 @@
          changed_when: True
 
        - name: Get the controller deployment name 
-         shell: kubectl get deployment -n {{ operator_ns }} -l openebs.io/component=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
+         shell: >
+           kubectl get deployment -n {{ operator_ns }} 
+           -l openebs.io/component=jiva-controller,openebs.io/persistent-volume="{{ pv_name.stdout }}" -o jsonpath='{.items[0].metadata.name}'
          args:
            executable: /bin/bash
          register: ctrl_deployment
 
        - name: Obtaining the replication factor count from controller deployment
-         shell: kubectl get deployments {{ ctrl_deployment.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'    
+         shell: >
+            kubectl get deployments {{ ctrl_deployment.stdout }} -n {{ operator_ns }} 
+            -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'    
          register: replication_factor_count
        
        - name: Verify that all the replicas are in RW state
@@ -23,7 +27,7 @@
          args:
            executable: /bin/bash
          register: result
-         until: result.stdout| int == 3
+         until: result.stdout| int == replication_factor_count.stdout | int
          delay: 10
          retries: 60
 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the until condition to verify the replica status

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
