### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -16,15 +16,15 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     apt-get update && apt-get install google-cloud-sdk -y
 
 #Installing ansible
-RUN pip install ansible==2.7.3
+RUN pip install --no-cache-dir ansible==2.7.3
 
-RUN pip install ruamel.yaml.clib==0.1.2
+RUN pip install --no-cache-dir ruamel.yaml.clib==0.1.2
 
 #Installing openshift
-RUN pip install openshift==0.11.2
+RUN pip install --no-cache-dir openshift==0.11.2
 
 #Installing jmespath
-RUN pip install jmespath
+RUN pip install --no-cache-dir jmespath
 
 RUN touch /mnt/parameters.yml
 


### PR DESCRIPTION
**What this PR does / why we need it**:

using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

**Checklist**

* [ ] Does this PR have a corresponding GitHub issue?
* [ ] Have you included relevant README for the chaoslib/experiment with details?
* [ ] Have you added debug messages where necessary? 
* [ ] Have you added task comments where necessary? 
* [ ] Have you tested the changes for possible failure conditions?
* [ ] Have you provided the positive & negative test logs for the e2ebook execution?
* [ ] Does the e2ebook ensure idempotency of cluster state?, i.e., is cluster restored to original state?
* [ ] Have you used non-shell/command modules for Kubernetes tasks?
* [ ] Have you (jinja) templatized custom scripts that is run by the e2ebook, if any? 
* [ ] Have you (jinja) templatized Kubernetes deployment manifests used by the e2ebook, if any?
* [ ] Have you reused/created util functions instead of repeating tasks in the e2ebook?
* [ ] Do the artifacts follow the appropriate directory structure? 
* [ ] Have you isolated storage (eg: OpenEBS) specific implementations, checks? 
* [ ] Have you isolated platform (eg: baremetal kubeadm/openshift/aws/gcloud) specific implementations, checks?  
* [ ] Are the ansible facts well defined? Is the scope explicitly set for playbook & included utils?
* [ ] Have you ensured minimum/careful usage of shell utilities (awk, grep, sed, cut, xargs etc.,)?
* [ ] Can the limtusbook be executed both from within & outside a container (configurable paths, no hardcode)?
* [ ] Can you suggest the minimal resource requirements for the e2ebook execution?
* [ ] Does the e2ebook job artifact carry comments/default options/range for the ENV tunables?
* [ ] Has the e2ebooks been linted? 

**Special notes for your reviewer**:
