### PR TITLE
Modified the backup restore test case for jiva storage engine

### DIFF
--- a/experiments/functional/backup_and_restore/jiva/backup-restore.yml
+++ b/experiments/functional/backup_and_restore/jiva/backup-restore.yml
@@ -9,7 +9,6 @@
 
   when: action == "BACKUP"
 
-
 - block:
      # Schedule creates a cron job for backup. Notation "--schedule=*/2 * * * *" applies same as kubernetes cron job here.
    - name: Creating schedule using minio bucket
@@ -35,11 +34,6 @@
    
 - block:
      
-    - name: Creating application namespace
-      shell: kubectl create ns {{ app_ns }}
-      register: app_ns_create_status
-      failed_when: "'created' not in app_ns_create_status.stdout"
-
     - name: Restoring application 
       shell: >
         velero restore create --from-backup {{ velero_backup_name }} --restore-volumes=true


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>
 - Removed the task to create new namespace for jiva backup restore test

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the litmusbook execution?
* [ ] Does the litmusbook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the litmusbook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the litmusbook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the litmusbook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the litmusbook execution?
* [ ] Does the litmusbook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the litmusbooks been linted? 

**Special notes for your reviewer**:
